### PR TITLE
[REVIEW] Exposing EHCache over JMX.

### DIFF
--- a/components/nexus-ehcache/src/main/java/org/sonatype/sisu/ehcache/CacheManagerComponentImpl.java
+++ b/components/nexus-ehcache/src/main/java/org/sonatype/sisu/ehcache/CacheManagerComponentImpl.java
@@ -103,7 +103,7 @@ public class CacheManagerComponentImpl
         try
         {
             final MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
-            ManagementService.registerMBeans( cacheManager, mBeanServer, false, false, false, true );
+            ManagementService.registerMBeans( cacheManager, mBeanServer, false, false, true, true );
         }
         catch ( final Exception e )
         {


### PR DESCRIPTION
Original issue [1] was closed with remark EHCache "being already exposed via REST". But this is true for NFC cache only, while Shiro in Nexus uses multitude of other caches (sessions, authc, authz and LDAPPro etc). This change is very handy one, to be able to see which cache is "overflowing" etc.

This solution exposes all cache stats (with some slight change might do even more), and allows inspection of caches used by Shiro too (as it uses 3 more caches in OSS and even more in Pro).

I used this change to debug/recreate [2], in progress.

Just here as reference, I'd even put this into master with some "switches" that would allow to turn this ON or OFF maybe. Unregistering is handled by CacheManager listener used under the hub in EHCache code, and MBean(s) are unregistered when the EHCache CacheManager is shut down.

[1] https://issues.sonatype.org/browse/NEXUS-4888
[2] https://issues.sonatype.org/browse/NEXUS-5728
