### PR TITLE
TRIVIAL: log critical runtime env details

### DIFF
--- a/components/nexus-bootstrap/src/main/java/org/sonatype/nexus/bootstrap/Launcher.java
+++ b/components/nexus-bootstrap/src/main/java/org/sonatype/nexus/bootstrap/Launcher.java
@@ -27,6 +27,8 @@ import org.sonatype.nexus.bootstrap.monitor.commands.HaltCommand;
 import org.sonatype.nexus.bootstrap.monitor.commands.PingCommand;
 import org.sonatype.nexus.bootstrap.monitor.commands.StopApplicationCommand;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import static org.sonatype.nexus.bootstrap.monitor.CommandMonitorThread.LOCALHOST;
@@ -75,6 +77,27 @@ public class Launcher
     Map<String, String> props = builder.build();
     System.getProperties().putAll(props);
     ConfigurationHolder.set(props);
+
+    // log critical information about the runtime environment
+    Logger log = LoggerFactory.getLogger(Launcher.class);
+    log.info("Java: {}, {}, {}, {}",
+        System.getProperty("java.version"),
+        System.getProperty("java.vm.name"),
+        System.getProperty("java.vm.vendor"),
+        System.getProperty("java.vm.version")
+    );
+    log.info("OS: {}, {}, {}",
+        System.getProperty("os.name"),
+        System.getProperty("os.version"),
+        System.getProperty("os.arch")
+    );
+    log.info("User: {}, {}, {}",
+        System.getProperty("user.name"),
+        System.getProperty("user.language"),
+        System.getProperty("user.home")
+    );
+    log.info("CWD: {}", System.getProperty("user.dir"));
+    log.info("TMP: {}", System.getProperty("java.io.tmpdir"));
 
     if (args == null) {
       throw new NullPointerException();


### PR DESCRIPTION
`
jvm 1    | 2013-12-12 10:38:40,872-0800 INFO  [WrapperListener_start_runner] - org.sonatype.nexus.bootstrap.jsw.JswLauncher$1 - Java: 1.7.0_45, Java HotSpot(TM) 64-Bit Server VM, Oracle Corporation, 24.45-b08
jvm 1    | 2013-12-12 10:38:40,872-0800 INFO  [WrapperListener_start_runner] - org.sonatype.nexus.bootstrap.jsw.JswLauncher$1 - OS: Mac OS X, 10.9, x86_64
jvm 1    | 2013-12-12 10:38:40,872-0800 INFO  [WrapperListener_start_runner] - org.sonatype.nexus.bootstrap.jsw.JswLauncher$1 - User: jason, en, /Users/jason
jvm 1    | 2013-12-12 10:38:40,873-0800 INFO  [WrapperListener_start_runner] - org.sonatype.nexus.bootstrap.jsw.JswLauncher$1 - CWD: /Users/jason/ws/sonatype/nexus/nexus-oss/target/nexus-bundle-template-2.8.0-SNAPSHOT
jvm 1    | 2013-12-12 10:38:40,873-0800 INFO  [WrapperListener_start_runner] - org.sonatype.nexus.bootstrap.jsw.JswLauncher$1 - TMP: /Users/jason/ws/sonatype/nexus/nexus-oss/target/sonatype-work/nexus/tmp
`
