### PR TITLE
NEXUS-5838: RRB uses wrong path in case of some index pages

### DIFF
--- a/plugins/basic/nexus-rrb-plugin/src/test/java/org/sonatype/nexus/plugins/rrb/RemoteBrowserResourceAuthTest.java
+++ b/plugins/basic/nexus-rrb-plugin/src/test/java/org/sonatype/nexus/plugins/rrb/RemoteBrowserResourceAuthTest.java
@@ -125,8 +125,8 @@ public class RemoteBrowserResourceAuthTest
     String jsonString = plexusResource.get(null, request, null, null).toString();
 
     // TODO: do some better validation then this
-    Assert.assertTrue(jsonString.contains("/auth-test/classes/"));
-    Assert.assertTrue(jsonString.contains("/auth-test/test-classes/"));
+    Assert.assertTrue(jsonString.contains("/classes/"));
+    Assert.assertTrue(jsonString.contains("/test-classes/"));
 
   }
 


### PR DESCRIPTION
Code was prepared for two possibilities: that HTML `a` tag's `href`
attribute contains relative paths (taken from index page base),
or, that `href` attribute contains full URLs.

But here we have a third (valid) case: the `href` attribute contains
absolute paths from the server root.

Hence, the paths were wrongly assembled, as the basePath
element was duplicated in the URL requested from remote.

Issue
https://issues.sonatype.org/browse/NEXUS-5838

CI
https://bamboo.zion.sonatype.com/browse/NX-OSSF36
