### PR TITLE
NEXUS-6258: AR interferes with NFC

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/AbstractMavenRepository.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/AbstractMavenRepository.java
@@ -537,7 +537,7 @@ public abstract class AbstractMavenRepository
   protected boolean shouldAddToNotFoundCache(final ResourceStoreRequest request) {
     boolean shouldAddToNFC = super.shouldAddToNotFoundCache(request);
     if (shouldAddToNFC && request.getRequestContext().containsKey(Manager.ROUTING_REQUEST_REJECTED_FLAG_KEY)) {
-      // TODO: should we un-flag the request?
+      request.getRequestContext().remove(Manager.ROUTING_REQUEST_REJECTED_FLAG_KEY);
       shouldAddToNFC = false;
       log.debug("Maven proxy repository {} autorouting rejected this request, not adding path {} to NFC.",
           RepositoryStringUtils.getHumanizedNameString(this), request.getRequestPath());


### PR DESCRIPTION
As request context is reused, the request rejected from
AR will disable NFC for all subsequent proxy participants.

Issue
https://issues.sonatype.org/browse/NEXUS-6258

CI
TBD
