### PR TITLE
REVIEW: Make possible to specify a period of time for which nexus should not run any tasks

### DIFF
--- a/testsupport/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/Scheduler.java
+++ b/testsupport/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/Scheduler.java
@@ -33,4 +33,7 @@ public interface Scheduler
     void waitForAllTasksToStop( Time timeout )
         throws TasksAreStillRunningException;
 
+    void waitForAllTasksToStop( Time timeout, Time window )
+        throws TasksAreStillRunningException;
+
 }

--- a/testsupport/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/internal/JerseyScheduler.java
+++ b/testsupport/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/internal/JerseyScheduler.java
@@ -80,8 +80,16 @@ public class JerseyScheduler
         waitForAllTasksToStop( null );
     }
 
+
+
     @Override
     public void waitForAllTasksToStop( @Nullable final Time timeout )
+    {
+        waitForAllTasksToStop( timeout, null );
+    }
+
+    @Override
+    public void waitForAllTasksToStop(final Time timeout, final Time window)
     {
         try
         {
@@ -91,12 +99,20 @@ public class JerseyScheduler
                 actualTimeout = Time.minutes( 1 );
             }
 
+            Time actualWindow = window;
+            if ( actualWindow == null )
+            {
+                actualWindow = Time.seconds( 10 );
+            }
+
             LOG.info(
-                "Waiting for Nexus to not execute any task (timeouts in {})", actualTimeout.toString()
+                "Waiting for Nexus to not execute any task for {} (timeouts in {})",
+                actualWindow.toString(), actualTimeout.toString()
             );
 
             final MultivaluedMap<String, String> params = new MultivaluedMapImpl();
             params.add( "timeout", String.valueOf( actualTimeout.toMillis() ) );
+            params.add( "window", String.valueOf( actualWindow.toMillis() ) );
 
             final ClientResponse response = getNexusClient()
                 .serviceResource( "tasks/waitFor", params )


### PR DESCRIPTION
This param will force the TasksWaitForPlexusResource helper resource to not return immediately if tasks are not running, but wait for a period of time (windows) in which no tasks are being run

https://bamboo.zion.sonatype.com/browse/NX-OSSF32

Signed-off-by: Alin Dreghiciu adreghiciu@gmail.com
