### PR TITLE
Nx PM changed to discover indexes

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/plugins/DefaultNexusPluginManager.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/plugins/DefaultNexusPluginManager.java
@@ -464,10 +464,8 @@ public class DefaultNexusPluginManager
       if (exists(sisuIndexUrl)) {
         return true;
       }
-      final URL plexusComponents = url.toURI().resolve("META-INF/plexus/components.xml").toURL();
-      if (exists(plexusComponents)) {
-        return true;
-      }
+      // no need for plx XML discovery, as that will be picked up
+      // even without scanning
     }
     catch (Exception e) {
       // just neglect any URISyntaxEx or MalformedUrlEx


### PR DESCRIPTION
Some plugin dependencies might have indexes,
hence, components would need to be discovered.

Currently, a non-shared plugin dependency will not have
components discovered by Nx PM.

Instead to put this work on a developer to track
which deps have and which does not have components,
this change should make Nx PM "smarter" and
should decide on it's own if some Index is
found in dependency (SISU index or Plexus components XML).

Still, turning ON scanning globally is bad idea, as
on dependencies that does not have index file, 
SISU would fall back to classpath scanning, 
making boot process painfully slow, especially
with many and/or large dependencies without
index/components.

CI
https://bamboo.zion.sonatype.com/browse/NX-OSSF66
