### PR TITLE
[REVIEW] NXCM-5448: trigger clearing of authorization caches when security configuration is rebuilt

### DIFF
--- a/components/nexus-security-realms/src/main/java/org/sonatype/security/realms/tools/AbstractConfigurationManager.java
+++ b/components/nexus-security-realms/src/main/java/org/sonatype/security/realms/tools/AbstractConfigurationManager.java
@@ -13,14 +13,22 @@
 
 package org.sonatype.security.realms.tools;
 
+import org.sonatype.security.events.AuthorizationConfigurationChanged;
 import org.sonatype.security.model.Configuration;
 import org.sonatype.sisu.goodies.common.ComponentSupport;
+import org.sonatype.sisu.goodies.eventbus.EventBus;
 
 public abstract class AbstractConfigurationManager
     extends ComponentSupport
     implements ConfigurationManager
 {
+  private final EventBus eventBus;
+
   private volatile EnhancedConfiguration configurationCache = null;
+
+  protected AbstractConfigurationManager(EventBus eventBus) {
+    this.eventBus = eventBus;
+  }
 
   public void clearCache() {
     configurationCache = null;
@@ -29,15 +37,23 @@ public abstract class AbstractConfigurationManager
   protected EnhancedConfiguration getConfiguration() {
     // Assign configuration to local variable first, as calls to clearCache can null it out at any time
     EnhancedConfiguration configuration = this.configurationCache;
-    if (configuration == null || shouldRebuildConifuguration()) {
+    if (configuration == null || shouldRebuildConfiguration()) {
+      boolean rebuiltConfiguration = false;
+
       synchronized (this) {
         // double-checked locking of volatile is apparently OK with java5+
         // http://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html
         configuration = this.configurationCache;
-        if (configuration == null || shouldRebuildConifuguration()) {
+        if (configuration == null || shouldRebuildConfiguration()) {
+          rebuiltConfiguration = (configuration != null);
           configuration = new EnhancedConfiguration(doGetConfiguration());
           this.configurationCache = configuration;
         }
+      }
+
+      if (rebuiltConfiguration) {
+        // signal rebuild (outside lock to avoid contention)
+        eventBus.post(new AuthorizationConfigurationChanged());
       }
     }
     return configuration;
@@ -46,13 +62,13 @@ public abstract class AbstractConfigurationManager
   /**
    * Returns <code>true</code> if configuration needs to be rebuilt (by calling {@link #doGetConfiguration()}).
    */
-  protected boolean shouldRebuildConifuguration() {
+  protected boolean shouldRebuildConfiguration() {
     return false;
   }
 
   /**
    * Builds and returns fresh new Configuration instance. Implementation is expected to reset
-   * {@link #shouldRebuildConifuguration()} flag back to <code>false</code>.
+   * {@link #shouldRebuildConfiguration()} flag back to <code>false</code>.
    */
   protected abstract Configuration doGetConfiguration();
 }

--- a/components/nexus-security-realms/src/main/java/org/sonatype/security/realms/tools/DefaultConfigurationManager.java
+++ b/components/nexus-security-realms/src/main/java/org/sonatype/security/realms/tools/DefaultConfigurationManager.java
@@ -43,6 +43,7 @@ import org.sonatype.security.realms.validator.SecurityConfigurationValidator;
 import org.sonatype.security.realms.validator.SecurityValidationContext;
 import org.sonatype.security.usermanagement.UserNotFoundException;
 import org.sonatype.security.usermanagement.xml.SecurityXmlUserManager;
+import org.sonatype.sisu.goodies.eventbus.EventBus;
 
 import com.google.common.collect.Sets;
 import org.apache.shiro.authc.credential.PasswordService;
@@ -66,13 +67,15 @@ public class DefaultConfigurationManager
   private final PasswordService passwordService;
 
   @Inject
-  public DefaultConfigurationManager(List<SecurityConfigurationModifier> configurationModifiers,
+  public DefaultConfigurationManager(EventBus eventBus,
+                                     List<SecurityConfigurationModifier> configurationModifiers,
                                      SecurityConfigurationCleaner configCleaner,
                                      SecurityConfigurationValidator validator,
                                      @Named("file") SecurityModelConfigurationSource configurationSource,
                                      List<PrivilegeDescriptor> privilegeDescriptors,
                                      PasswordService passwordService)
   {
+    super(eventBus);
     this.configurationModifiers = configurationModifiers;
     this.configCleaner = configCleaner;
     this.validator = validator;

--- a/components/nexus-security-realms/src/main/java/org/sonatype/security/realms/tools/ResourceMergingConfigurationManager.java
+++ b/components/nexus-security-realms/src/main/java/org/sonatype/security/realms/tools/ResourceMergingConfigurationManager.java
@@ -38,6 +38,7 @@ import org.sonatype.security.realms.privileges.PrivilegeDescriptor;
 import org.sonatype.security.realms.validator.SecurityValidationContext;
 import org.sonatype.security.usermanagement.UserNotFoundException;
 import org.sonatype.security.usermanagement.xml.SecurityXmlUserManager;
+import org.sonatype.sisu.goodies.eventbus.EventBus;
 
 import org.codehaus.plexus.util.StringUtils;
 
@@ -61,10 +62,12 @@ public class ResourceMergingConfigurationManager
   private final List<DynamicSecurityResource> dynamicResources;
 
   @Inject
-  public ResourceMergingConfigurationManager(List<DynamicSecurityResource> dynamicResources,
+  public ResourceMergingConfigurationManager(EventBus eventBus,
+                                             List<DynamicSecurityResource> dynamicResources,
                                              @Named("legacydefault") ConfigurationManager manager,
                                              List<StaticSecurityResource> staticResources)
   {
+    super(eventBus);
     this.dynamicResources = dynamicResources;
     this.manager = manager;
     this.staticResources = staticResources;
@@ -476,7 +479,7 @@ public class ResourceMergingConfigurationManager
   // ==
 
   @Override
-  protected boolean shouldRebuildConifuguration() {
+  protected boolean shouldRebuildConfiguration() {
     for (DynamicSecurityResource resource : dynamicResources) {
       if (resource.isDirty()) {
         return true;


### PR DESCRIPTION
Only triggers event when cache is rebuilt (ie. replacing an existing configuration due to failure of isDirty checks).
