### PR TITLE
REVIEW: [NEXUS-5811] Use the absolute URL in RRB when the links are absolute and they do not start with proxy repository URL

### DIFF
--- a/plugins/basic/nexus-rrb-plugin/src/main/java/org/sonatype/nexus/plugins/rrb/MavenRepositoryReader.java
+++ b/plugins/basic/nexus-rrb-plugin/src/main/java/org/sonatype/nexus/plugins/rrb/MavenRepositoryReader.java
@@ -15,6 +15,8 @@ package org.sonatype.nexus.plugins.rrb;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -80,13 +82,21 @@ public class MavenRepositoryReader
 
     this.id = id;
 
-    String baseRemoteUrl = proxyRepository.getRemoteUrl();
-
-    if (!baseRemoteUrl.endsWith("/") && !remotePath.startsWith("/")) {
-      this.remoteUrl = baseRemoteUrl + "/" + remotePath;
+    // NEXUS-5811: check first if we have an valid URL as remote path. If we do we use that one, else we have a relative
+    // path and we append it to proxy repository URL
+    try {
+      new URL(remotePath);
+      remoteUrl = remotePath;
     }
-    else {
-      this.remoteUrl = baseRemoteUrl + remotePath;
+    catch (MalformedURLException e) {
+      String baseRemoteUrl = proxyRepository.getRemoteUrl();
+
+      if (!baseRemoteUrl.endsWith("/") && !remotePath.startsWith("/")) {
+        remoteUrl = baseRemoteUrl + "/" + remotePath;
+      }
+      else {
+        remoteUrl = baseRemoteUrl + remotePath;
+      }
     }
 
     StringBuilder html = getContent();


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-5811
https://bamboo.zion.sonatype.com/browse/NX-OSSF17

IN case that the index page returned from remote nexus has links that start with the forced base URL which are different then the proxy repository configured URL, use the absolute URLS returned by remote nexus.
