### PR TITLE
Changed title to Sonatype and Nexus in left hand navigation

### DIFF
--- a/plugins/basic/nexus-ui-extjs3-plugin/src/main/resources/static/js/Sonatype/view.js
+++ b/plugins/basic/nexus-ui-extjs3-plugin/src/main/resources/static/js/Sonatype/view.js
@@ -98,7 +98,7 @@ Sonatype.view = {
           layout : 'border',
           items : [Sonatype.view.headerPanel, {
                 region : 'west',
-                title : 'Sonatype&trade; Servers',
+                title : 'Sonatype&trade;',
                 collapsible : true,
                 // collapseMode: 'mini',
                 // border: false,

--- a/plugins/basic/nexus-ui-extjs3-plugin/src/main/resources/static/js/repoServer/RepoServer.js
+++ b/plugins/basic/nexus-ui-extjs3-plugin/src/main/resources/static/js/repoServer/RepoServer.js
@@ -123,7 +123,7 @@ define('repoServer/RepoServer',['extjs', 'sonatype', 'Sonatype/lib', 'Nexus/conf
         // Left Panel
         this.nexusPanel = new Sonatype.navigation.NavigationPanel({
               id : 'st-nexus-tab',
-              title : 'nexus'
+              title : 'Nexus'
             });
 
         this.createSubComponents();


### PR DESCRIPTION
Removed the "Servers" reference since this is never relevant and looks weird and fixed the title of the Nexus menu to uppercase. 
