### PR TITLE
NEXUS-6287: Cache use cleanup

### DIFF
--- a/components/nexus-ldap-common/src/test/java/org/sonatype/security/ldap/realms/LdapSchemaTestSupport.java
+++ b/components/nexus-ldap-common/src/test/java/org/sonatype/security/ldap/realms/LdapSchemaTestSupport.java
@@ -116,16 +116,9 @@ public abstract class LdapSchemaTestSupport
       throws Exception
   {
 
-    UsernamePasswordToken upToken = new UsernamePasswordToken("brianf", "brianf123");
-
-    AuthenticationInfo ai = realm.getAuthenticationInfo(upToken);
-
-    assertNull(ai.getCredentials());
-
-    // String password = new String( (char[]) ai.getCredentials() );
-    //
-    // // password is plain text
-    // assertEquals( "brianf123", password );
+    final UsernamePasswordToken upToken = new UsernamePasswordToken("brianf", "brianf123");
+    final AuthenticationInfo ai = realm.getAuthenticationInfo(upToken);
+    assertEquals("brianf123".toCharArray(), ai.getCredentials());
   }
 
   @Test

--- a/components/nexus-ldap-common/src/test/java/org/sonatype/security/ldap/realms/SimpleLdapAuthenticatingRealm.java
+++ b/components/nexus-ldap-common/src/test/java/org/sonatype/security/ldap/realms/SimpleLdapAuthenticatingRealm.java
@@ -17,6 +17,8 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.sonatype.sisu.goodies.eventbus.EventBus;
+
 import org.eclipse.sisu.Description;
 
 @Singleton
@@ -29,8 +31,8 @@ public class SimpleLdapAuthenticatingRealm
   public static final String ROLE = "LdapAuthenticatingRealm";
 
   @Inject
-  public SimpleLdapAuthenticatingRealm(final LdapManager ldapManager) {
-    super(ldapManager);
+  public SimpleLdapAuthenticatingRealm(final EventBus eventBus, final LdapManager ldapManager) {
+    super(eventBus, ldapManager);
   }
 
   @Override

--- a/components/nexus-security-realms/src/main/java/org/sonatype/security/realms/XmlAuthenticatingRealm.java
+++ b/components/nexus-security-realms/src/main/java/org/sonatype/security/realms/XmlAuthenticatingRealm.java
@@ -34,10 +34,8 @@ import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.authc.credential.CredentialsMatcher;
 import org.apache.shiro.authc.credential.PasswordMatcher;
 import org.apache.shiro.authc.credential.PasswordService;
-import org.apache.shiro.authz.AuthorizationInfo;
-import org.apache.shiro.realm.AuthorizingRealm;
+import org.apache.shiro.realm.AuthenticatingRealm;
 import org.apache.shiro.realm.Realm;
-import org.apache.shiro.subject.PrincipalCollection;
 import org.eclipse.sisu.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,7 +52,7 @@ import org.slf4j.LoggerFactory;
 @Named(XmlAuthenticatingRealm.ROLE)
 @Description("Xml Authenticating Realm")
 public class XmlAuthenticatingRealm
-    extends AuthorizingRealm
+    extends AuthenticatingRealm
     implements Realm
 {
   private static final Logger logger = LoggerFactory.getLogger(XmlAuthenticatingRealm.class);
@@ -78,6 +76,7 @@ public class XmlAuthenticatingRealm
     passwordMatcher.setPasswordService(this.passwordService);
     setCredentialsMatcher(passwordMatcher);
     setName(ROLE);
+    setAuthenticationCachingEnabled(true);
   }
 
   @Override
@@ -114,11 +113,6 @@ public class XmlAuthenticatingRealm
       throw new AccountException("User '" + upToken.getUsername() + "' is in illegal status '"
           + user.getStatus() + "'.");
     }
