### PR TITLE
FIX: Propagate exit code to the caller

### DIFF
--- a/assemblies/nexus-bundle-template/src/main/resources/content/bin/nexus
+++ b/assemblies/nexus-bundle-template/src/main/resources/content/bin/nexus
@@ -293,6 +293,8 @@ checkUser() {
             # Still want to change users, recurse.  This means that the user will only be
             #  prompted for a password once. Variables shifted by 1
             su - $RUN_AS_USER -c "\"$REALPATH\" $2"
+            
+            exitCode="$?"
     
             # Now that we are the original user again, we may need to clean up the lock file.
             if [ "X$LOCKPROP" != "X" ]
@@ -308,7 +310,7 @@ checkUser() {
                 fi
             fi
     
-            exit 0
+            exit $exitCode
         fi
     fi
 


### PR DESCRIPTION
Hi,

the exit code of the recursive script call was simply swallowed.

**Background:** My problem occurred when using Puppet to ensure that the Nexus service is running. However, the _nexus status_ invocation always returned the same exit code (namely 0 [zero]) independent if the service was already running or not.

Here is a possible solution (fix) to the problem. Could you please have a look on it?

Thanks a lot in advance.

With best regards

Holger
