### PR TITLE
REVIEW: [Backport NXCM-5448 to nexus-oss-2.6.x]

### DIFF
--- a/components/nexus-security-realms/src/main/java/org/sonatype/security/realms/XmlRolePermissionResolver.java
+++ b/components/nexus-security-realms/src/main/java/org/sonatype/security/realms/XmlRolePermissionResolver.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.enterprise.inject.Typed;
@@ -29,11 +30,20 @@ import org.apache.shiro.authz.permission.RolePermissionResolver;
 import org.sonatype.security.authorization.NoSuchPrivilegeException;
 import org.sonatype.security.authorization.NoSuchRoleException;
 import org.sonatype.security.authorization.PermissionFactory;
+import org.sonatype.security.events.AuthorizationConfigurationChanged;
+import org.sonatype.security.events.SecurityConfigurationChanged;
 import org.sonatype.security.model.CPrivilege;
 import org.sonatype.security.model.CRole;
 import org.sonatype.security.realms.privileges.PrivilegeDescriptor;
 import org.sonatype.security.realms.tools.ConfigurationManager;
+import org.sonatype.security.realms.tools.ConfigurationManagerAction;
 import org.sonatype.security.realms.tools.StaticSecurityResource;
+import org.sonatype.sisu.goodies.eventbus.EventBus;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.MapMaker;
+import com.google.common.eventbus.AllowConcurrentEvents;
+import com.google.common.eventbus.Subscribe;
 
 /**
  * The default implementation of the RolePermissionResolver which reads roles from {@link StaticSecurityResource}s to
@@ -54,31 +64,77 @@ public class XmlRolePermissionResolver
 
     private final PermissionFactory permissionFactory;
 
+    private final Map<String, Collection<Permission>> permissionsCache;
+
     @Inject
     public XmlRolePermissionResolver( @Named( "default" ) ConfigurationManager configuration,
                                       List<PrivilegeDescriptor> privilegeDescriptors,
-                                      @Named( "caching" ) PermissionFactory permissionFactory )
+                                      @Named( "caching" ) PermissionFactory permissionFactory,
+                                      EventBus eventBus )
     {
         this.configuration = configuration;
         this.privilegeDescriptors = privilegeDescriptors;
         this.permissionFactory = permissionFactory;
+        this.permissionsCache = new MapMaker().weakValues().makeMap();
+        eventBus.register( this );
+    }
+
+    @AllowConcurrentEvents
+    @Subscribe
+    public void on( final AuthorizationConfigurationChanged event )
+    {
+        permissionsCache.clear(); // invalidate previous results
+    }
+
+    @AllowConcurrentEvents
+    @Subscribe
+    public void on( final SecurityConfigurationChanged event )
+    {
+        permissionsCache.clear(); // invalidate previous results
     }
 
     public Collection<Permission> resolvePermissionsInRole( final String roleString )
     {
+        try
+        {
+            final Set<Permission> permissions = new LinkedHashSet<Permission>();
+            configuration.runRead( new ConfigurationManagerAction()
+            {
+                public void run()
+                    throws Exception
+                {
+                    resolvePermissionsInRole( roleString, permissions );
+                }
+            } );
+            return permissions;
+        }
+        catch ( Exception e )
+        {
+            throw Throwables.propagate( e );
+        }
+    }
+
+    protected void resolvePermissionsInRole( final String roleString, final Collection<Permission> permissions )
+    {
         final LinkedList<String> rolesToProcess = new LinkedList<String>();
         rolesToProcess.add( roleString ); // initial role
         final Set<String> processedRoleIds = new LinkedHashSet<String>();
-        final Set<Permission> permissions = new LinkedHashSet<Permission>();
         while ( !rolesToProcess.isEmpty() )
         {
             final String roleId = rolesToProcess.removeFirst();
-            if ( !processedRoleIds.contains( roleId ) )
+            if ( processedRoleIds.add( roleId ) )
             {
                 try
                 {
                     final CRole role = configuration.readRole( roleId );
-                    processedRoleIds.add( roleId );
+
+                    // check memory-sensitive cache (after readRole to allow for the dirty check)
+                    final Collection<Permission> cachedPermissions = permissionsCache.get( roleId );
+                    if ( cachedPermissions != null )
+                    {
+                        permissions.addAll( cachedPermissions );
+                        continue; // use cached results
+                    }
 
                     // process the roles this role has recursively
                     rolesToProcess.addAll( role.getRoles() );
@@ -96,7 +152,9 @@ public class XmlRolePermissionResolver
                 }
             }
         }
-        return permissions;
+
+        // cache result of (non-trivial) computation
+        permissionsCache.put( roleString, permissions );
     }
 
     protected Set<Permission> getPermissions( final String privilegeId )

--- a/components/nexus-security-realms/src/main/java/org/sonatype/security/realms/tools/DefaultConfigurationManager.java
+++ b/components/nexus-security-realms/src/main/java/org/sonatype/security/realms/tools/DefaultConfigurationManager.java
@@ -45,6 +45,7 @@ import org.sonatype.security.realms.validator.SecurityConfigurationValidator;
 import org.sonatype.security.realms.validator.SecurityValidationContext;
 import org.sonatype.security.usermanagement.UserNotFoundException;
 import org.sonatype.security.usermanagement.xml.SecurityXmlUserManager;
+import org.sonatype.sisu.goodies.eventbus.EventBus;
 
 import com.google.common.collect.Sets;
 
@@ -70,13 +71,15 @@ public class DefaultConfigurationManager
     private final PasswordService passwordService;
 
     @Inject
-    public DefaultConfigurationManager( List<SecurityConfigurationModifier> configurationModifiers,
+    public DefaultConfigurationManager( EventBus eventBus,
+                                        List<SecurityConfigurationModifier> configurationModifiers,
                                         SecurityConfigurationCleaner configCleaner,
                                         SecurityConfigurationValidator validator,
                                         @Named( "file" ) SecurityModelConfigurationSource configurationSource,
                                         List<PrivilegeDescriptor> privilegeDescriptors,
                                         PasswordService passwordService )
     {
+        super( eventBus );
         this.configurationModifiers = configurationModifiers;
         this.configCleaner = configCleaner;
         this.validator = validator;

--- a/components/nexus-security-realms/src/main/java/org/sonatype/security/realms/tools/ResourceMergingConfigurationManager.java
+++ b/components/nexus-security-realms/src/main/java/org/sonatype/security/realms/tools/ResourceMergingConfigurationManager.java
@@ -40,6 +40,7 @@ import org.sonatype.security.realms.privileges.PrivilegeDescriptor;
 import org.sonatype.security.realms.validator.SecurityValidationContext;
 import org.sonatype.security.usermanagement.UserNotFoundException;
 import org.sonatype.security.usermanagement.xml.SecurityXmlUserManager;
+import org.sonatype.sisu.goodies.eventbus.EventBus;
 
 /**
  * ConfigurationManager that aggregates {@link StaticSecurityResource}s and {@link DynamicSecurityResource}s with
@@ -63,10 +64,12 @@ public class ResourceMergingConfigurationManager
     private final List<DynamicSecurityResource> dynamicResources;
 
     @Inject
-    public ResourceMergingConfigurationManager( List<DynamicSecurityResource> dynamicResources,
+    public ResourceMergingConfigurationManager( EventBus eventBus,
+                                                List<DynamicSecurityResource> dynamicResources,
                                                 @Named( "legacydefault" ) ConfigurationManager manager,
                                                 List<StaticSecurityResource> staticResources )
     {
+        super( eventBus );
         this.dynamicResources = dynamicResources;
         this.manager = manager;
         this.staticResources = staticResources;
@@ -517,7 +520,7 @@ public class ResourceMergingConfigurationManager
     // ==
 
     @Override
-    protected boolean shouldRebuildConifuguration()
+    protected boolean shouldRebuildConfiguration()
     {
         for ( DynamicSecurityResource resource : dynamicResources )
         {

--- a/components/nexus-security/src/main/java/org/sonatype/security/authorization/WildcardPermissionFactory.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/authorization/WildcardPermissionFactory.java
@@ -36,6 +36,15 @@ public class WildcardPermissionFactory
     @Override
     public Permission create( final String permission )
     {
-        return new WildcardPermission( permission );
+        return new WildcardPermission( permission )
+        {
+            private final int cachedHash = super.hashCode();
+
+            @Override
+            public int hashCode()
+            {
+                return cachedHash;
+            }
+        };
     }
 }


### PR DESCRIPTION
- cache WildcardPermission hash because its contents never change after construction and calculating the hash is expensive (involves collections of collections of strings)
- resolve role permissions using single read lock, rather than repeatedly taking and dropping lock for the role and each of its sub-roles/privileges
- add memory-sensitive cache to XML permissions resolver
- move resolver cache check to before we even attempt to read-lock the configuration (note: this is only viable if we don't need to invalidate the resolve cache when DynamicSecurityResources change)
- trigger clearing of authorization caches when security configuration is rebuilt due to changes in dynamic sources

This is a backport of the performance fixes from #229 and #232

https://issues.sonatype.org/browse/NEXUS-6118
