### PR TITLE
REVIEW: Make capabilities depend on crypto plugin for crypto related conditions

### DIFF
--- a/components/nexus-plugin-api/pom.xml
+++ b/components/nexus-plugin-api/pom.xml
@@ -102,11 +102,6 @@
 
     <dependency>
       <groupId>org.sonatype.sisu.goodies</groupId>
-      <artifactId>goodies-crypto</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.sonatype.sisu.goodies</groupId>
       <artifactId>goodies-inject</artifactId>
     </dependency>
 

--- a/plugins/basic/nexus-crypto-plugin/pom.xml
+++ b/plugins/basic/nexus-crypto-plugin/pom.xml
@@ -55,6 +55,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.sonatype.sisu.goodies</groupId>
+      <artifactId>goodies-crypto</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.sonatype.nexus</groupId>
       <artifactId>nexus-plugin-testsupport</artifactId>
       <scope>test</scope>
@@ -71,6 +76,7 @@
             <sharedDependency>org.bouncycastle:bcprov-jdk15on</sharedDependency>
             <sharedDependency>org.bouncycastle:bcpg-jdk15on</sharedDependency>
             <sharedDependency>org.bouncycastle:bcpkix-jdk15on</sharedDependency>
+            <sharedDependency>org.sonatype.sisu.goodies:goodies-crypto</sharedDependency>
           </sharedDependencies>
         </configuration>
       </plugin>

--- a/plugins/capabilities/nexus-capabilities-plugin/pom.xml
+++ b/plugins/capabilities/nexus-capabilities-plugin/pom.xml
@@ -63,6 +63,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.sonatype.nexus.plugins</groupId>
+      <artifactId>nexus-crypto-plugin</artifactId>
+      <type>${nexus-plugin.type}</type>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.sonatype.nexus</groupId>
       <artifactId>nexus-plugin-testsupport</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
- Make crypto plugin depend/export goodies-crypto

When I moved crypto conditions from pro to oss I wrongly put goodies-crypto as a shared dependency.

https://bamboo.zion.sonatype.com/browse/NX-OSSF84
