### PR TITLE
[2.7.x] NEXUS-6258: Autorouting kills NFC

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/AbstractMavenRepository.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/AbstractMavenRepository.java
@@ -537,7 +537,7 @@ public abstract class AbstractMavenRepository
   protected boolean shouldAddToNotFoundCache(final ResourceStoreRequest request) {
     boolean shouldAddToNFC = super.shouldAddToNotFoundCache(request);
     if (shouldAddToNFC && request.getRequestContext().containsKey(Manager.ROUTING_REQUEST_REJECTED_FLAG_KEY)) {
-      // TODO: should we un-flag the request?
+      request.getRequestContext().remove(Manager.ROUTING_REQUEST_REJECTED_FLAG_KEY);
       shouldAddToNFC = false;
       getLogger().debug("Maven proxy repository {} autorouting rejected this request, not adding path {} to NFC.",
           RepositoryStringUtils.getHumanizedNameString(this), request.getRequestPath());


### PR DESCRIPTION
The TODO was right, yes, we should unset that flag.

Issue
https://issues.sonatype.org/browse/NEXUS-6258

CI
https://bamboo.zion.sonatype.com/browse/NX-OSSF46
