### PR TITLE
Fix the unintentional CredProvider replace.

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/apachehttpclient/Hc4ProviderBase.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/apachehttpclient/Hc4ProviderBase.java
@@ -215,16 +215,14 @@ public class Hc4ProviderBase
       }
 
       if (credentials != null) {
-        final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         if (proxyHost != null) {
-          credentialsProvider.setCredentials(new AuthScope(proxyHost), credentials);
+          builder.setCredentials(new AuthScope(proxyHost), credentials);
           builder.getRequestConfigBuilder().setProxyPreferredAuthSchemes(authorisationPreference);
         }
         else {
-          credentialsProvider.setCredentials(AuthScope.ANY, credentials);
+          builder.setCredentials(AuthScope.ANY, credentials);
           builder.getRequestConfigBuilder().setTargetPreferredAuthSchemes(authorisationPreference);
         }
-        builder.getHttpClientBuilder().setDefaultCredentialsProvider(credentialsProvider);
       }
     }
   }


### PR DESCRIPTION
As Benjamin spotted, the HttpClientBuilder#setDefaultCredentialsProvider
method silently replaced any previously set provider.

This also happened in case when remote but also proxy needed
credentials. In worst case, the provider would be replaced 3
times (remote authc + HTTP + HTTPS proxy).

Added Javadoc warning about this, and also added
a new Builder method that delegates to it's own instance
of CredentialsProvider that if used, will replace the
HttpClientBuilder.

Added UT verifying the change.

CI
https://bamboo.zion.sonatype.com/browse/NX-OSSF21
