### PR TITLE
POC: LevelDB AttributeStorage (experimental)

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultAttributesHandler.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultAttributesHandler.java
@@ -120,7 +120,7 @@ public class DefaultAttributesHandler
 
   @Inject
   public DefaultAttributesHandler(ApplicationConfiguration applicationConfiguration,
-                                  @Named("ls") AttributeStorage attributeStorage,
+                                  @Named("${org.sonatype.nexus.proxy.attributes.DefaultAttributesHandler.attributeStorage:-ls}") AttributeStorage attributeStorage,
                                   @Named("legacy") AttributeStorage legacyAttributeStorage,
                                   List<StorageItemInspector> itemInspectorList,
                                   List<StorageFileItemInspector> fileItemInspectorList)

--- a/components/nexus-webapp/pom.xml
+++ b/components/nexus-webapp/pom.xml
@@ -129,6 +129,15 @@
 
     <dependency>
       <groupId>org.sonatype.nexus.plugins</groupId>
+      <artifactId>nexus-leveldb-plugin</artifactId>
+      <version>${nexus.version}</version>
+      <classifier>bundle</classifier>
+      <type>zip</type>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.sonatype.nexus.plugins</groupId>
       <artifactId>nexus-restlet1x-plugin</artifactId>
       <version>${nexus.version}</version>
       <classifier>bundle</classifier>

--- a/components/nexus-webapp/src/main/assembly/plugins.xml
+++ b/components/nexus-webapp/src/main/assembly/plugins.xml
@@ -38,6 +38,7 @@
         <include>*:nexus-crypto-plugin</include>
         <include>*:nexus-groovy-plugin</include>
         <include>*:nexus-h2-plugin</include>
+        <include>*:nexus-leveldb-plugin</include>
         <include>*:nexus-restlet1x-plugin</include>
         <include>*:nexus-siesta-plugin</include>
         <include>*:nexus-lvo-plugin</include>

