### PR TITLE
[2.8.x] Add deprecated put(Object key, Object value) to RequestContext to provide binary compatibility with 2.7

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/RequestContext.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/RequestContext.java
@@ -155,6 +155,11 @@ public class RequestContext
     return delegate.put(key, value);
   }
 
+  @Deprecated
+  public Object put(final Object key, final Object value) {
+    return delegate.put((String) key, value);
+  }
+
   public Object remove(final Object key) {
     return delegate.remove(key);
   }


### PR DESCRIPTION
Backported from #450

http://bamboo.s/browse/NX-OSSF34-1 :white_check_mark: 
