### PR TITLE
TRIVIAL: [NEXUS-6100] Use component instead of label for icon/message in authenticate window

### DIFF
--- a/plugins/internal/nexus-wonderland-plugin/src/main/resources/static/css/nexus-wonderland-plugin.css
+++ b/plugins/internal/nexus-wonderland-plugin/src/main/resources/static/css/nexus-wonderland-plugin.css
@@ -13,7 +13,6 @@
 
 .nx-wonderland-view-authenticate-description {
   font: normal 11px arial, tahoma, verdana, helvetica;
-  padding: 10px;
 }
 
 .nx-wonderland-view-authenticate-description img {
@@ -22,6 +21,7 @@
 }
 
 .nx-wonderland-view-authenticate-description div {
+  padding-top: 10px;
   padding-right: 10px;
 }
 

--- a/plugins/internal/nexus-wonderland-plugin/src/main/resources/static/js/Nexus/wonderland/view/AuthenticateWindow.js
+++ b/plugins/internal/nexus-wonderland-plugin/src/main/resources/static/js/Nexus/wonderland/view/AuthenticateWindow.js
@@ -72,7 +72,7 @@ NX.define('Nexus.wonderland.view.AuthenticateWindow', {
 
           items: [
             {
-              xtype: 'label',
+              xtype: 'component',
               cls: 'nx-wonderland-view-authenticate-description',
               html: icons.get('lock').variant('x32').img + '<div>' + me.message +
                   '</div><br style="clear:both;"/>' // clear to get remaining form elements aligned correctly


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-6100
