### PR TITLE
NXCM-5406: Make nx-staging-plugin mvn3.1 friendly

### DIFF
--- a/components/nexus-client-core/pom.xml
+++ b/components/nexus-client-core/pom.xml
@@ -76,17 +76,6 @@
       <artifactId>joda-time</artifactId>
     </dependency>
 
-    <!-- Version (for now all of Aether API/UTIL) -->
-    <dependency>
-      <groupId>org.sonatype.aether</groupId>
-      <artifactId>aether-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.sonatype.aether</groupId>
-      <artifactId>aether-util</artifactId>
-    </dependency>
-
     <!-- Needed by Model/XStream configuration -->
     <dependency>
       <groupId>commons-lang</groupId>

--- a/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/condition/VersionConditions.java
+++ b/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/condition/VersionConditions.java
@@ -12,12 +12,12 @@
  */
 package org.sonatype.nexus.client.core.condition;
 
-import org.sonatype.aether.util.version.GenericVersionScheme;
-import org.sonatype.aether.version.InvalidVersionSpecificationException;
-import org.sonatype.aether.version.Version;
-import org.sonatype.aether.version.VersionConstraint;
 import org.sonatype.nexus.client.core.Condition;
 import org.sonatype.nexus.client.core.NexusStatus;
+import org.sonatype.nexus.client.core.condition.internal.GenericVersionScheme;
+import org.sonatype.nexus.client.core.condition.internal.InvalidVersionSpecificationException;
+import org.sonatype.nexus.client.core.condition.internal.Version;
+import org.sonatype.nexus.client.core.condition.internal.VersionConstraint;
 import org.sonatype.nexus.client.internal.util.Check;
 import org.sonatype.nexus.client.internal.util.Template;
 

