### PR TITLE
[2.7.x] NEXUS-6279: request#pathInfo not decoded but should

### DIFF
--- a/buildsupport/guice/pom.xml
+++ b/buildsupport/guice/pom.xml
@@ -49,8 +49,9 @@
       <dependency>
         <groupId>org.sonatype.sisu.inject</groupId>
         <artifactId>guice-servlet</artifactId>
-        <!-- Patched version for NEXUS-6279 -->
-        <version>3.1.10</version>
+        <!--<version>${sisu-guice.version}</version>-->
+        <!-- NEXUS-6279: patched for fixing pathInfo encoding -->
+        <version>3.1.4.1</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Bumping to sisu-guice 3.1.10 is it contains the
fix for this.

Conflicts:
    buildsupport/guice/pom.xml

Original PR
https://github.com/sonatype/nexus-oss/pull/356

Issue
https://issues.sonatype.org/browse/NEXUS-6279

CI
https://bamboo.zion.sonatype.com/browse/NX-OSSF59
