### PR TITLE
NEXUS-6156: Deleted files left after optimize

### DIFF
--- a/plugins/indexer/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/NexusIndexingContext.java
+++ b/plugins/indexer/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/NexusIndexingContext.java
@@ -70,13 +70,7 @@ public class NexusIndexingContext
     // NEXUS-6156: Make SearcherManager be notified about this
     // This will release the deleted files removed after. SearcherManager is not reachable (private, no getter)
     // so this is the only way to make superclass invoke SearcherManager#maybeRefresh()
-    IndexSearcher is = null;
-    try {
-      is = acquireIndexSearcher();
-    }
-    finally {
-      releaseIndexSearcher(is);
-    }
+    releaseIndexSearcher(acquireIndexSearcher());
   }
 
   @Override


### PR DESCRIPTION
This was due to the fact that SearcherManager
maybeRefresh() method was invoked only before
ANY search attempt, that made manager perform
a bookkeeping that released deleted files.

This is basically true to any operation modifying
and committing to index, but is most "visible"
after optimizing of huge index, as it left
Lucene index with double sized segments (the
deleted files got copied into new segment file).

Still, since all the ops doing "heavy lifting"
like merge or replace on context does invoke
optimize as last step, having this happen
here is okay thing, in contrast to do the same
on IndexingContext#commit, where it would happen
"too often" harming the performance of small
but frequent index changes (ie. deploys).

Issue
https://issues.sonatype.org/browse/NEXUS-6172

CI
TBD
