### PR TITLE
REVIEW: normalize custom shiro component names

### DIFF
--- a/components/nexus-security/src/main/java/org/apache/shiro/nexus/NexusDefaultSessionManager.java
+++ b/components/nexus-security/src/main/java/org/apache/shiro/nexus/NexusDefaultSessionManager.java
@@ -11,7 +11,7 @@
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
 
-package org.apache.shiro.nexus5727;
+package org.apache.shiro.nexus;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -22,7 +22,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Fixed {@link DefaultSessionManager} for issue SHIRO-443. This subclass is put into package of Shiro to have
+ * Nexus customized {@link DefaultSessionManager}.
+ *
+ * Provides fixes for issue SHIRO-443. This subclass is put into package of Shiro to have
  * shiro-guice's TypeListener applied to it, and result in same behavior as for other Shiro classes.
  *
  * @author cstamas
@@ -31,10 +33,10 @@ import org.slf4j.LoggerFactory;
  * @see <a href="https://issues.sonatype.org/browse/NEXUS-5727>NEXUS-5727 Shiro's session validating thread created
  *      multiple times</a>
  */
-public class FixedDefaultSessionManager
+public class NexusDefaultSessionManager
     extends DefaultSessionManager
 {
-  private static final Logger log = LoggerFactory.getLogger(FixedDefaultSessionManager.class);
+  private static final Logger log = LoggerFactory.getLogger(NexusDefaultSessionManager.class);
 
   @Inject
   public void configureProperties(

--- a/components/nexus-security/src/main/java/org/apache/shiro/nexus/NexusDefaultWebSessionManager.java
+++ b/components/nexus-security/src/main/java/org/apache/shiro/nexus/NexusDefaultWebSessionManager.java
@@ -11,7 +11,7 @@
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
 
-package org.apache.shiro.nexus5727;
+package org.apache.shiro.nexus;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -22,7 +22,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Fixed {@link DefaultWebSessionManager} for issue SHIRO-443. This subclass is put into package of Shiro to have
+ * Nexus customized {@link DefaultWebSessionManager}.
+ *
+ * Provides fixes for issue SHIRO-443. This subclass is put into package of Shiro to have
  * shiro-guice's TypeListener applied to it, and result in same behavior as for other Shiro classes.
  *
  * @author cstamas
@@ -31,10 +33,10 @@ import org.slf4j.LoggerFactory;
  * @see <a href="https://issues.sonatype.org/browse/NEXUS-5727>NEXUS-5727 Shiro's session validating thread created
  *      multiple times</a>
  */
-public class FixedDefaultWebSessionManager
+public class NexusDefaultWebSessionManager
     extends DefaultWebSessionManager
 {
-  private static final Logger log = LoggerFactory.getLogger(FixedDefaultWebSessionManager.class);
+  private static final Logger log = LoggerFactory.getLogger(NexusDefaultWebSessionManager.class);
 
   @Inject
   public void configureProperties(

--- a/components/nexus-security/src/main/java/org/sonatype/security/guice/SecurityModule.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/guice/SecurityModule.java
@@ -31,7 +31,7 @@ import org.apache.shiro.guice.ShiroModule;
 import org.apache.shiro.mgt.DefaultSecurityManager;
 import org.apache.shiro.mgt.RealmSecurityManager;
 import org.apache.shiro.mgt.SecurityManager;
-import org.apache.shiro.nexus5727.FixedDefaultSessionManager;
+import org.apache.shiro.nexus.NexusDefaultSessionManager;
 import org.apache.shiro.realm.Realm;
 import org.apache.shiro.session.mgt.SessionManager;
 import org.apache.shiro.session.mgt.eis.EnterpriseCacheSessionDAO;
@@ -70,10 +70,10 @@ public class SecurityModule
 
   @Override
   protected void bindSessionManager(AnnotatedBindingBuilder<SessionManager> bind) {
-    // workaround for NEXUS-5727, see FixedDefaultSessionManager javadoc for clues
-    bind.to(FixedDefaultSessionManager.class).asEagerSingleton();
-    // this is a PrivateModule, so explicitly binding the FixedDefaultSessionManager class
-    bind(FixedDefaultSessionManager.class);
+    // workaround for NEXUS-5727, see NexusDefaultSessionManager javadoc for clues
+    bind.to(NexusDefaultSessionManager.class).asEagerSingleton();
+    // this is a PrivateModule, so explicitly binding the NexusDefaultSessionManager class
+    bind(NexusDefaultSessionManager.class);
   }
 
   /**

--- a/components/nexus-security/src/main/java/org/sonatype/security/web/guice/SecurityWebModule.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/web/guice/SecurityWebModule.java
@@ -40,7 +40,7 @@ import org.apache.shiro.config.ConfigurationException;
 import org.apache.shiro.guice.web.ShiroWebModule;
 import org.apache.shiro.mgt.RealmSecurityManager;
 import org.apache.shiro.nexus.NexusWebSecurityManager;
-import org.apache.shiro.nexus5727.FixedDefaultWebSessionManager;
+import org.apache.shiro.nexus.NexusDefaultWebSessionManager;
 import org.apache.shiro.realm.Realm;
 import org.apache.shiro.session.mgt.SessionManager;
 import org.apache.shiro.session.mgt.eis.EnterpriseCacheSessionDAO;
@@ -110,10 +110,10 @@ public class SecurityWebModule
   @Override
   protected void bindSessionManager(AnnotatedBindingBuilder<SessionManager> bind) {
     // use native web session management instead of delegating to servlet container
-    // workaround for NEXUS-5727, see FixedDefaultWebSessionManager javadoc for clues
-    bind.to(FixedDefaultWebSessionManager.class).asEagerSingleton();
-    // this is a PrivateModule, so explicitly binding the FixedDefaultSessionManager class
-    bind(FixedDefaultWebSessionManager.class);
+    // workaround for NEXUS-5727, see NexusDefaultWebSessionManager javadoc for clues
+    bind.to(NexusDefaultWebSessionManager.class).asEagerSingleton();
+    // this is a PrivateModule, so explicitly binding the NexusDefaultSessionManager class
+    bind(NexusDefaultWebSessionManager.class);
   }
 
   /**

--- a/components/nexus-security/src/test/java/org/sonatype/security/guice/SecurityModuleTest.java
+++ b/components/nexus-security/src/test/java/org/sonatype/security/guice/SecurityModuleTest.java
@@ -29,7 +29,7 @@ import org.apache.shiro.cache.ehcache.EhCacheManager;
 import org.apache.shiro.mgt.DefaultSecurityManager;
 import org.apache.shiro.mgt.RealmSecurityManager;
 import org.apache.shiro.mgt.SecurityManager;
-import org.apache.shiro.nexus5727.FixedDefaultSessionManager;
+import org.apache.shiro.nexus.NexusDefaultSessionManager;
 import org.apache.shiro.session.mgt.eis.EnterpriseCacheSessionDAO;
 import org.eclipse.sisu.space.BeanScanning;
 import org.eclipse.sisu.space.SpaceModule;
@@ -74,9 +74,9 @@ public class SecurityModuleTest
     assertThat(securityManager, instanceOf(DefaultSecurityManager.class));
     DefaultSecurityManager defaultSecurityManager = (DefaultSecurityManager) securityManager;
 
-    assertThat(defaultSecurityManager.getSessionManager(), instanceOf(FixedDefaultSessionManager.class));
-    FixedDefaultSessionManager sessionManager =
-        (FixedDefaultSessionManager) defaultSecurityManager.getSessionManager();
+    assertThat(defaultSecurityManager.getSessionManager(), instanceOf(NexusDefaultSessionManager.class));
+    NexusDefaultSessionManager sessionManager =
+        (NexusDefaultSessionManager) defaultSecurityManager.getSessionManager();
     assertThat(sessionManager.getSessionDAO(), instanceOf(EnterpriseCacheSessionDAO.class));
     assertThat(
         ((EhCacheManager) ((EnterpriseCacheSessionDAO) sessionManager.getSessionDAO()).getCacheManager())


### PR DESCRIPTION
"Fixed" session\* here always confused me and I thought it meant that it had a fixed number of sessions, but its really just a nexus specific component that _fixes_ some bugs, and customizes the behavior.  Normalize to use nexus.\* and Nexus*.
