### PR TITLE
On fresh cached files no UID lock was applied.

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
@@ -837,7 +837,11 @@ public abstract class AbstractProxyRepository
 
         removeFromNotFoundCache(item.getResourceStoreRequest());
 
-        result = getLocalStorage().retrieveItem(this, new ResourceStoreRequest(item));
+        // we swapped the remote item with the one from local storage
+        // using this method below, we ensure that we get a "wrapped"
+        // content locator that will keel shared-lock on the content
+        // until being fully read
+        result = doRetrieveLocalItem(item.getResourceStoreRequest());
 
       }
       finally {

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
@@ -1229,22 +1229,23 @@ public abstract class AbstractRepository
   protected StorageItem doRetrieveItem(ResourceStoreRequest request)
       throws IllegalOperationException, ItemNotFoundException, StorageException
   {
-    AbstractStorageItem localItem = null;
+    return doRetrieveLocalItem(request);
+  }
 
+  protected AbstractStorageItem doRetrieveLocalItem(final ResourceStoreRequest request)
+      throws ItemNotFoundException, LocalStorageException
+  {
+    AbstractStorageItem localItem = null;
     try {
       localItem = getLocalStorage().retrieveItem(this, request);
-
-      // plain file? wrap it
       if (localItem instanceof StorageFileItem) {
         StorageFileItem file = (StorageFileItem) localItem;
-
         // wrap the content locator if needed
         if (!(file.getContentLocator() instanceof ReadLockingContentLocator)) {
           final RepositoryItemUid uid = createUid(request.getRequestPath());
           file.setContentLocator(new ReadLockingContentLocator(uid, file.getContentLocator()));
         }
       }
-
       if (getLogger().isDebugEnabled()) {
         getLogger().debug("Item " + request.toString() + " found in local storage.");
       }
@@ -1253,7 +1254,6 @@ public abstract class AbstractRepository
       if (getLogger().isDebugEnabled()) {
         getLogger().debug("Item " + request.toString() + " not found in local storage.");
       }
-
       throw ex;
     }
 


### PR DESCRIPTION
As revealed by debugging: with empty cache, a content
request that made Nx go remote, fetch, cache and serve
the content, the StorageFileItemRepresentation got a
file item which ContentLocator was not wrapped with
ReadLockingContentLocator (but it was plain FileContentLocator).

This means, that files served up like these (or processed internally)
were prone to deletion by some other thread, like request
for deletion of a parent directory or such.

CI
https://bamboo.zion.sonatype.com/browse/NX-OSSF35
