### PR TITLE
NEXUS-5799: Sort indexCreators when creating context

### DIFF
--- a/plugins/indexer/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexerManager.java
+++ b/plugins/indexer/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexerManager.java
@@ -95,6 +95,7 @@ import org.apache.maven.index.updater.IndexUpdateRequest;
 import org.apache.maven.index.updater.IndexUpdateResult;
 import org.apache.maven.index.updater.IndexUpdater;
 import org.apache.maven.index.updater.ResourceFetcher;
+import org.apache.maven.index.util.IndexCreatorSorter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonatype.nexus.configuration.application.NexusConfiguration;
@@ -527,7 +528,7 @@ public class DefaultIndexerManager
                 openFSDirectory( indexDirectory ), // indexDirectory
                 null, // repositoryUrl
                 null, // indexUpdateUrl
-                indexCreators, //
+                IndexCreatorSorter.sort( indexCreators ), //
                 true, // reclaimIndex
                 ISPROXY( repository ) );
             mavenIndexer.addIndexingContext( ctx );


### PR DESCRIPTION
During indexer fixes (since Nexus 2.2 and on), new methods were added on NexusIndexer that circumvents the sort of creators, that slipped my attention.

This change simple ensures that the indexCreators are passed in needed order (before they were not, we actually relied on order returned by "active" collection got injected).

Issue
https://issues.sonatype.org/browse/NEXUS-5799

CI
https://bamboo.zion.sonatype.com/browse/NX-OSSF5