--- a/plugins/basic/nexus-leveldb-plugin/pom.xml
+++ b/plugins/basic/nexus-leveldb-plugin/pom.xml
@@ -1,0 +1,82 @@
+<!--
+
+    Sonatype Nexus (TM) Open Source Version
+    Copyright (c) 2007-2013 Sonatype, Inc.
+    All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+
+    This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+    which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+
+    Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+    of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+    Eclipse Foundation. All other trademarks are the property of their respective owners.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.sonatype.nexus.plugins</groupId>
+    <artifactId>nexus-plugins-basic</artifactId>
+    <version>2.7.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>nexus-leveldb-plugin</artifactId>
+  <name>${project.groupId}:${project.artifactId}</name>
+  <packaging>nexus-plugin</packaging>
+
+  <properties>
+    <pluginName>Nexus LevelDB Provider Plugin</pluginName>
+    <pluginDescription>Provides access to LevelDB databases.</pluginDescription>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-plugin-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.iq80.leveldb</groupId>
+      <artifactId>leveldb-api</artifactId>
+      <version>0.6</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.iq80.leveldb</groupId>
+      <artifactId>leveldb</artifactId>
+      <version>0.6</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.iq80.snappy</groupId>
+      <artifactId>snappy</artifactId>
+      <version>0.3</version>
+    </dependency>
+     
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-plugin-testsupport</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.nexus</groupId>
+        <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
+        <configuration>
+          <sharedDependencies>
+            <sharedDependency>org.iq80.leveldb:leveldb-api</sharedDependency>
+            <sharedDependency>org.iq80.leveldb:leveldb</sharedDependency>
+          </sharedDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/plugins/basic/nexus-leveldb-plugin/src/main/java/org/sonatype/nexus/leveldb/LevelDbManager.java
+++ b/plugins/basic/nexus-leveldb-plugin/src/main/java/org/sonatype/nexus/leveldb/LevelDbManager.java
@@ -1,0 +1,88 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2013 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.leveldb;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.iq80.leveldb.DB;
+import org.iq80.leveldb.Options;
+
+/**
+ * A manager of databases that removes the burden of finding a proper place for, and closing them out (at Nexus
+ * shutdown). Primarily, it is meant to ease of use of LevelDB in cases when database instances are "long living". Using
+ * this manager all you have to use {@link #openManaged(String, Options)} method, keep and use the instance as you wish,
+ * and it removes the burden of finding place/file to store the database files and to manage it's lifecycle, as all
+ * "managed" databases will be closed once, when Nexus instance shuts down. Still, nothing prevents you to use the
+ * "native" LevelDB way of creating a database that suits your needs, using the factory method {@link
+ * org.iq80.leveldb.impl.Iq80DBFactory.open(File, Options)} (as plugin also exports whole LevelDB too). Databases
+ * created in that way, will need to be manually shut down when no needed, and also, you will need to ensure to find a
+ * proper location to store the database files.
+ * <p>
+ * A note about {@code dbKey}s, that are actually plain strings: in current implementation, those will be used to
+ * calculate (if no explicit {@link File} passed in) the location of the database, and will end up in path. Hence, only
+ * "file system safe" characters should be used for now (currently nothing enforces this!). Keys with prefix "nx-" are
+ * reserved for Nexus internal use (this is not enforced eitherF).
+ * 
+ * @author cstamas
+ * @see <a href="https://github.com/dain/leveldb">LevelDB in Java</a>
+ * @since 2.7.0
+ */
+public interface LevelDbManager
+{
+    /**
+     * Creates and opens a "managed" LevelDB instance for caller, keyed with {@code dbKey} parameter and using passed in
+     * {@link Options}. Internally, LevelDB manager maintains a registry of databases, and will prevent creation of
+     * another database using same key. Location of the database will be the default location in Nexus (in it's work
+     * directory).
+     * 
+     * @param dbKey a DB key, never {@code null}.
+     * @param options LevelDB options, never {@code null}.
+     * @throws IllegalArgumentException if DB keyed with {@code dbKey} already exists.
+     * @throws IOException see {@link org.iq80.leveldb.impl.Iq80DBFactory.open(File, Options)}.
+     */
+    DB openManaged( String dbKey, Options options )
+        throws IOException, IllegalArgumentException;
+
+    /**
+     * Creates and opens a "managed" LevelDB instance for caller, keyed with {@code dbKey} parameter, stored at location
+     * {@code file} parameter (it has to be non existent or existent directory), and using passed in {@link Options}.
+     * Internally, LevelDB manager maintains a registry of databases, and will prevent creation of another database
+     * using same key. Location of the database will be the default location in Nexus (in it's work directory).
+     * 
+     * @param dbKey a DB key, never {@code null}.
+     * @param options LevelDB options, never {@code null}.
+     * @throws IllegalArgumentException if DB keyed with {@code dbKey} already exists, or if passed in file exists and
+     *             is not a directory.
+     * @throws IOException see {@link org.iq80.leveldb.impl.Iq80DBFactory.open(File, Options)}.
+     */
+    DB openManaged( String dbKey, File file, Options options )
+        throws IOException, IllegalArgumentException;
+
+    /**
+     * Returns the managed DB instance opened under key {@code dbKey}. If there is no DB under given key, {@code null}
+     * is returned.
+     * 
+     * @param dbKey a DB key, never {@code null}.
+     */
+    DB getManaged( String dbKey );
+
+    /**
+     * Closes the managed DB instance opened under the key {@code dbKey}, and removes instance from internal structure
+     * (close on it will not be attempted on Nexus shutdown). If there is no DB under given key, nothing happens, call
+     * will return cleanly.
+     * 
+     * @param dbKey a DB key, never {@code null}.
+     */
+    void closeManaged( String dbKey );
+}

