### PR TITLE
NEXUS-5306: move locking to ctx lister booting plexus

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/NxApplication.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/NxApplication.java
@@ -35,13 +35,13 @@ import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
 import org.sonatype.nexus.proxy.repository.ShadowRepository;
 import org.sonatype.nexus.scheduling.NexusScheduler;
 import org.sonatype.nexus.tasks.SynchronizeShadowsTask;
-import org.sonatype.nexus.util.LockFile;
 import org.sonatype.security.SecuritySystem;
 import org.sonatype.sisu.goodies.eventbus.EventBus;
 import org.sonatype.sisu.goodies.lifecycle.LifecycleSupport;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -54,8 +54,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class NxApplication
     extends LifecycleSupport
 {
-  private final LockFile lockFile;
-
   private final EventBus eventBus;
 
   private final ApplicationStatusSource applicationStatusSource;
@@ -83,12 +81,6 @@ public class NxApplication
     this.securitySystem = checkNotNull(securitySystem);
     this.nexusScheduler = checkNotNull(nexusScheduler);
     this.repositoryRegistry = checkNotNull(repositoryRegistry);
-
-    this.lockFile = new LockFile(new File(nexusConfiguration.getWorkingDirectory(), "nexus.lock"));
-
-    if (!lockFile.lock()) {
-      throw new IllegalStateException("Nexus work directory already in use: " + lockFile.getFile());
-    }
 
     logInitialized();
 
@@ -200,7 +192,6 @@ public class NxApplication
     securitySystem.stop();
     applicationStatusSource.getSystemStatus().setState(SystemState.STOPPED);
     log.info("Stopped {}", getNexusNameForLogs());
-    lockFile.release();
   }
 
   private void synchronizeShadowsAtStartup() {


### PR DESCRIPTION
To avoid chatty logging when exception preventing boot
happens within container, during wire up of things.

Change of merged
https://github.com/sonatype/nexus-oss/pull/171

Issue
https://issues.sonatype.org/browse/NEXUS-5306
