### PR TITLE
NEXUS-6169: MKCOL method returns 501

### DIFF
--- a/plugins/basic/nexus-content-plugin/src/main/java/org/sonatype/nexus/content/internal/ContentServlet.java
+++ b/plugins/basic/nexus-content-plugin/src/main/java/org/sonatype/nexus/content/internal/ContentServlet.java
@@ -285,7 +285,27 @@ public class ContentServlet
   {
     webUtils.equipResponseWithStandardHeaders(response);
     response.setHeader("Accept-Ranges", "bytes");
-    super.service(request, response);
+
+    final String method = request.getMethod();
+    if (method.equals("GET") || method.equals("HEAD")) {
+      doGet(request, response);
+    }
+    else if (method.equals("PUT") || method.equals("POST")) {
+      doPut(request, response);
+    }
+    else if (method.equals("DELETE")) {
+      doDelete(request, response);
+    }
+    else if (method.equals("OPTIONS")) {
+      doOptions(request, response);
+    }
+    else if (method.equals("TRACE")) {
+      doTrace(request, response);
+    }
+    else {
+      throw new ErrorStatusServletException(HttpServletResponse.SC_METHOD_NOT_ALLOWED, null,
+          "Method " + method + " not supported.");
+    }
   }
 
   // GET
@@ -501,14 +521,6 @@ public class ContentServlet
     // send no cache headers, as any of these responses should not be cached, ever
     webUtils.addNoCacheResponseHeaders(response);
     contentRenderer.renderRequestDescription(request, response, rsr, item, e);
-  }
-
-  // POST
-
-  protected void doPost(HttpServletRequest req, HttpServletResponse resp)
-      throws ServletException, IOException
-  {
-    doPut(req, resp); // just do same as would on PUT
   }
 
   // PUT


### PR DESCRIPTION
Overriding service method to return old
behavior, to return 405 Method not allowed
instead of 501 Not Implemented.

Issue
https://issues.sonatype.org/browse/NEXUS-6169
