### PR TITLE
NEXUS-6294: Deleted file handles.

### DIFF
--- a/plugins/basic/nexus-timeline-plugin/src/main/java/org/sonatype/timeline/internal/DefaultTimelineIndexer.java
+++ b/plugins/basic/nexus-timeline-plugin/src/main/java/org/sonatype/timeline/internal/DefaultTimelineIndexer.java
@@ -183,6 +183,7 @@ public class DefaultTimelineIndexer
       throws IOException
   {
     indexWriter.commit();
+    searcherManager.maybeRefresh();
   }
 
   protected void retrieve(final long fromTime, final long toTime, final Set<String> types,
@@ -278,6 +279,7 @@ public class DefaultTimelineIndexer
     }
     finally {
       searcherManager.release(searcher);
+      searcherManager.maybeRefresh();
     }
   }
 


### PR DESCRIPTION
While not quite same as NEXUS-6172, a bit different
approach was made here. Writer is kept open during the
lifetime of timeline component, and readers are now
opened per-request. This should be "light" operation
as it's done with applyDeletes=false.

Before, the searcherManager opened a reader at
component creation (nexus boot), and that
reader was kept as is even if nobody touched
feeds (reader keeps a "snapshot" of index frozen
at the point in time where it was open).

Issue
https://issues.sonatype.org/browse/NEXUS-6294

CI
https://bamboo.zion.sonatype.com/browse/NX-OSSF76
