### PR TITLE
NXCM-5433: Undo 5ee2d0741d533e05761e2b74bf1a7ecbf98bf9af

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultLSAttributeStorage.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultLSAttributeStorage.java
@@ -88,7 +88,7 @@ public class DefaultLSAttributeStorage
         final ResourceStoreRequest request =
             new ResourceStoreRequest(getAttributePath(repository, uid.getPath()));
 
-        repository.getLocalStorage().shredItem(repository, request);
+        repository.getLocalStorage().deleteItem(repository, request);
 
         return true;
       }


### PR DESCRIPTION
Attributes will (again, as were since 2.0) go in trash along with content.

Original commit (manually reverted due to formatting changes, was conflicting)
5ee2d0741d533e05761e2b74bf1a7ecbf98bf9af

Original pull:
https://github.com/sonatype/nexus-oss/pull/81

Issue
https://issues.sonatype.org/browse/NXCM-5433

CI
https://bamboo.zion.sonatype.com/browse/NX-OSSF30