--- a/plugins/basic/nexus-leveldb-plugin/src/main/java/org/sonatype/nexus/leveldb/attributes/LevelDBAttributeStorage.java
+++ b/plugins/basic/nexus-leveldb-plugin/src/main/java/org/sonatype/nexus/leveldb/attributes/LevelDBAttributeStorage.java
@@ -1,0 +1,185 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2013 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.leveldb.attributes;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.iq80.leveldb.impl.Iq80DBFactory.bytes;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import javax.enterprise.inject.Typed;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.iq80.leveldb.DB;
+import org.iq80.leveldb.DBException;
+import org.iq80.leveldb.Options;
+import org.sonatype.nexus.leveldb.LevelDbManager;
+import org.sonatype.nexus.proxy.access.Action;
+import org.sonatype.nexus.proxy.attributes.AbstractAttributeStorage;
+import org.sonatype.nexus.proxy.attributes.AttributeStorage;
+import org.sonatype.nexus.proxy.attributes.Attributes;
+import org.sonatype.nexus.proxy.attributes.JacksonJSONMarshaller;
+import org.sonatype.nexus.proxy.attributes.Marshaller;
+import org.sonatype.nexus.proxy.item.RepositoryItemUid;
+import org.sonatype.nexus.proxy.item.RepositoryItemUidLock;
+
+/**
+ * {@link AttributeStorage} implementation that uses LevelDB to store attributes.
+ * 
+ * @author cstamas
+ * @since 2.7.0
+ */
+@Typed( AttributeStorage.class )
+@Named( "leveldb" )
+@Singleton
+public class LevelDBAttributeStorage
+    extends AbstractAttributeStorage
+    implements AttributeStorage
+{
+    private final Marshaller marshaller;
+
+    private final DB levelDb;
+
+    /**
+     * Instantiates a new LevelDB attribute storage.
+     */
+    @Inject
+    public LevelDBAttributeStorage( final LevelDbManager levelDbManager )
+        throws IOException
+    {
+        this( levelDbManager, new JacksonJSONMarshaller() );
+    }
+
+    /**
+     * Instantiates a new LevelDB attribute storage.
+     */
+    public LevelDBAttributeStorage( final LevelDbManager levelDbManager, final Marshaller marshaller )
+        throws IOException
+    {
+        checkNotNull( levelDbManager );
+        this.marshaller = checkNotNull( marshaller );
+        // we obtain a managed DB instance, as we need it throughout whole Nx lifecycle, and manager will close it out for us
+        levelDb = levelDbManager.openManaged( "nx-attributes", new Options().createIfMissing( true ) );
+        getLogger().info( "LevelDB AttributeStorage in place, using {} marshaller.", marshaller );
+    }
+
+    @Override
+    public boolean deleteAttributes( final RepositoryItemUid uid )
+        throws IOException
+    {
+        final RepositoryItemUidLock uidLock = uid.getLock();
+        uidLock.lock( Action.delete );
+        try
+        {
+            getLogger().debug( "Deleting attribute on UID={}", uid );
+            try
+            {
+                levelDb.delete( bytes( uid.getKey() ) );
+                return true;
+            }
+            catch ( DBException e )
+            {
+                getLogger().error( "Got DBException during deletion of UID=" + uid.toString(), e );
+            }
+            return false;
+        }
+        finally
+        {
+            uidLock.unlock();
+        }
+    }
+
+    @Override
+    public Attributes getAttributes( final RepositoryItemUid uid )
+        throws IOException
+    {
+        final RepositoryItemUidLock uidLock = uid.getLock();
+        uidLock.lock( Action.read );
+        try
+        {
+            getLogger().debug( "Loading attribute on UID={}", uid );
+            final byte[] attributeContent = levelDb.get( bytes( uid.getKey() ) );
+            if ( attributeContent != null )
+            {
+                final Attributes result = marshaller.unmarshal( new ByteArrayInputStream( attributeContent ) );
+                result.setRepositoryId( uid.getRepository().getId() );
+                result.setPath( uid.getPath() );
+                // fixing remoteChecked
+                if ( result.getCheckedRemotely() == 0 || result.getCheckedRemotely() == 1 )
+                {
+                    result.setCheckedRemotely( System.currentTimeMillis() );
+                    result.setExpired( true );
+                }
+                // fixing lastRequested
+                if ( result.getLastRequested() == 0 )
+                {
+                    result.setLastRequested( System.currentTimeMillis() );
+                }
+                return result;
+            }
+        }
+        catch ( DBException e )
+        {
+            getLogger().error( "Got DBException during retrieval of UID=" + uid.toString(), e );
+        }
+        finally
+        {
+            uidLock.unlock();
+        }
+        return null;
+    }
+
+    @Override
+    public void putAttributes( final RepositoryItemUid uid, Attributes attributes )
+        throws IOException
+    {
+        checkNotNull( attributes );
+        final RepositoryItemUidLock uidLock = uid.getLock();
+        uidLock.lock( Action.create );
+        try
+        {
+            getLogger().debug( "Storing attribute on UID={}", uid );
+            try
+            {
+                final Attributes onDisk = getAttributes( uid );
+                if ( onDisk != null && ( onDisk.getGeneration() > attributes.getGeneration() ) )
+                {
+                    // change detected, overlay the to be saved onto the newer one and swap
+                    onDisk.overlayAttributes( attributes );
+                    // and overlay other things too
+                    onDisk.setRepositoryId( uid.getRepository().getId() );
+                    onDisk.setPath( uid.getPath() );
+                    onDisk.setReadable( attributes.isReadable() );
+                    onDisk.setWritable( attributes.isWritable() );
+                    attributes = onDisk;
+                }
+                attributes.incrementGeneration();
+                final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                marshaller.marshal( attributes, bos );
+                levelDb.put( bytes( uid.getKey() ), bos.toByteArray() );
+            }
+            catch ( DBException e )
+            {
+                getLogger().error( "Got DBException during store of UID=" + uid.toString(), e );
+            }
+        }
+        finally
+        {
+            uidLock.unlock();
+        }
+    }
+}

