### PR TITLE
NEXUS-5861: RemoteStorageContext values might come from parent

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/DefaultRemoteConnectionSettings.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/DefaultRemoteConnectionSettings.java
@@ -55,4 +55,37 @@ public class DefaultRemoteConnectionSettings
   public void setUserAgentCustomizationString(String userAgentCustomizationString) {
     this.userAgentCustomizationString = userAgentCustomizationString;
   }
+
+  // ==
+
+  public static RemoteConnectionSettings asReadOnly(final RemoteConnectionSettings remoteConnectionSettings) {
+    return new ReadOnlyRemoteConnectionSettings(remoteConnectionSettings);
+  }
+
+  public static class ReadOnlyRemoteConnectionSettings
+      extends DefaultRemoteConnectionSettings
+  {
+    public ReadOnlyRemoteConnectionSettings(final RemoteConnectionSettings remoteConnectionSettings) {
+      super.setConnectionTimeout(remoteConnectionSettings.getConnectionTimeout());
+      super.setQueryString(remoteConnectionSettings.getQueryString());
+      super.setRetrievalRetryCount(remoteConnectionSettings.getRetrievalRetryCount());
+      super.setUserAgentCustomizationString(remoteConnectionSettings.getUserAgentCustomizationString());
+    }
+
+    public void setConnectionTimeout(int connectionTimeout) {
+      throw new IllegalStateException("Parent instance is not modifiable!");
+    }
+
+    public void setRetrievalRetryCount(int retrievalRetryCount) {
+      throw new IllegalStateException("Parent instance is not modifiable!");
+    }
+
+    public void setQueryString(String queryString) {
+      throw new IllegalStateException("Parent instance is not modifiable!");
+    }
+
+    public void setUserAgentCustomizationString(String userAgentCustomizationString) {
+      throw new IllegalStateException("Parent instance is not modifiable!");
+    }
+  }
 }

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/storage/remote/DefaultRemoteStorageContext.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/storage/remote/DefaultRemoteStorageContext.java
@@ -13,6 +13,7 @@
 
 package org.sonatype.nexus.proxy.storage.remote;
 
+import org.sonatype.nexus.proxy.repository.DefaultRemoteConnectionSettings;
 import org.sonatype.nexus.proxy.repository.RemoteAuthenticationSettings;
 import org.sonatype.nexus.proxy.repository.RemoteConnectionSettings;
 import org.sonatype.nexus.proxy.repository.RemoteProxySettings;
@@ -21,7 +22,7 @@ import org.sonatype.nexus.proxy.storage.StorageContext;
 
 /**
  * The default remote storage context.
- *
+ * 
  * @author cstamas
  */
 public class DefaultRemoteStorageContext
@@ -59,7 +60,13 @@ public class DefaultRemoteStorageContext
 
   @Override
   public RemoteConnectionSettings getRemoteConnectionSettings() {
-    return (RemoteConnectionSettings) getContextObject(RemoteConnectionSettings.class.getName());
+    final RemoteConnectionSettings remoteConnectionSettings = (RemoteConnectionSettings) getContextObject(RemoteConnectionSettings.class.getName());
+    if (hasContextObject(RemoteConnectionSettings.class.getName())) {
+      return remoteConnectionSettings;
+    }
+    else {
+      return DefaultRemoteConnectionSettings.asReadOnly(remoteConnectionSettings);
+    }
   }
 
   @Override


### PR DESCRIPTION
So, wrapping the RemoteConnectionSettings as ReadOnly when it comes from parent RemoteStorageContext.

Issue:
https://issues.sonatype.org/browse/NEXUS-5861

CI:
https://bamboo.zion.sonatype.com/browse/NX-OSSF13
