### PR TITLE
NEXUS-6250: index rendering with query params

### DIFF
--- a/plugins/basic/nexus-content-plugin/src/main/java/org/sonatype/nexus/content/internal/VelocityContentRenderer.java
+++ b/plugins/basic/nexus-content-plugin/src/main/java/org/sonatype/nexus/content/internal/VelocityContentRenderer.java
@@ -82,6 +82,8 @@ public class VelocityContentRenderer
   {
     final Set<String> uniqueNames = Sets.newHashSetWithExpectedSize(children.size());
     final List<CollectionEntry> entries = Lists.newArrayListWithCapacity(children.size());
+    
+    // use request URL (it does not contain any parameters) as the base URL of collection entries
     final String collUrl = request.getRequestURL().toString();
     for (StorageItem child : children) {
       if (child.isVirtual() || !child.getRepositoryItemUid().getBooleanAttributeValue(IsHiddenAttribute.class)) {


### PR DESCRIPTION
Query params broke the links that were rendered when a
collection index page was rendered.

Issue
https://issues.sonatype.org/browse/NEXUS-6250

CI
https://bamboo.zion.sonatype.com/browse/NX-OSSF19
