### PR TITLE
NEXUS-6279: request#pathInfo not decoded but should

### DIFF
--- a/buildsupport/guice/pom.xml
+++ b/buildsupport/guice/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <eclipse-sisu.version>0.1.1</eclipse-sisu.version>
-    <sisu-guice.version>3.1.4</sisu-guice.version>
+    <sisu-guice.version>3.1.10</sisu-guice.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Bumping to sisu-guice 3.1.10 is it contains the
fix for this.

Issue
https://issues.sonatype.org/browse/NEXUS-6279

CI
https://bamboo.zion.sonatype.com/browse/NX-OSSF58
