### PR TITLE
NEXUS-6197: LVO should upgrade model version 1.0.0

### DIFF
--- a/plugins/basic/nexus-lvo-plugin/src/main/java/org/sonatype/nexus/plugins/lvo/config/DefaultLvoPluginConfiguration.java
+++ b/plugins/basic/nexus-lvo-plugin/src/main/java/org/sonatype/nexus/plugins/lvo/config/DefaultLvoPluginConfiguration.java
@@ -71,7 +71,15 @@ public class DefaultLvoPluginConfiguration
 
     @Override
     public String readVersion(final InputStream input) throws IOException, CorruptModelException {
-      return versionedHelper.readVersion(input);
+      // NEXUS-6099: Treat "1.0.0" XML as "1.0.1" as those are backward compatible
+      // But it seems we still have instances with mismanaged LVO XML versions out there
+      final String version = versionedHelper.readVersion(input);
+      if ("1.0.0".equals(version)) {
+        return "1.0.1";
+      }
+      else {
+        return version;
+      }
     }
   }
 

--- a/plugins/basic/nexus-lvo-plugin/src/test/java/org/sonatype/nexus/plugins/lvo/config/DefaultLvoPluginConfigurationTest.java
+++ b/plugins/basic/nexus-lvo-plugin/src/test/java/org/sonatype/nexus/plugins/lvo/config/DefaultLvoPluginConfigurationTest.java
@@ -1,0 +1,74 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2013 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+
+package org.sonatype.nexus.plugins.lvo.config;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
+import org.sonatype.nexus.plugins.lvo.config.model.Configuration;
+import org.sonatype.sisu.litmus.testsupport.TestSupport;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * NEXUS-6197 and NEXUS-6099: UT for configuration upgrade.
+ */
+public class DefaultLvoPluginConfigurationTest
+    extends TestSupport
+{
+  File configDirectory;
+
+  File lvoConfigurationFile;
+
+  ApplicationConfiguration applicationConfiguration;
+
+  @Before
+  public void prepare() {
+    configDirectory = new File("target/test-classes");
+    lvoConfigurationFile = new File(configDirectory, "lvo-plugin.xml");
+    applicationConfiguration = mock(ApplicationConfiguration.class);
+    when(applicationConfiguration.getConfigurationDirectory())
+        .thenReturn(configDirectory);
+  }
+
+  @Test
+  public void perform100Upgrade() throws Exception {
+    Files.copy(new File(configDirectory, "lvo-plugin-100.xml").toPath(), lvoConfigurationFile.toPath(),
+        StandardCopyOption.REPLACE_EXISTING);
+
+    final DefaultLvoPluginConfiguration config = new DefaultLvoPluginConfiguration(applicationConfiguration);
+    final Configuration configuration = config.getConfiguration();
+    assertThat(configuration.getVersion(), equalTo(Configuration.MODEL_VERSION));
+    assertThat(configuration.getLvoKeys(), hasSize(2));
+  }
+
+  @Test
+  public void perform101Upgrade() throws Exception {
+    Files.copy(new File(configDirectory, "lvo-plugin-101.xml").toPath(), lvoConfigurationFile.toPath(),
+        StandardCopyOption.REPLACE_EXISTING);
+
+    final DefaultLvoPluginConfiguration config = new DefaultLvoPluginConfiguration(applicationConfiguration);
+    final Configuration configuration = config.getConfiguration();
+    assertThat(configuration.getVersion(), equalTo(Configuration.MODEL_VERSION));
+    assertThat(configuration.getLvoKeys(), hasSize(2));
+  }
+}

--- a/plugins/basic/nexus-lvo-plugin/src/test/resources/lvo-plugin-100.xml
+++ b/plugins/basic/nexus-lvo-plugin/src/test/resources/lvo-plugin-100.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lvoConfiguration>
+  <version>1.0.0</version>
+  <lvoKeys>
+    <lvoKey>
+      <key>nexus-oss</key>
+      <strategy>http-get-properties</strategy>
+      <remoteUrl>http://www.sonatype.com/products/nexus/product-versions.properties</remoteUrl>
+    </lvoKey>
+    <lvoKey>
+      <key>nexus-pro</key>
+      <strategy>http-get-properties</strategy>
+      <remoteUrl>http://www.sonatype.com/products/nexus/product-versions.properties</remoteUrl>
+    </lvoKey>
+  </lvoKeys>
+</lvoConfiguration>

--- a/plugins/basic/nexus-lvo-plugin/src/test/resources/lvo-plugin-101.xml
+++ b/plugins/basic/nexus-lvo-plugin/src/test/resources/lvo-plugin-101.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lvoConfiguration>
+  <version>1.0.1</version>
+  <lvoKeys>
+    <lvoKey>
+      <key>nexus-oss</key>
+      <strategy>http-get-properties</strategy>
+      <remoteUrl>http://www.sonatype.com/products/nexus/product-versions.properties</remoteUrl>
+    </lvoKey>
+    <lvoKey>
+      <key>nexus-pro</key>
+      <strategy>http-get-properties</strategy>
+      <remoteUrl>http://www.sonatype.com/products/nexus/product-versions.properties</remoteUrl>
+    </lvoKey>
+  </lvoKeys>
+</lvoConfiguration>


### PR DESCRIPTION
Even if it is "old" and should be de-supported by
work done in NEXUS-6099, it seems LVO model version
was not really managed by Nx, and we still have
instances that are 2.x but LVO XML model version
is left at 1.0.0.

This change will just treat 1.0.0 as 1.0.1 as
those two are compatible (latter got new fields
with default values).

Added UT to exercise upgrades from 1.0.0 and
1.0.1.

Issue
https://issues.sonatype.org/browse/NEXUS-6197

CI
https://bamboo.zion.sonatype.com/browse/NX-OSSF11