--- a/plugins/basic/nexus-leveldb-plugin/src/main/java/org/sonatype/nexus/leveldb/internal/LevelDbManagerImpl.java
+++ b/plugins/basic/nexus-leveldb-plugin/src/main/java/org/sonatype/nexus/leveldb/internal/LevelDbManagerImpl.java
@@ -1,0 +1,151 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2013 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.leveldb.internal;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.iq80.leveldb.DB;
+import org.iq80.leveldb.Options;
+import org.iq80.leveldb.impl.Iq80DBFactory;
+import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
+import org.sonatype.nexus.leveldb.LevelDbManager;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
+import org.sonatype.nexus.proxy.events.NexusStoppedEvent;
+import org.sonatype.sisu.goodies.eventbus.EventBus;
+
+import com.google.common.collect.Maps;
+import com.google.common.eventbus.Subscribe;
+
+/**
+ * Implementation of {@link LevelDbManager}.
+ * 
+ * @author cstamas
+ */
+@Singleton
+@Named
+public class LevelDbManagerImpl
+    extends AbstractLoggingComponent
+    implements LevelDbManager
+{
+    private final ApplicationConfiguration applicationConfiguration;
+
+    private final Map<String, DB> managedDatabases;
+
+    @Inject
+    public LevelDbManagerImpl( final EventBus eventBus, final ApplicationConfiguration applicationConfiguration )
+    {
+        this.applicationConfiguration = checkNotNull( applicationConfiguration );
+        this.managedDatabases = Maps.newHashMap();
+        eventBus.register( this );
+    }
+
+    @Override
+    public DB openManaged( final String dbKey, final Options options )
+        throws IOException
+    {
+        checkNotNull( dbKey, "dbKey is null" );
+        checkNotNull( options, "options is null" );
+        final File location = new File( applicationConfiguration.getWorkingDirectory( "leveldb" ), dbKey );
+        return openManaged( dbKey, location, options );
+    }
+
+    @Override
+    public DB openManaged( final String dbKey, final File file, final Options options )
+        throws IOException, IllegalArgumentException
+    {
+        checkNotNull( dbKey, "dbKey is null" );
+        checkArgument( !file.exists() || file.isDirectory() );
+        checkNotNull( options, "options is null" );
+        synchronized ( managedDatabases )
+        {
+            if ( managedDatabases.containsKey( dbKey ) )
+            {
+                throw new IllegalArgumentException( "Database keyed \"" + dbKey + "\" already created and is managed!" );
+            }
+            final DB result = create( file, options );
+            managedDatabases.put( dbKey, result );
+            return result;
+        }
+    }
+
+    @Override
+    public DB getManaged( final String dbKey )
+    {
+        checkNotNull( dbKey, "dbKey is null" );
+        synchronized ( managedDatabases )
+        {
+            return managedDatabases.get( dbKey );
+        }
+    }
+
+    @Override
+    public void closeManaged( String dbKey )
+    {
+        checkNotNull( dbKey, "dbKey is null" );
+        synchronized ( managedDatabases )
+        {
+            final DB db = managedDatabases.get( dbKey );
+            if ( db != null )
+            {
+                closeSilently( dbKey, db );
+            }
+            managedDatabases.remove( dbKey );
+        }
+    }
+
+    // == events
+
+    @Subscribe
+    public void on( final NexusStoppedEvent evt )
+    {
+        getLogger().info( "Closing all managed LevelDB instances..." );
+        synchronized ( managedDatabases )
+        {
+            for ( Map.Entry<String, DB> entry : managedDatabases.entrySet() )
+            {
+                closeSilently( entry.getKey(), entry.getValue() );
+            }
+            managedDatabases.clear();
+        }
+    }
+
+    // == internal
+
+    protected DB create( final File file, final Options options )
+        throws IOException
+    {
+        return Iq80DBFactory.factory.open( file, options );
+    }
+
+    protected void closeSilently( final String dbKey, final DB db )
+    {
+        try
+        {
+            getLogger().debug( "closing {}", dbKey );
+            db.close();
+        }
+        catch ( Exception e )
+        {
+            getLogger().warn( "Problem while closing managed LevelDB {}", dbKey, e );
+        }
+    }
+}

