### PR TITLE
REVIEW: set MDC "userId" attribute early & normalize value

### DIFF
--- a/assemblies/nexus-bundle-template/src/main/resources/content/conf/logback.xml
+++ b/assemblies/nexus-bundle-template/src/main/resources/content/conf/logback.xml
@@ -17,7 +17,7 @@
 <configuration>
   <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{"yyyy-MM-dd HH:mm:ss,SSSZ"} %-5p [%thread] %X{userId} %c - %m%n</pattern>
+      <pattern>%d{"yyyy-MM-dd HH:mm:ss,SSSZ"} %-5p [%thread] %X{userId}, %c - %m%n</pattern>
     </encoder>
   </appender>
 

--- a/components/nexus-bootstrap/src/main/java/org/sonatype/nexus/bootstrap/Launcher.java
+++ b/components/nexus-bootstrap/src/main/java/org/sonatype/nexus/bootstrap/Launcher.java
@@ -47,6 +47,8 @@ public class Launcher
   // FIXME: Move this to CommandMonitorThread
   public static final String COMMAND_MONITOR_PORT = CommandMonitorThread.class.getName() + ".port";
 
+  public static final String SYSTEM_USERID = "*SYSTEM";
+
   private static final String FIVE_SECONDS = "5000";
 
   private static final String ONE_SECOND = "1000";
@@ -171,7 +173,7 @@ public class Launcher
   }
 
   public static void main(final String[] args) throws Exception {
-    MDC.put("userId", "<system>");
+    MDC.put("userId", SYSTEM_USERID);
     new Launcher(null, null, args).start();
   }
 }

--- a/components/nexus-bootstrap/src/main/java/org/sonatype/nexus/bootstrap/jsw/JswLauncher.java
+++ b/components/nexus-bootstrap/src/main/java/org/sonatype/nexus/bootstrap/jsw/JswLauncher.java
@@ -19,6 +19,7 @@ import org.sonatype.nexus.bootstrap.ShutdownHelper;
 import org.slf4j.MDC;
 import org.tanukisoftware.wrapper.WrapperManager;
 
+import static org.sonatype.nexus.bootstrap.Launcher.SYSTEM_USERID;
 import static org.tanukisoftware.wrapper.WrapperManager.WRAPPER_CTRL_LOGOFF_EVENT;
 
 /**
@@ -70,7 +71,7 @@ public class JswLauncher
   }
 
   public static void main(final String[] args) throws Exception {
-    MDC.put("userId", "<system>");
+    MDC.put("userId", SYSTEM_USERID);
     ShutdownHelper.setDelegate(new JswShutdownDelegate());
     WrapperManager.start(new JswLauncher(), args);
   }

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/threads/FakeAlmightySubject.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/threads/FakeAlmightySubject.java
@@ -43,7 +43,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class FakeAlmightySubject
     implements Subject
 {
-  public static final String TASK_USERID = "Task-User";
+  public static final String TASK_USERID = "*TASK";
 
   public static final Subject TASK_SUBJECT = forUserId(TASK_USERID);
 

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/threads/MDCUtils.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/threads/MDCUtils.java
@@ -37,7 +37,7 @@ public class MDCUtils
 
   public static final String USER_ID_KEY = "userId";
 
-  public static final String UNKNOWN_USER_ID = "<unknown-user>";
+  public static final String UNKNOWN_USER_ID = "*UNKNOWN";
 
   public static void setMDCUserIdIfNeeded() {
     final String userId = MDC.get(USER_ID_KEY);

--- a/components/nexus-core/src/main/resources/META-INF/log/logback.properties
+++ b/components/nexus-core/src/main/resources/META-INF/log/logback.properties
@@ -12,5 +12,5 @@
 #
 
 root.level=INFO
-appender.pattern=%d{"yyyy-MM-dd HH:mm:ss,SSSZ"} %-5p [%thread] %X{userId} %c - %m%n
+appender.pattern=%d{"yyyy-MM-dd HH:mm:ss,SSSZ"} %-5p [%thread] %X{userId}, %c - %m%n
 appender.file=${nexus.log-config-dir}/../logs/nexus.log


### PR DESCRIPTION
set the MDC "userId" attribute early in launcher to "*SYSTEM" to avoid (most) empty %X{userId} pattern evaluations in logs.

also normalizes fake-userId to *UPPER and uses "," in log format as separator.  Use of <> in the log was too distracting IMO.
