### PR TITLE
NXCM-5396: Realms that have no UserManager pollute logs

### DIFF
--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/security/rest/authentication/AbstractUIPermissionCalculatingPlexusResource.java
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/security/rest/authentication/AbstractUIPermissionCalculatingPlexusResource.java
@@ -107,9 +107,15 @@ public abstract class AbstractUIPermissionCalculatingPlexusResource
             }
             catch ( UserNotFoundException e )
             {
-                this.getLogger().warn( "Failed to lookup user: " + username, e );
+                if ( getLogger().isDebugEnabled() )
+                {
+                    getLogger().info( "Failed to lookup user: {}", username, e );
+                }
+                else
+                {
+                    getLogger().info( "Failed to lookup user: {}: {}/{}", username, e.getClass().getName(), e.getMessage() );
+                }
             }
-
         }
 
         Map<String, Integer> privilegeMap = new HashMap<String, Integer>();


### PR DESCRIPTION
This change lessens the log noise, while the information
about "not found user" is still logged.

On instances where some Realm is used that does
not have UserManager implementation (like Kenai Realm is),
the logs would be polluted with a lot of exceptions
on every log-in and UI use (status resource).

A Realm without UserManager is still serving the purpose
well (authc and authz would work just fine), but
operations like "user lookup" all fail due to lack
of UserManager.

Issue:
https://issues.sonatype.org/browse/NXCM-5396

CI:
TBD
