### PR TITLE
NEXUS-5989: AS settings non optional

### DIFF
--- a/plugins/basic/nexus-ui-extjs3-plugin/src/main/resources/static/js/Sonatype/repoServer/ServerEditPanel.js
+++ b/plugins/basic/nexus-ui-extjs3-plugin/src/main/resources/static/js/Sonatype/repoServer/ServerEditPanel.js
@@ -384,11 +384,12 @@ Ext.define('Sonatype.repoServer.ServerEditPanel', {
         },
         {
           xtype : 'fieldset',
-          checkboxToggle : true,
-          collapsed : true,
+          checkboxToggle : false,
+          collapsed : false,
+          collapsible : true,
           id : formId + '_' + 'globalRestApiSettings',
           name : 'globalRestApiSettings',
-          title : 'Application Server Settings (optional)',
+          title : 'Application Server Settings',
           anchor : Sonatype.view.FIELDSET_OFFSET,
           autoHeight : true,
           layoutConfig : {


### PR DESCRIPTION
The Application Server Settings are not optional, checkbox removed and label adjusted.

Issue
https://issues.sonatype.org/browse/NEXUS-5989

CI
TBD
