### PR TITLE
Add deprecated put(Object key, Object value) to RequestContext to provide binary compatibility with 2.7

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/RequestContext.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/RequestContext.java
@@ -155,6 +155,11 @@ public class RequestContext
     return delegate.put(key, value);
   }
 
+  @Deprecated
+  public Object put(final Object key, final Object value) {
+    return delegate.put((String) key, value);
+  }
+
   public Object remove(final Object key) {
     return delegate.remove(key);
   }


### PR DESCRIPTION
The solution for https://issues.sonatype.org/browse/NEXUS-6091 implemented in https://github.com/sonatype/nexus-oss/commit/ae197f5b97b97d6e289a2b24c3feda2467cd0c3d accidentally introduced a binary incompatibility for clients using RequestContext.put

This can be fixed by adding a deprecated `put(Object key, Object value)` method for old clients.

http://bamboo.s/browse/NX-OSSF2-1 :white_check_mark: 
