### PR TITLE
backport change for ruby-plugin on master to Nexus 2.7.x

### DIFF
--- a/components/nexus-web-utils/src/main/java/org/sonatype/nexus/web/content/NexusContentServlet.java
+++ b/components/nexus-web-utils/src/main/java/org/sonatype/nexus/web/content/NexusContentServlet.java
@@ -546,6 +546,14 @@ public class NexusContentServlet
     renderer.renderRequestDescription(request, response, rsr, item, e);
   }
 
+  // POST
+ 
+  protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+       throws ServletException, IOException
+  {
+    doPut(req, resp); // just do same as would on PUT
+  } 
+
   // PUT
 
   @Override


### PR DESCRIPTION
not sure if there is another 2.7.x release but in case than it would be great to include those backport for the nexus-ruby-plugin to work again.
