### PR TITLE
NEXUS-5747: Support packaging bundle

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/packaging/DefaultArtifactPackagingMapper.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/packaging/DefaultArtifactPackagingMapper.java
@@ -60,6 +60,7 @@ public class DefaultArtifactPackagingMapper
         defaults.put( "java-source", "jar" );
         defaults.put( "javadoc", "jar" );
         defaults.put( "test-jar", "jar" );
+        defaults.put( "bundle", "jar" );
     }
 
     public void setPropertiesFile( File propertiesFile )

--- a/components/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/packaging/DefaultArtifactPackagingMapperTest.java
+++ b/components/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/packaging/DefaultArtifactPackagingMapperTest.java
@@ -1,0 +1,70 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2013 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.maven.packaging;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.Test;
+import org.sonatype.sisu.litmus.testsupport.TestSupport;
+
+public class DefaultArtifactPackagingMapperTest
+    extends TestSupport
+{
+    @Test
+    public void defaults()
+    {
+        final ArtifactPackagingMapper apm = new DefaultArtifactPackagingMapper();
+        assertThat( apm.getExtensionForPackaging( "jar" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "ejb-client" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "ejb" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "rar" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "par" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "maven-plugin" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "maven-archetype" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "plexus-application" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "eclipse-plugin" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "eclipse-feature" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "eclipse-application" ), equalTo( "zip" ) );
+        assertThat( apm.getExtensionForPackaging( "nexus-plugin" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "java-source" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "javadoc" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "test-jar" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "bundle" ), equalTo( "jar" ) );
+    }
+
+    @Test
+    public void overrides()
+    {
+        final ArtifactPackagingMapper apm = new DefaultArtifactPackagingMapper();
+        apm.setPropertiesFile( util.resolveFile( "src/test/resources/packaging2extension-mapping.properties" ) );
+        assertThat( apm.getExtensionForPackaging( "jar" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "ejb-client" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "ejb" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "rar" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "par" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "maven-plugin" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "maven-archetype" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "plexus-application" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "eclipse-plugin" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "eclipse-feature" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "eclipse-application" ), equalTo( "zip" ) );
+        assertThat( apm.getExtensionForPackaging( "nexus-plugin" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "java-source" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "javadoc" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "test-jar" ), equalTo( "jar" ) );
+        assertThat( apm.getExtensionForPackaging( "bundle" ), equalTo( "foo" ) ); // overridden!
+        assertThat( apm.getExtensionForPackaging( "one" ), equalTo( "1" ) ); // user specified
+        assertThat( apm.getExtensionForPackaging( "two" ), equalTo( "2" ) ); // user specified
+    }
+}

--- a/components/nexus-core/src/test/resources/packaging2extension-mapping.properties
+++ b/components/nexus-core/src/test/resources/packaging2extension-mapping.properties
@@ -1,0 +1,4 @@
+# User mappings
+bundle=foo
+one=1
+two=2


### PR DESCRIPTION
Added bundle to defaults and added UT for
DefaultArtifactPackagingMapper.

Note: while issue points at ASF Maven Indexer
mapper, the Nexus Maven Indexer integration actually
redirects MI to this (changed) component. So,
this applies the fix to Nexus, but does not
applies the same to MI...

Related issue:
https://issues.sonatype.org/browse/NEXUS-5747

CI:
https://bamboo.zion.sonatype.com/browse/NX-OSSF45-1
