### PR TITLE
NEXUS-5418: Fix for MD helper

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/AbstractMavenRepository.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/AbstractMavenRepository.java
@@ -346,6 +346,8 @@ public abstract class AbstractMavenRepository
 
     public abstract boolean isMavenMetadataPath( String path );
 
+    public abstract boolean isMavenArtifactChecksumPath( String path );
+
     public abstract boolean shouldServeByPolicies( ResourceStoreRequest request );
 
     public void storeItemWithChecksums( ResourceStoreRequest request, InputStream is, Map<String, String> userAttributes )
@@ -608,6 +610,12 @@ public abstract class AbstractMavenRepository
         return shouldAddToNFC;
     }
 
+    @Override
+    protected boolean shouldNeglectItemNotFoundExOnDelete( ResourceStoreRequest request, ItemNotFoundException ex )
+    {
+        return isMavenArtifactChecksumPath( request.getRequestPath() );
+    }
+
     /**
      * Deletes item and regenerates Maven metadata, if repository is a hosted repository and maven-metadata.xml file is
      * present.
@@ -618,7 +626,22 @@ public abstract class AbstractMavenRepository
     protected void doDeleteItem( final ResourceStoreRequest request )
         throws UnsupportedStorageOperationException, ItemNotFoundException, StorageException
     {
-        super.doDeleteItem( request );
+        try
+        {
+            super.doDeleteItem( request );
+        }
+        catch ( ItemNotFoundException ex )
+        {
+            // NEXUS-5773, NEXUS-5418
+            // Since Nx 2.5, checksum are not stored on disk
+            // but are stored as attributes. Still, upgraded systems
+            // might have them on disk, so delete is attempted
+            // but INFex on Checksum file in general can be neglected here.
+            if ( !shouldNeglectItemNotFoundExOnDelete( request, ex ) )
+            {
+                throw ex;
+            }
+        }
         // regenerate maven metadata for parent of this item if is a hosted maven repo and it contains maven-metadata.xml
         if ( getRepositoryKind().isFacetAvailable( MavenHostedRepository.class ) )
         {

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/maven1/M1Repository.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/maven1/M1Repository.java
@@ -95,10 +95,16 @@ public class M1Repository
         return M1ArtifactRecognizer.isMetadata( path );
     }
 
+    @Override
+    public boolean isMavenArtifactChecksumPath( String path )
+    {
+        return M1ArtifactRecognizer.isChecksum( path );
+    }
+
     /**
      * Should serve by policies.
      * 
-     * @param uid the uid
+     * @param request the request
      * @return true, if successful
      */
     @Override

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/maven2/M2Repository.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/maven2/M2Repository.java
@@ -133,6 +133,12 @@ public class M2Repository
         return M2ArtifactRecognizer.isMetadata( path );
     }
 
+    @Override
+    public boolean isMavenArtifactChecksumPath( String path )
+    {
+        return M2ArtifactRecognizer.isChecksum( path );
+    }
+
     /**
      * Should serve by policies.
      * 

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/metadata/DefaultMetadataHelper.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/metadata/DefaultMetadataHelper.java
@@ -196,15 +196,6 @@ public class DefaultMetadataHelper
             request.getRequestContext().put( DeleteOperation.DELETE_OPERATION_CTX_KEY, operation );
             repository.deleteItem( false, request );
         }
-        catch ( ItemNotFoundException e ) {
-            // Since Nx 2.5, checksum are not stored on disk
-            // but are stored as attributes. Still, upgraded systems
-            // might have them on disk, so delete is attempted
-            // but INFex on Checksum file in general can be neglected here.
-            if (!isChecksumFile( path )) {
-                throw new IOException( e );
-            }
-        }
         catch ( Exception e )
         {
             throw new IOException( e );


### PR DESCRIPTION
As the checksum files are not "real" files anymore
(since 2.5), they are stored as attributes in "main" items
themselves. Still, collectionItem#list will return them,
hence walkers like this will try to delete them, resulting
in INFex

https://bamboo.zion.sonatype.com/browse/NX-OSSF7
