### PR TITLE
NEXUS-6311 - Upgrade tycho dependencies in p2 for CLM compliance

### DIFF
--- a/plugins/p2/pom.xml
+++ b/plugins/p2/pom.xml
@@ -76,13 +76,13 @@
       <dependency>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>org.eclipse.tycho.noopsecurity</artifactId>
-        <version>0.13.0</version>
+        <version>0.19.0</version>
       </dependency>
 
       <dependency>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-metadata-model</artifactId>
-        <version>0.12.0</version>
+        <version>0.19.0</version>
         <exclusions>
           <exclusion>
             <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
- update to newest available version(which has license info in our CLM data)

Passes CI, which @adreghiciu suggests should be enough to validate the upgrade.

https://issues.sonatype.org/browse/NEXUS-6311
https://bamboo.zion.sonatype.com/browse/NX-OSSF77-1
