### PR TITLE
NEXUS-5744: fix for redirect strategy

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientManagerImpl.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientManagerImpl.java
@@ -127,7 +127,7 @@ public class HttpClientManagerImpl
             {
                 if ( super.isRedirected( request, response, context ) )
                 {
-                    if ( response.getHeaders( "location" ) != null )
+                    if ( response.getFirstHeader( "location" ) != null )
                     {
                         final String sourceUri = getPreviousRequestUri( request );
                         final String targetUri = response.getFirstHeader( "location" ).getValue();


### PR DESCRIPTION
There was initially a "prevent redirection to index pages"
check that proved to be overly broad. It was meant to prevent
redirections like:

http://host/path -> http://host/path/

as "path" is actually a collection (directory in HTTP lingo)
on server side, and this is usual redirections that HTTP
servers do when asked for that 1st URL: redirect to "index page"
of the given collection.

But, this check was too broad, as it prevented redirections
like

http://hostA/path/ -> http://hostB/path/

for example (same for HTTP -> HTTPS or even port change
redirections), as it was checking only that 2nd URL does not end with slash.

Related issue:
https://issues.sonatype.org/browse/NEXUS-5744