-  }
-
-  @Override
-  protected AuthorizationInfo doGetAuthorizationInfo(PrincipalCollection arg0) {
-    return null;
   }
 
   /*

--- a/components/nexus-security-realms/src/main/java/org/sonatype/security/realms/XmlAuthorizingRealm.java
+++ b/components/nexus-security-realms/src/main/java/org/sonatype/security/realms/XmlAuthorizingRealm.java
@@ -76,6 +76,8 @@ public class XmlAuthorizingRealm
     this.userManagerMap = userManagerMap;
     setCredentialsMatcher(new Sha1CredentialsMatcher());
     setName(ROLE);
+    setAuthenticationCachingEnabled(false); // we authz only, no authc done by this realm
+    setAuthorizationCachingEnabled(true);
   }
 
   @Override

--- a/plugins/security/nexus-kenai-plugin/src/main/java/org/sonatype/security/realms/kenai/KenaiRealm.java
+++ b/plugins/security/nexus-kenai-plugin/src/main/java/org/sonatype/security/realms/kenai/KenaiRealm.java
@@ -77,9 +77,8 @@ public class KenaiRealm
     this.kenaiRealmConfiguration = checkNotNull(kenaiRealmConfiguration);
     this.hc4Provider = checkNotNull(hc4Provider);
     setName(ROLE);
-
-    // TODO: write another test before enabling this
-    // this.setAuthenticationCachingEnabled( true );
+    setAuthenticationCachingEnabled(true);
+    setAuthorizationCachingEnabled(true);
   }
 
   // ------------ AUTHENTICATION ------------

--- a/plugins/security/nexus-ldap-realm-plugin/src/main/java/org/sonatype/nexus/security/ldap/realms/NexusLdapAuthenticationRealm.java
+++ b/plugins/security/nexus-ldap-realm-plugin/src/main/java/org/sonatype/nexus/security/ldap/realms/NexusLdapAuthenticationRealm.java
@@ -19,6 +19,7 @@ import javax.inject.Singleton;
 
 import org.sonatype.security.ldap.realms.AbstractLdapAuthenticatingRealm;
 import org.sonatype.security.ldap.realms.LdapManager;
+import org.sonatype.sisu.goodies.eventbus.EventBus;
 
 import org.eclipse.sisu.Description;
 
@@ -32,7 +33,7 @@ public class NexusLdapAuthenticationRealm
   public static final String ROLE = "NexusLdapAuthenticationRealm";
 
   @Inject
-  public NexusLdapAuthenticationRealm(final LdapManager ldapManager) {
-    super(ldapManager);
+  public NexusLdapAuthenticationRealm(final EventBus eventBus, final LdapManager ldapManager) {
+    super(eventBus, ldapManager);
   }
 }


### PR DESCRIPTION
Shiro since release 1.2.0 supports
authc and authz caching, that we use
instead of the removed (removed when
upped Shiro version to 1.2.0) homegrown
caching.

But, authc caching is disabled by default
in Shiro, and needs to be explicitly enabled.

This is done in XmlAuthenticatingRealm,
AbstractLdapAuthenticatingRealm and KenaiRealm,
as those were NOT performing authc caching
at all.

authz caching is enabled by default in Shiro,
still added explicit settings to make it clear.

Finally, XmlAuthenticatingRealm made
AuthenticatingRealm as originally it was
AuthorizingRealm without any purpose (as the
authz is not performed by it and method was
simply overridden).

This also means, that there was no authc caching
happening nor in XML realm, nor in the
OSS LDAP realms.

Pro LDAP is unaffected by these changes,
and was caching and is caching both, authc
and authz.

Also, this fixes the misleading cache creation
of unused caches by some realms (ie. XmlAuthenticatingRealm
was creating authorizationCache but it never used it
as it never performed authz).

Issue
https://issues.sonatype.org/browse/NEXUS-6287

Seems related
https://issues.sonatype.org/browse/NEXUS-5305

CI
https://bamboo.zion.sonatype.com/browse/NX-OSSF66
