### PR TITLE
[NEXUS-6133] Only gather nexus settings when user is logged in

### DIFF
--- a/plugins/basic/nexus-ui-extjs3-plugin/src/main/resources/static/js/Sonatype/utils.js
+++ b/plugins/basic/nexus-ui-extjs3-plugin/src/main/resources/static/js/Sonatype/utils.js
@@ -751,11 +751,9 @@ define('Sonatype/utils',['../extjs', 'Nexus/config', 'Nexus/util/Format', 'Sonat
       };
 
       // catch the case of page reload, which will leave the user logged in but not go through the login handler
-      Sonatype.Events.addListener('nexusStatus', function() {
-        if (Sonatype.user.curr && Sonatype.user.curr.isLoggedIn) {
-          ns.refreshTask.start();
-        }
-      }, this, {single: true});
+      Sonatype.Events.addListener('nexusSettings', function () {
+        ns.refreshTask.start();
+      }, this);
 
       // public API
       return {
@@ -800,10 +798,7 @@ define('Sonatype/utils',['../extjs', 'Nexus/config', 'Nexus/util/Format', 'Sonat
                 Sonatype.repoServer.RepoServer.loginForm.getForm().reset();
               }
 
-              var respObj = Ext.decode(response.responseText);
-              ns.loadNexusSettings();
-
-              Ext.namespace('Sonatype.utils').refreshTask.start();
+              ns.loadNexusStatus();
             },
             failure : function(response, options) {
               Ext.namespace('Sonatype.utils').refreshTask.stop();
@@ -838,7 +833,7 @@ define('Sonatype/utils',['../extjs', 'Nexus/config', 'Nexus/util/Format', 'Sonat
     },
 
     /**
-     * Loads Nexus settings & status.
+     * Loads Nexus settings.
      */
     loadNexusSettings: function () {
       Ext.Ajax.request({
@@ -857,7 +852,7 @@ define('Sonatype/utils',['../extjs', 'Nexus/config', 'Nexus/util/Format', 'Sonat
             });
           }
           ns.settings.keepAlive = ns.settings.keepAlive === 'true';
-          ns.loadNexusStatus();
+          Sonatype.Events.fireEvent('nexusSettings');
         }
       });
     },
@@ -950,6 +945,10 @@ define('Sonatype/utils',['../extjs', 'Nexus/config', 'Nexus/util/Format', 'Sonat
               ns.onHistoryChange(token);
               ns.updateHistory();
               Sonatype.view.justLoggedOut = false;
+
+              if (Sonatype.lib.Permissions.checkPermission('nexus:settings', Sonatype.lib.Permissions.READ)) {
+                ns.loadNexusSettings();
+              }
             }
           });
     },

--- a/plugins/basic/nexus-ui-extjs3-plugin/src/main/resources/static/js/repoServer/RepoServer.js
+++ b/plugins/basic/nexus-ui-extjs3-plugin/src/main/resources/static/js/repoServer/RepoServer.js
@@ -375,7 +375,7 @@ define('repoServer/RepoServer',['extjs', 'sonatype', 'Sonatype/lib', 'Nexus/conf
           url : Sonatype.config.repos.urls.logout,
           callback : function(options, success, response) {
             Sonatype.view.justLoggedOut = true;
-            Sonatype.utils.loadNexusSettings();
+            Sonatype.utils.loadNexusStatus();
             window.location.hash = 'welcome';
           }
         });

--- a/plugins/basic/nexus-ui-extjs3-plugin/src/main/resources/templates/index.vm
+++ b/plugins/basic/nexus-ui-extjs3-plugin/src/main/resources/templates/index.vm
@@ -86,7 +86,7 @@
                         Sonatype.init();
                         Sonatype.view.init();
                         Nexus.Log.debug('Loading Nexus Status...');
-                        Sonatype.utils.loadNexusSettings();
+                        Sonatype.utils.loadNexusStatus();
                     };
 
                     Nexus.Log.debug('Loaded plugins');


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-6133

The fix is to only call into getting the settings if user is logged in (has nexus:settings read rights).
