### PR TITLE
[2.7.x] NEXUS-6230: Backport to 2.7.x

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/maven/tasks/DefaultSnapshotRemover.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/maven/tasks/DefaultSnapshotRemover.java
@@ -593,7 +593,8 @@ public class DefaultSnapshotRemover
       final Collection<StorageItem> items = repository.list(false, coll);
       for (final StorageItem listedItem : items) {
         final Gav listedItemGav = repository.getGavCalculator().pathToGav(listedItem.getPath());
-        if (gav.getSnapshotBuildNumber().equals(listedItemGav.getSnapshotBuildNumber())
+        // NEXUS-6230: returned GAV might be null, if file does not obey layout or is metadata
+        if (listedItemGav != null && gav.getSnapshotBuildNumber().equals(listedItemGav.getSnapshotBuildNumber())
             && gav.getSnapshotTimeStamp().equals(listedItemGav.getSnapshotTimeStamp())) {
           lastRequested = Math.max(lastRequested, listedItem.getLastRequested());
         }


### PR DESCRIPTION
Nullcheck was missing for listedGav
As the folder might contain maven metadata and other stuff
that M2GavCalculator cannot interpret, and will return
null.

Original PR
https://github.com/sonatype/nexus-oss/pull/321

Issue
https://issues.sonatype.org/browse/NEXUS-6230

CI
TBD
