### PR TITLE
[NXCM-5431] Use latest p2-bridge that has the removed hc3 from eclipse runtime

### DIFF
--- a/plugins/p2/pom.xml
+++ b/plugins/p2/pom.xml
@@ -28,7 +28,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <p2-bridge.version>1.1.7</p2-bridge.version>
+    <p2-bridge.version>1.1.8-SNAPSHOT</p2-bridge.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
https://issues.sonatype.org/browse/NXCM-5431
https://bamboo.zion.sonatype.com/browse/NX-OSSF16

Uses changes from https://github.com/sonatype/p2-bridge/commit/8346673665a9f4d32cfceb06a7b69cef683a41fb
