### PR TITLE
NXCM-5398: Kenai role was applied unconditionally

### DIFF
--- a/plugins/security/nexus-kenai-plugin/src/main/java/org/sonatype/security/realms/kenai/KenaiRealm.java
+++ b/plugins/security/nexus-kenai-plugin/src/main/java/org/sonatype/security/realms/kenai/KenaiRealm.java
@@ -158,14 +158,13 @@ public class KenaiRealm
     @Override
     protected AuthorizationInfo doGetAuthorizationInfo( final PrincipalCollection principals )
     {
-        // shortcut for now
-        return buildAuthorizationInfo();
-    }
-
-    private AuthorizationInfo buildAuthorizationInfo()
-    {
-        final SimpleAuthorizationInfo authorizationInfo = new SimpleAuthorizationInfo();
+        // only if authenticated with this realm too
+        if ( !principals.getRealmNames().contains( getName() ) )
+        {
+            return null;
+        }
         // add the default role
+        final SimpleAuthorizationInfo authorizationInfo = new SimpleAuthorizationInfo();
         authorizationInfo.addRole( kenaiRealmConfiguration.getConfiguration().getDefaultRole() );
         return authorizationInfo;
     }


### PR DESCRIPTION
Hence, every user, even anonymous got it, even without
logging in into Kenai.

Problem was introduced in commit:
5bec64796705e8f6cc754a4f9d8d5f222959cd12

When the plugin was moved in into OSS sources.

Issue:
https://issues.sonatype.org/browse/NXCM-5398

CI
https://bamboo.zion.sonatype.com/browse/NX-OSSF17-1
