### PR TITLE
REVIEW: [NEXUS-6075] Use RepositoryConfigurationUpdatedEvent instead of RepositoryEventLocalStatusChanged in RepositoryLocalStatusCondition

### DIFF
--- a/plugins/capabilities/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/condition/RepositoryLocalStatusCondition.java
+++ b/plugins/capabilities/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/condition/RepositoryLocalStatusCondition.java
@@ -14,7 +14,7 @@
 package org.sonatype.nexus.plugins.capabilities.internal.condition;
 
 import org.sonatype.nexus.plugins.capabilities.support.condition.RepositoryConditions;
-import org.sonatype.nexus.proxy.events.RepositoryEventLocalStatusChanged;
+import org.sonatype.nexus.proxy.events.RepositoryConfigurationUpdatedEvent;
 import org.sonatype.nexus.proxy.events.RepositoryRegistryEventAdd;
 import org.sonatype.nexus.proxy.events.RepositoryRegistryEventRemove;
 import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
@@ -57,9 +57,9 @@ public class RepositoryLocalStatusCondition
 
   @AllowConcurrentEvents
   @Subscribe
-  public void handle(final RepositoryEventLocalStatusChanged event) {
+  public void handle(final RepositoryConfigurationUpdatedEvent event) {
     if (sameRepositoryAs(event.getRepository().getId())) {
-      setSatisfied(localStatus.equals(event.getNewLocalStatus()));
+      setSatisfied(localStatus.equals(event.getRepository().getLocalStatus()));
     }
   }
 

--- a/plugins/capabilities/nexus-capabilities-plugin/src/test/java/org/sonatype/nexus/plugins/capabilities/internal/condition/RepositoryLocalStatusConditionTest.java
+++ b/plugins/capabilities/nexus-capabilities-plugin/src/test/java/org/sonatype/nexus/plugins/capabilities/internal/condition/RepositoryLocalStatusConditionTest.java
@@ -15,6 +15,7 @@ package org.sonatype.nexus.plugins.capabilities.internal.condition;
 
 import org.sonatype.nexus.plugins.capabilities.EventBusTestSupport;
 import org.sonatype.nexus.plugins.capabilities.support.condition.RepositoryConditions;
+import org.sonatype.nexus.proxy.events.RepositoryConfigurationUpdatedEvent;
 import org.sonatype.nexus.proxy.events.RepositoryEventLocalStatusChanged;
 import org.sonatype.nexus.proxy.events.RepositoryRegistryEventAdd;
 import org.sonatype.nexus.proxy.events.RepositoryRegistryEventRemove;
@@ -81,9 +82,9 @@ public class RepositoryLocalStatusConditionTest
     assertThat(underTest.isSatisfied(), is(true));
 
     when(repository.getLocalStatus()).thenReturn(LocalStatus.OUT_OF_SERVICE);
-    underTest.handle(new RepositoryEventLocalStatusChanged(
-        repository, LocalStatus.IN_SERVICE, LocalStatus.OUT_OF_SERVICE
-    ));
+    RepositoryConfigurationUpdatedEvent event = new RepositoryConfigurationUpdatedEvent(repository);
+    event.setLocalStatusChanged(true);
+    underTest.handle(event);
     assertThat(underTest.isSatisfied(), is(false));
 
     verifyEventBusEvents(satisfied(underTest), unsatisfied(underTest));
@@ -97,14 +98,12 @@ public class RepositoryLocalStatusConditionTest
     assertThat(underTest.isSatisfied(), is(true));
 
     when(repository.getLocalStatus()).thenReturn(LocalStatus.OUT_OF_SERVICE);
-    underTest.handle(new RepositoryEventLocalStatusChanged(
-        repository, LocalStatus.IN_SERVICE, LocalStatus.OUT_OF_SERVICE
-    ));
+    RepositoryConfigurationUpdatedEvent event = new RepositoryConfigurationUpdatedEvent(repository);
+    event.setLocalStatusChanged(true);
+    underTest.handle(event);
 
     when(repository.getLocalStatus()).thenReturn(LocalStatus.IN_SERVICE);
-    underTest.handle(new RepositoryEventLocalStatusChanged(
-        repository, LocalStatus.OUT_OF_SERVICE, LocalStatus.IN_SERVICE
-    ));
+    underTest.handle(event);
     assertThat(underTest.isSatisfied(), is(true));
 
     verifyEventBusEvents(satisfied(underTest), unsatisfied(underTest), satisfied(underTest));


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-6075
https://bamboo.zion.sonatype.com/browse/NX-OSSF6
