### PR TITLE
NEXUS-6183: Returned stopwatch for outbound logging purposes

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientRemoteStorage.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientRemoteStorage.java
@@ -448,7 +448,7 @@ public class HttpClientRemoteStorage
     final TimerContext timerContext = timer.time();
     Stopwatch stopwatch = null;
     if (outboundRequestLog.isDebugEnabled()) {
-      stopwatch = new Stopwatch();
+      stopwatch = new Stopwatch().start();
     }
     try {
       return doExecuteRequest(repository, request, httpRequest);


### PR DESCRIPTION
For now by returning Stopwatch in game.

As Yammer does not provide clean way to extract the
"last recorded duration" from timer or timer context in
cheap way.

Issue
https://issues.sonatype.org/browse/NEXUS-6183

CI
https://bamboo.zion.sonatype.com/browse/NX-OSSF10