--- a/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/condition/internal/GenericVersion.java
+++ b/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/condition/internal/GenericVersion.java
@@ -1,0 +1,450 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2013 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.client.core.condition.internal;
+
+/*******************************************************************************
+ * Copyright (c) 2010-2011 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+
+/******
+ * Copied from org.sonatype.aether:aether-util:1.13.1
+ ******/
+/**
+ * A generic version, that is a version that accepts any input string and tries to apply common sense sorting. See
+ * {@link GenericVersionScheme} for details.
+ */
+final class GenericVersion
+    implements Version
+{
+
+    private final String version;
+
+    private final Item[] items;
+
+    private final int hash;
+
+    /**
+     * Creates a generic version from the specified string.
+     * 
+     * @param version The version string, must not be {@code null}.
+     */
+    public GenericVersion( String version )
+    {
+        this.version = version;
+        items = parse( version );
+        hash = Arrays.hashCode( items );
+    }
+
+    private static Item[] parse( String version )
+    {
+        List<Item> items = new ArrayList<Item>();
+
+        for ( Tokenizer tokenizer = new Tokenizer( version ); tokenizer.next(); )
+        {
+            Item item = new Item( tokenizer );
+            items.add( item );
+        }
+
+        trimPadding( items );
+
+        return items.toArray( new Item[items.size()] );
+    }
+
+    private static void trimPadding( List<Item> items )
+    {
+        Boolean number = null;
+        int end = items.size() - 1;
+        for ( int i = end; i > 0; i-- )
+        {
+            Item item = items.get( i );
+            if ( !Boolean.valueOf( item.isNumber() ).equals( number ) )
+            {
+                end = i;
+                number = Boolean.valueOf( item.isNumber() );
+            }
+            if ( end == i && ( i == items.size() - 1 || items.get( i - 1 ).isNumber() == item.isNumber() )
+                && item.compareTo( null ) == 0 )
+            {
+                items.remove( i );
+                end--;
+            }
+        }
+    }
+
+    public int compareTo( Version obj )
+    {
+        final Item[] these = items;
+        final Item[] those = ( (GenericVersion) obj ).items;
+
+        boolean number = true;
+
+        for ( int index = 0;; index++ )
+        {
+            if ( index >= these.length && index >= those.length )
+            {
+                return 0;
+            }
+            else if ( index >= these.length )
+            {
+                return -comparePadding( those, index, null );
+            }
+            else if ( index >= those.length )
+            {
+                return comparePadding( these, index, null );
+            }
+
+            Item thisItem = these[index];
+            Item thatItem = those[index];
+
+            if ( thisItem.isNumber() != thatItem.isNumber() )
+            {
+                if ( number == thisItem.isNumber() )
+                {
+                    return comparePadding( these, index, Boolean.valueOf( number ) );
+                }
+                else
+                {
+                    return -comparePadding( those, index, Boolean.valueOf( number ) );
+                }
+            }
+            else
+            {
+                int rel = thisItem.compareTo( thatItem );
+                if ( rel != 0 )
+                {
+                    return rel;
+                }
+                number = thisItem.isNumber();
+            }
+        }
+    }
+
+    private static int comparePadding( Item[] items, int index, Boolean number )
+    {
+        int rel = 0;
+        for ( int i = index; i < items.length; i++ )
+        {
+            Item item = items[i];
+            if ( number != null && number.booleanValue() != item.isNumber() )
+            {
+                break;
+            }
+            rel = item.compareTo( null );
+            if ( rel != 0 )
+            {
+                break;
+            }
+        }
+        return rel;
+    }
+
+    @Override
+    public boolean equals( Object obj )
+    {
+        return ( obj instanceof GenericVersion ) && compareTo( (GenericVersion) obj ) == 0;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return hash;
+    }
+
+    @Override
+    public String toString()
+    {
+        return version;
+    }
+
+    static final class Tokenizer
+    {
+
+        private final String version;
+
+        private int index;
+
+        private String token;
+
+        private boolean number;
+
+        private boolean terminatedByNumber;
+
+        public Tokenizer( String version )
+        {
+            this.version = ( version.length() > 0 ) ? version : "0";
+        }
+
+        public String getToken()
+        {
+            return token;
+        }
+
+        public boolean isNumber()
+        {
+            return number;
+        }
+
+        public boolean isTerminatedByNumber()
+        {
+            return terminatedByNumber;
+        }
+
+        public boolean next()
+        {
+            final int n = version.length();
+            if ( index >= n )
+            {
+                return false;
+            }
+
+            int state = -2;
+
+            int start = index;
+            int end = n;
+            terminatedByNumber = false;
+
+            for ( ; index < n; index++ )
+            {
+                char c = version.charAt( index );
+
+                if ( c == '.' || c == '-' )
+                {
+                    end = index;
+                    index++;
+                    break;
+                }
+                else
+                {
+                    int digit = Character.digit( c, 10 );
+                    if ( digit >= 0 )
+                    {
+                        if ( state == -1 )
+                        {
+                            end = index;
+                            terminatedByNumber = true;
+                            break;
+                        }
+                        if ( state == 0 )
+                        {
+                            // normalize numbers and strip leading zeros (prereq for Integer/BigInteger handling)
+                            start++;
+                        }
+                        state = ( state > 0 || digit > 0 ) ? 1 : 0;
+                    }
+                    else
+                    {
+                        if ( state >= 0 )
+                        {
+                            end = index;
+                            break;
+                        }
+                        state = -1;
+                    }
+                }
+
+            }
+
+            if ( end - start > 0 )
+            {
+                token = version.substring( start, end );
+                number = state >= 0;
+            }
+            else
+            {
+                token = "0";
+                number = true;
+            }
+
+            return true;
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.valueOf( token );
+        }
+
+    }
+
+    static final class Item
+    {
+
+        private static final int KIND_BIGINT = 3;
+
+        private static final int KIND_INT = 2;
+
+        private static final int KIND_STRING = 1;
+
+        private static final int KIND_QUALIFIER = 0;
+
+        private static final Map<String, Integer> QUALIFIERS;
+
+        static
+        {
+            QUALIFIERS = new TreeMap<String, Integer>( String.CASE_INSENSITIVE_ORDER );
+            QUALIFIERS.put( "alpha", Integer.valueOf( -5 ) );
+            QUALIFIERS.put( "beta", Integer.valueOf( -4 ) );
+            QUALIFIERS.put( "milestone", Integer.valueOf( -3 ) );
+            QUALIFIERS.put( "cr", Integer.valueOf( -2 ) );
+            QUALIFIERS.put( "rc", Integer.valueOf( -2 ) );
+            QUALIFIERS.put( "snapshot", Integer.valueOf( -1 ) );
+            QUALIFIERS.put( "ga", Integer.valueOf( 0 ) );
+            QUALIFIERS.put( "final", Integer.valueOf( 0 ) );
+            QUALIFIERS.put( "", Integer.valueOf( 0 ) );
+            QUALIFIERS.put( "sp", Integer.valueOf( 1 ) );
+        }
+
+        private final int kind;
+
+        private final Object value;
+
+        public Item( Tokenizer tokenizer )
+        {
+            String token = tokenizer.getToken();
+            if ( tokenizer.isNumber() )
+            {
+                try
+                {
+                    if ( token.length() < 10 )
+                    {
+                        kind = KIND_INT;
+                        value = Integer.valueOf( Integer.parseInt( token ) );
+                    }
+                    else
+                    {
+                        kind = KIND_BIGINT;
+                        value = new BigInteger( token );
+                    }
+                }
+                catch ( NumberFormatException e )
+                {
+                    throw new IllegalStateException( e );
+                }
+            }
+            else
+            {
+                if ( tokenizer.isTerminatedByNumber() && token.length() == 1 )
+                {
+                    switch ( token.charAt( 0 ) )
+                    {
+                        case 'a':
+                        case 'A':
+                            token = "alpha";
+                            break;
+                        case 'b':
+                        case 'B':
+                            token = "beta";
+                            break;
+                        case 'm':
+                        case 'M':
+                            token = "milestone";
+                            break;
+                    }
+                }
+                Integer qualifier = QUALIFIERS.get( token );
+                if ( qualifier != null )
+                {
+                    kind = KIND_QUALIFIER;
+                    value = qualifier;
+                }
+                else
+                {
+                    kind = KIND_STRING;
+                    value = token.toLowerCase( Locale.ENGLISH );
+                }
+            }
+        }
+
+        public boolean isNumber()
+        {
+            return kind >= KIND_INT;
+        }
+
+        public int compareTo( Item that )
+        {
+            int rel;
+            if ( that == null )
+            {
+                // null in this context denotes the pad item (0 or "ga")
+                switch ( kind )
+                {
+                    case KIND_BIGINT:
+                    case KIND_STRING:
+                        rel = 1;
+                        break;
+                    case KIND_INT:
+                    case KIND_QUALIFIER:
+                        rel = ( (Integer) value ).intValue();
+                        break;
+                    default:
+                        throw new IllegalStateException( "unknown version item kind " + kind );
+                }
+            }
+            else
+            {
+                rel = kind - that.kind;
+                if ( rel == 0 )
+                {
+                    switch ( kind )
+                    {
+                        case KIND_BIGINT:
+                            rel = ( (BigInteger) value ).compareTo( (BigInteger) that.value );
+                            break;
+                        case KIND_INT:
+                        case KIND_QUALIFIER:
+                            rel = ( (Integer) value ).compareTo( (Integer) that.value );
+                            break;
+                        case KIND_STRING:
+                            rel = ( (String) value ).compareToIgnoreCase( (String) that.value );
+                            break;
+                        default:
+                            throw new IllegalStateException( "unknown version item kind " + kind );
+                    }
+                }
+            }
+            return rel;
+        }
+
+        @Override
+        public boolean equals( Object obj )
+        {
+            return ( obj instanceof Item ) && compareTo( (Item) obj ) == 0;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return value.hashCode() + kind * 31;
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.valueOf( value );
+        }
+
+    }
+
+}

