### PR TITLE
NXCM-5433: Attributes should never be thrashed

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultLSAttributeStorage.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultLSAttributeStorage.java
@@ -92,7 +92,7 @@ public class DefaultLSAttributeStorage
                 final ResourceStoreRequest request =
                     new ResourceStoreRequest( getAttributePath( repository, uid.getPath() ) );
 
-                repository.getLocalStorage().deleteItem( repository, request );
+                repository.getLocalStorage().shredItem( repository, request );
 
                 return true;
             }


### PR DESCRIPTION
Since attributes were moved into LS (since 2.0),
on deletion of a file item, it's attributes were always
thrashed (content fate depends on actual DeleteOperation
in effect).

This was a long outstanding bug, as we do support content
restoration from thrash, but not attribute restoration.

After this change:
- attributes of deleted item(s) are lost forever (never thrashed)
- content of deleted item(s) are either thrashed or shredded
  (depends on DeleteOperation in effect)

Issue
https://issues.sonatype.org/browse/NXCM-5433

CI
https://bamboo.zion.sonatype.com/browse/NX-OSSF39