--- a/plugins/basic/pom.xml
+++ b/plugins/basic/pom.xml
@@ -32,6 +32,7 @@
     <module>nexus-crypto-plugin</module>
     <module>nexus-groovy-plugin</module>
     <module>nexus-h2-plugin</module>
+    <module>nexus-leveldb-plugin</module>
     <module>nexus-lvo-plugin</module>
     <module>nexus-plugin-console-plugin</module>
     <module>nexus-rrb-plugin</module>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -168,6 +168,22 @@
         <version>2.7.0-SNAPSHOT</version>
       </dependency>
 
+      <!-- levelDB -->
+
+      <dependency>
+        <groupId>org.sonatype.nexus.plugins</groupId>
+        <artifactId>nexus-leveldb-plugin</artifactId>
+        <type>nexus-plugin</type>
+        <version>2.7.0-SNAPSHOT</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.sonatype.nexus.plugins</groupId>
+        <artifactId>nexus-leveldb-plugin</artifactId>
+        <type>jar</type>
+        <version>2.7.0-SNAPSHOT</version>
+      </dependency>
+
       <!-- indexer -->
 
       <dependency>


### PR DESCRIPTION
A fully workable Nexus OSS with AttributeStorage that
uses LevelDB

Experimental! No upgrade path for example.... works for
new deployments, but upgraded instance will not have
attributes upgraded!
- introduced LevelDB "provider" plugin with some helpers
- LevelDB AttributeStorage moved out (just as LevelDB itself) from core
- LevelDB AttributeStorage is now configurable via nexus.properties (default is LS)
