### PR TITLE
Update Tika to latest

### DIFF
--- a/buildsupport/other/pom.xml
+++ b/buildsupport/other/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>org.apache.tika</groupId>
         <artifactId>tika-core</artifactId>
-        <version>1.4</version>
+        <version>1.5</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Bump to 1.5, but the fix for empty zip is still in 1.6 (not released yet)

https://bamboo.zion.sonatype.com/browse/NX-OSSF26
