### PR TITLE
[2.8.x] NEXUS-6485: Optimizing Local discovery

### DIFF
--- a/components/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/routing/internal/LocalContentDiscovererImplTest.java
+++ b/components/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/routing/internal/LocalContentDiscovererImplTest.java
@@ -186,8 +186,10 @@ public class LocalContentDiscovererImplTest
           entrySource.readEntries(),
           hasItems("/archetype-catalog.xml", "/archetype-catalog.xml.sha1", "/archetype-catalog.xml.md5",
               "/com/sonatype", "/org/apache"));
-      assertThat(entrySource.readEntries(), not(hasItems("/org/sonatype")));
-      assertThat(entrySource.readEntries().size(), equalTo(5));
+      // NEXUS-6485: Not true anymore, we do include empty directories due to "depth" optimization
+      // see LocalContentDiscovererImpl
+      // assertThat(entrySource.readEntries(), not(hasItems("/org/sonatype")));
+      assertThat(entrySource.readEntries().size(), equalTo(6)); // was 5
     }
   }
 }


### PR DESCRIPTION
Instead of walking whole directory, we do walk only
the needed depth.

As a consequence, potentially including empty
directories as well.

Backport of
https://github.com/sonatype/nexus-oss/pull/430

Issue
https://issues.sonatype.org/browse/NEXUS-6485

CI
https://bamboo.zion.sonatype.com/browse/NX-OSSF47
