### PR TITLE
NEXUS-5734: Prevent load and use of empty prefix.txt got from remote

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/internal/RemotePrefixFileStrategy.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/internal/RemotePrefixFileStrategy.java
@@ -120,6 +120,10 @@ public class RemotePrefixFileStrategy
                 {
                     return new StrategyResult( "Remote disabled automatic routing", UNSUPPORTED_PREFIXSOURCE, false );
                 }
+                if ( unmarshalled.entries().isEmpty() )
+                {
+                    return new StrategyResult( "Remote publishes empty prefix file", UNSUPPORTED_PREFIXSOURCE, false );
+                }
 
                 final PrefixSource prefixSource = new FilePrefixSource( mavenProxyRepository, path, config );
                 if ( prefixFileAgeInDays < 1 )

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/internal/TextFilePrefixSourceMarshaller.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/internal/TextFilePrefixSourceMarshaller.java
@@ -185,12 +185,6 @@ public class TextFilePrefixSourceMarshaller
                 }
             }
 
-            // dump empty files
-            if ( entries.isEmpty() )
-            {
-                throw new InvalidInputException( "Prefix file has no entries, refusing to load it." );
-            }
-
             return new Result()
             {
                 @Override

--- a/components/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/routing/internal/RemotePrefixFileIsGarbageTest.java
+++ b/components/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/routing/internal/RemotePrefixFileIsGarbageTest.java
@@ -12,11 +12,15 @@
  */
 package org.sonatype.nexus.proxy.maven.routing.internal;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.RandomAccessFile;
 import java.io.StringWriter;
 import java.net.ServerSocket;
 import java.util.ArrayList;
@@ -44,10 +48,7 @@ import org.sonatype.nexus.proxy.maven.maven2.M2GroupRepositoryConfiguration;
 import org.sonatype.nexus.proxy.maven.maven2.M2Repository;
 import org.sonatype.nexus.proxy.maven.maven2.M2RepositoryConfiguration;
 import org.sonatype.nexus.proxy.maven.routing.discovery.RemoteStrategy;
-import org.sonatype.nexus.proxy.maven.routing.discovery.StrategyFailedException;
 import org.sonatype.nexus.proxy.maven.routing.discovery.StrategyResult;
-import org.sonatype.nexus.proxy.maven.routing.internal.InvalidInputException;
-import org.sonatype.nexus.proxy.maven.routing.internal.RemotePrefixFileStrategy;
 import org.sonatype.nexus.proxy.repository.GroupRepository;
 import org.sonatype.nexus.proxy.repository.Repository;
 import org.sonatype.tests.http.server.fluent.Behaviours;
@@ -297,7 +298,7 @@ public class RemotePrefixFileIsGarbageTest
         }
     }
 
-    @Test( expected = InvalidInputException.class )
+    @Test
     public void discoverEmptyPrefixFile()
         throws Exception
     {
@@ -311,6 +312,9 @@ public class RemotePrefixFileIsGarbageTest
             final StrategyResult result =
                 subject.discover( getRepositoryRegistry().getRepositoryWithFacet( PROXY_REPO_ID,
                     MavenProxyRepository.class ) );
+            assertThat( result.getMessage(), containsString( "empty prefix file" ) );
+            assertThat( result.getPrefixSource(), notNullValue() );
+            assertThat( result.getPrefixSource().supported(), is( false ) );
         }
         finally
         {


### PR DESCRIPTION
Refuse to load (and process) prefix file got from remote that is empty. Not a fix for related issue (as I was unable to reproduce it), but came out as idea for improvement the already existing "validation" around prefix file parsing.

Improvement related to this issue:
https://issues.sonatype.org/browse/NEXUS-5734