--- a/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/condition/internal/GenericVersionConstraint.java
+++ b/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/condition/internal/GenericVersionConstraint.java
@@ -1,0 +1,157 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2013 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.client.core.condition.internal;
+
+/*******************************************************************************
+ * Copyright (c) 2010-2011 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
+import java.util.Collection;
+import java.util.HashSet;
+
+/******
+ * Copied from org.sonatype.aether:aether-util:1.13.1
+ ******/
+/**
+ * A constraint on versions for a dependency.
+ * 
+ * @author Benjamin Bentmann
+ */
+final class GenericVersionConstraint
+    implements VersionConstraint
+{
+
+    private Collection<VersionRange> ranges = new HashSet<VersionRange>();
+
+    private Version version;
+
+    /**
+     * Adds the specified version range to this constraint. All versions matched by the given range satisfy this
+     * constraint.
+     * 
+     * @param range The version range to add, may be {@code null}.
+     * @return This constraint for chaining, never {@code null}.
+     */
+    public GenericVersionConstraint addRange( VersionRange range )
+    {
+        if ( range != null )
+        {
+            ranges.add( range );
+        }
+        return this;
+    }
+
+    public Collection<VersionRange> getRanges()
+    {
+        return ranges;
+    }
+
+    /**
+     * Sets the recommended version to satisfy this constraint.
+     * 
+     * @param version The recommended version for this constraint, may be {@code null} if none.
+     * @return This constraint for chaining, never {@code null}.
+     */
+    public GenericVersionConstraint setVersion( Version version )
+    {
+        this.version = version;
+        return this;
+    }
+
+    public Version getVersion()
+    {
+        return version;
+    }
+
+    public boolean containsVersion( Version version )
+    {
+        if ( ranges.isEmpty() )
+        {
+            return version.equals( this.version );
+        }
+        else
+        {
+            for ( VersionRange range : ranges )
+            {
+                if ( range.containsVersion( version ) )
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder buffer = new StringBuilder( 128 );
+
+        for ( VersionRange range : getRanges() )
+        {
+            if ( buffer.length() > 0 )
+            {
+                buffer.append( "," );
+            }
+            buffer.append( range );
+        }
+
+        if ( buffer.length() <= 0 )
+        {
+            buffer.append( getVersion() );
+        }
+
+        return buffer.toString();
+    }
+
+    @Override
+    public boolean equals( Object obj )
+    {
+        if ( this == obj )
+        {
+            return true;
+        }
+        if ( obj == null || !getClass().equals( obj.getClass() ) )
+        {
+            return false;
+        }
+
+        GenericVersionConstraint that = (GenericVersionConstraint) obj;
+
+        return ranges.equals( that.getRanges() ) && eq( version, that.getVersion() );
+    }
+
+    private static <T> boolean eq( T s1, T s2 )
+    {
+        return s1 != null ? s1.equals( s2 ) : s2 == null;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int hash = 17;
+        hash = hash * 31 + hash( getRanges() );
+        hash = hash * 31 + hash( getVersion() );
+        return hash;
+    }
+
+    private static int hash( Object obj )
+    {
+        return obj != null ? obj.hashCode() : 0;
+    }
+
+}

--- a/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/condition/internal/GenericVersionRange.java
+++ b/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/condition/internal/GenericVersionRange.java
@@ -1,0 +1,242 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2013 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.client.core.condition.internal;
+
+/*******************************************************************************
+ * Copyright (c) 2010-2011 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
+/******
+ * Copied from org.sonatype.aether:aether-util:1.13.1
+ ******/
+/**
+ * A version range inspired by mathematical range syntax. For example, "[1.0,2.0)", "[1.0,)" or "[1.0]".
+ * 
+ * @author Benjamin Bentmann
+ * @author Alin Dreghiciu
+ */
+final class GenericVersionRange
+    implements VersionRange
+{
+
+    private final Version lowerBound;
+
+    private final boolean lowerBoundInclusive;
+
+    private final Version upperBound;
+
+    private final boolean upperBoundInclusive;
+
+    /**
+     * Creates a version range from the specified range specification.
+     * 
+     * @param range The range specification to parse, must not be {@code null}.
+     * @throws InvalidVersionSpecificationException If the range could not be parsed.
+     */
+    public GenericVersionRange( String range )
+        throws InvalidVersionSpecificationException
+    {
+        String process = range;
+
+        if ( range.startsWith( "[" ) )
+        {
+            lowerBoundInclusive = true;
+        }
+        else if ( range.startsWith( "(" ) )
+        {
+            lowerBoundInclusive = false;
+        }
+        else
+        {
+            throw new InvalidVersionSpecificationException( range, "Invalid version range " + range
+                + ", a range must start with either [ or (" );
+        }
+
+        if ( range.endsWith( "]" ) )
+        {
+            upperBoundInclusive = true;
+        }
+        else if ( range.endsWith( ")" ) )
+        {
+            upperBoundInclusive = false;
+        }
+        else
+        {
+            throw new InvalidVersionSpecificationException( range, "Invalid version range " + range
+                + ", a range must end with either [ or (" );
+        }
+
+        process = process.substring( 1, process.length() - 1 );
+
+        int index = process.indexOf( "," );
+
+        if ( index < 0 )
+        {
+            if ( !lowerBoundInclusive || !upperBoundInclusive )
+            {
+                throw new InvalidVersionSpecificationException( range, "Invalid version range " + range
+                    + ", single version must be surrounded by []" );
+            }
+
+            lowerBound = upperBound = new GenericVersion( process.trim() );
+        }
+        else
+        {
+            String parsedLowerBound = process.substring( 0, index ).trim();
+            String parsedUpperBound = process.substring( index + 1 ).trim();
+
+            // more than two bounds, e.g. (1,2,3)
+            if ( parsedUpperBound.contains( "," ) )
+            {
+                throw new InvalidVersionSpecificationException( range, "Invalid version range " + range
+                    + ", bounds may not contain additional ','" );
+            }
+
+            lowerBound = parsedLowerBound.length() > 0 ? new GenericVersion( parsedLowerBound ) : null;
+            upperBound = parsedUpperBound.length() > 0 ? new GenericVersion( parsedUpperBound ) : null;
+
+            if ( upperBound != null && lowerBound != null )
+            {
+                if ( upperBound.compareTo( lowerBound ) < 0 )
+                {
+                    throw new InvalidVersionSpecificationException( range, "Invalid version range " + range
+                        + ", lower bound must not be greater than upper bound" );
+                }
+            }
+        }
+    }
+
+    public GenericVersionRange( Version lowerBound, boolean lowerBoundInclusive, Version upperBound,
+                                boolean upperBoundInclusive )
+    {
+        this.lowerBound = lowerBound;
+        this.lowerBoundInclusive = lowerBoundInclusive;
+        this.upperBound = upperBound;
+        this.upperBoundInclusive = upperBoundInclusive;
+    }
+
+    public Version getLowerBound()
+    {
+        return lowerBound;
+    }
+
+    public boolean isLowerBoundInclusive()
+    {
+        return lowerBoundInclusive;
+    }
+
+    public Version getUpperBound()
+    {
+        return upperBound;
+    }
+
+    public boolean isUpperBoundInclusive()
+    {
+        return upperBoundInclusive;
+    }
+
+    public boolean containsVersion( Version version )
+    {
+        if ( lowerBound != null )
+        {
+            int comparison = lowerBound.compareTo( version );
+
+            if ( comparison == 0 && !lowerBoundInclusive )
+            {
+                return false;
+            }
+            if ( comparison > 0 )
+            {
+                return false;
+            }
+        }
+
+        if ( upperBound != null )
+        {
+            int comparison = upperBound.compareTo( version );
+
+            if ( comparison == 0 && !upperBoundInclusive )
+            {
+                return false;
+            }
+            if ( comparison < 0 )
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean equals( Object obj )
+    {
+        if ( obj == this )
+        {
+            return true;
+        }
+        else if ( obj == null || !getClass().equals( obj.getClass() ) )
+        {
+            return false;
+        }
+
+        GenericVersionRange that = (GenericVersionRange) obj;
+
+        return upperBoundInclusive == that.upperBoundInclusive && lowerBoundInclusive == that.lowerBoundInclusive
+            && eq( upperBound, that.upperBound ) && eq( lowerBound, that.lowerBound );
+    }
+
+    private static <T> boolean eq( T s1, T s2 )
+    {
+        return s1 != null ? s1.equals( s2 ) : s2 == null;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int hash = 17;
+        hash = hash * 31 + hash( upperBound );
+        hash = hash * 31 + ( upperBoundInclusive ? 1 : 0 );
+        hash = hash * 31 + hash( lowerBound );
+        hash = hash * 31 + ( lowerBoundInclusive ? 1 : 0 );
+        return hash;
+    }
+
+    private static int hash( Object obj )
+    {
+        return obj != null ? obj.hashCode() : 0;
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder buffer = new StringBuilder( 64 );
+        buffer.append( lowerBoundInclusive ? '[' : '(' );
+        if ( lowerBound != null )
+        {
+            buffer.append( lowerBound );
+        }
+        buffer.append( ',' );
+        if ( upperBound != null )
+        {
+            buffer.append( upperBound );
+        }
+        buffer.append( upperBoundInclusive ? ']' : ')' );
+        return buffer.toString();
+    }
+
+}

--- a/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/condition/internal/GenericVersionScheme.java
+++ b/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/condition/internal/GenericVersionScheme.java
@@ -1,0 +1,129 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2013 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.client.core.condition.internal;
+
+/*******************************************************************************
+ * Copyright (c) 2010-2011 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
+/******
+ * Copied from org.sonatype.aether:aether-util:1.13.1
+ ******/
+/**
+ * A version scheme using a generic version syntax and common sense sorting. This scheme accepts versions of any form,
+ * interpreting a version as a sequence of numeric and alphabetic components. The characters '-' and '.' as well as the
+ * mere transitions from digit to letter and vice versa delimit the version components. Delimiters are treated as
+ * equivalent. Numeric components are compared mathematically, alphabetic components are compared lexicographically and
+ * case-insensitively. However, the following qualifier strings are recognized and treated specially: "alpha" < "beta" <
+ * "milestone" < "cr" = "rc" < "snapshot" < "final" = "ga" < "sp". All of those well-known qualifiers are considered
+ * smaller/older than other strings. An empty component/string is equivalent to 0. Numbers and strings are considered
+ * incomparable against each other. Where version components of different kind would collide, comparison will instead
+ * assume that the previous components are padded with 0 or "ga", respectively, until the kind mismatch is resolved,
+ * i.e. 1-alpha = 1.0.0-alpha < 1.0.1-ga = 1.0.1.
+ * 
+ * @author Benjamin Bentmann
+ * @author Alin Dreghiciu
+ */
+public class GenericVersionScheme
+    implements VersionScheme
+{
+
+    /**
+     * Creates a new instance of the version scheme for parsing versions.
+     */
+    public GenericVersionScheme()
+    {
+    }
+
+    public Version parseVersion( final String version )
+        throws InvalidVersionSpecificationException
+    {
+        return new GenericVersion( version );
+    }
+
+    public VersionRange parseVersionRange( final String range )
+        throws InvalidVersionSpecificationException
+    {
+        return new GenericVersionRange( range );
+    }
+
+    public VersionConstraint parseVersionConstraint( final String constraint )
+        throws InvalidVersionSpecificationException
+    {
+        GenericVersionConstraint result = new GenericVersionConstraint();
+
+        String process = constraint;
+
+        while ( process.startsWith( "[" ) || process.startsWith( "(" ) )
+        {
+            int index1 = process.indexOf( ')' );
+            int index2 = process.indexOf( ']' );
+
+            int index = index2;
+            if ( index2 < 0 || ( index1 >= 0 && index1 < index2 ) )
+            {
+                index = index1;
+            }
+
+            if ( index < 0 )
+            {
+                throw new InvalidVersionSpecificationException( constraint, "Unbounded version range " + constraint );
+            }
+
+            VersionRange range = parseVersionRange( process.substring( 0, index + 1 ) );
+            result.addRange( range );
+
+            process = process.substring( index + 1 ).trim();
+
+            if ( process.length() > 0 && process.startsWith( "," ) )
+            {
+                process = process.substring( 1 ).trim();
+            }
+        }
+
+        if ( process.length() > 0 && !result.getRanges().isEmpty() )
+        {
+            throw new InvalidVersionSpecificationException( constraint, "Invalid version range " + constraint
+                + ", expected [ or ( but got " + process );
+        }
+
+        if ( result.getRanges().isEmpty() )
+        {
+            result.setVersion( parseVersion( constraint ) );
+        }
+
+        return result;
+    }
+
+    @Override
+    public boolean equals( final Object obj )
+    {
+        if ( this == obj )
+        {
+            return true;
+        }
+
+        return obj != null && getClass().equals( obj.getClass() );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return getClass().hashCode();
+    }
+
+}

--- a/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/condition/internal/InvalidVersionSpecificationException.java
+++ b/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/condition/internal/InvalidVersionSpecificationException.java
@@ -1,0 +1,54 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2013 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.client.core.condition.internal;
+
+/*******************************************************************************
+ * Copyright (c) 2010-2011 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
+/******
+ * Copied from org.sonatype.aether:aether-api:1.13.1
+ ******/
+/**
+ * Thrown when a version or version range could not be parsed.
+ * 
+ * @author Benjamin Bentmann
+ */
+public class InvalidVersionSpecificationException
+    extends RuntimeException //RepositoryException
+{
+
+    private final String version;
+
+    public InvalidVersionSpecificationException( String version, String message )
+    {
+        super( message );
+        this.version = version;
+    }
+
+    public InvalidVersionSpecificationException( String version, Throwable cause )
+    {
+        super( "Could not parse version specification " + version, cause );
+        this.version = version;
+    }
+
+    public String getVersion()
+    {
+        return version;
+    }
+
+}

--- a/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/condition/internal/Version.java
+++ b/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/condition/internal/Version.java
@@ -1,0 +1,42 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2013 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.client.core.condition.internal;
+
+/*******************************************************************************
+ * Copyright (c) 2010-2011 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
+/******
+ * Copied from org.sonatype.aether:aether-api:1.13.1
+ ******/
+/**
+ * A parsed artifact version.
+ * 
+ * @author Benjamin Bentmann
+ */
+public interface Version
+    extends Comparable<Version>
+{
+
+    /**
+     * Gets the original string representation of the version.
+     * 
+     * @return The string representation of the version.
+     */
+    String toString();
+
+}

--- a/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/condition/internal/VersionConstraint.java
+++ b/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/condition/internal/VersionConstraint.java
@@ -1,0 +1,62 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2013 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.client.core.condition.internal;
+
+/*******************************************************************************
+ * Copyright (c) 2010-2011 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
+import java.util.Collection;
+
+/******
+ * Copied from org.sonatype.aether:aether-api:1.13.1
+ ******/
+/**
+ * A constraint on versions for a dependency. A constraint can either consist of one or more version ranges or a single
+ * version. In the first case, the constraint expresses a hard requirement on a version matching one of its ranges. In
+ * the second case, the constraint expresses a soft requirement on a specific version (i.e. a recommendation).
+ * 
+ * @author Benjamin Bentmann
+ */
+public interface VersionConstraint
+{
+
+    /**
+     * Gets the version ranges of this constraint.
+     * 
+     * @return The version ranges, may be empty but never {@code null}.
+     */
+    Collection<VersionRange> getRanges();
+
+    /**
+     * Gets the version recommended by this constraint.
+     * 
+     * @return The recommended version or {@code null} if none.
+     */
+    Version getVersion();
+
+    /**
+     * Determines whether the specified version satisfies this constraint. In more detail, a version satisfies this
+     * constraint if it matches at least one version range or if this constraint has no version ranges at all and the
+     * specified version equals the version recommended by the constraint.
+     * 
+     * @param version The version to test, must not be {@code null}.
+     * @return {@code true} if the specified version satisfies this constraint, {@code false} otherwise.
+     */
+    boolean containsVersion( Version version );
+
+}

--- a/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/condition/internal/VersionRange.java
+++ b/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/condition/internal/VersionRange.java
@@ -1,0 +1,42 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2013 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.client.core.condition.internal;
+
+/*******************************************************************************
+ * Copyright (c) 2010-2011 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
+/******
+ * Copied from org.sonatype.aether:aether-api:1.13.1
+ ******/
+/**
+ * A range of versions.
+ * 
+ * @author Benjamin Bentmann
+ */
+public interface VersionRange
+{
+
+    /**
+     * Determines whether the specified version is contained within this range.
+     * 
+     * @param version The version to test, must not be {@code null}.
+     * @return {@code true} if this range contains the specified version, {@code false} otherwise.
+     */
+    boolean containsVersion( Version version );
+
+}

--- a/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/condition/internal/VersionScheme.java
+++ b/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/condition/internal/VersionScheme.java
@@ -1,0 +1,66 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2013 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.client.core.condition.internal;
+
+/*******************************************************************************
+ * Copyright (c) 2010-2011 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
+/******
+ * Copied from org.sonatype.aether:aether-api:1.13.1
+ ******/
+/**
+ * A version scheme that handles interpretation of version strings to facilitate their comparison.
+ * 
+ * @author Benjamin Bentmann
+ * @author Alin Dreghiciu
+ */
+public interface VersionScheme
+{
+
+    /**
+     * Parses the specified version string, for example "1.0".
+     * 
+     * @param version The version string to parse, must not be {@code null}.
+     * @return The parsed version, never {@code null}.
+     * @throws InvalidVersionSpecificationException If the string violates the syntax rules of this scheme.
+     */
+    Version parseVersion( String version )
+        throws InvalidVersionSpecificationException;
+
+    /**
+     * Parses the specified version range specification, for example "[1.0,2.0)".
+     * 
+     * @param range The range specification to parse, must not be {@code null}.
+     * @return The parsed version range, never {@code null}.
+     * @throws InvalidVersionSpecificationException If the range specification violates the syntax rules of this scheme.
+     */
+    VersionRange parseVersionRange( String range )
+        throws InvalidVersionSpecificationException;
+
+    /**
+     * Parses the specified version constraint specification, for example "1.0" or "[1.0,2.0),(2.0,)".
+     * 
+     * @param constraint The constraint specification to parse, must not be {@code null}.
+     * @return The parsed version constraint, never {@code null}.
+     * @throws InvalidVersionSpecificationException If the constraint specification violates the syntax rules of this
+     *             scheme.
+     */
+    VersionConstraint parseVersionConstraint( final String constraint )
+        throws InvalidVersionSpecificationException;
+
+}


### PR DESCRIPTION
It turned out that the plugin itself is okay
with mvn3.1, but it's the nexus-core-client that
used old Aether for some version comparisions.

Luckily, these ops are well hidden behind the Condition
iface, so for now copy paste of relevant
Aether classes happened into the client
(and removal of Aether dependency).

This makes nexus-staging-maven-plugin happy in
mvn 3.1
