### PR TITLE
REVIEW: NEXUS-6526 log exception request context

### DIFF
--- a/plugins/basic/nexus-content-plugin/src/main/java/org/sonatype/nexus/content/internal/ContentServlet.java
+++ b/plugins/basic/nexus-content-plugin/src/main/java/org/sonatype/nexus/content/internal/ContentServlet.java
@@ -331,7 +331,7 @@ public class ContentServlet
   private String requestDetails(HttpServletRequest request) {
     StringBuilder sb = new StringBuilder();
     // getRemoteAddr respects x-forwarded-for if enabled and avoids potential DNS lookups
-    sb.append(" [client=").append(request.getRemoteAddr());
+    sb.append("[client=").append(request.getRemoteAddr());
     sb.append(",ua=").append(request.getHeader("User-Agent"));
     sb.append(",req=").append(request.getMethod()).append(' ').append(request.getRequestURL().toString());
     sb.append(']');


### PR DESCRIPTION
add request context to org.eclipse.jetty.io.EofException to aid determining the root cause

https://issues.sonatype.org/browse/NEXUS-6526
