### PR TITLE
REVIEW: [NEXUS-6112] Upgrade to Sonatype/Sisu 2.5.0

### DIFF
--- a/buildsupport/guice/pom.xml
+++ b/buildsupport/guice/pom.xml
@@ -28,7 +28,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <sisu-inject.version>2.3.4</sisu-inject.version>
+    <sisu-inject.version>2.5.0</sisu-inject.version>
     <sisu-guice.version>3.1.4</sisu-guice.version>
   </properties>
 


### PR DESCRIPTION
This is now a legacy runtime wrapper around Eclipse/Sisu 0.1.0 which will help aid migration to the Eclipse/Sisu API.

https://issues.sonatype.org/browse/NEXUS-6112
