### PR TITLE
REVIEW - NEXUS-6526 - log request details on IOException or internal error

### DIFF
--- a/components/nexus-web-utils/src/main/java/org/sonatype/nexus/web/content/NexusContentServlet.java
+++ b/components/nexus-web-utils/src/main/java/org/sonatype/nexus/web/content/NexusContentServlet.java
@@ -312,7 +312,7 @@ public class NexusContentServlet
   private String requestDetails(HttpServletRequest request) {
     StringBuilder sb = new StringBuilder();
     // getRemoteAddr respects x-forwarded-for if enabled and avoids potential DNS lookups
-    sb.append(" [client=").append(request.getRemoteAddr());
+    sb.append("[client=").append(request.getRemoteAddr());
     sb.append(",ua=").append(request.getHeader("User-Agent"));
     sb.append(",req=").append(request.getMethod()).append(' ').append(request.getRequestURL().toString());
     sb.append(']');


### PR DESCRIPTION
backport of https://issues.sonatype.org/browse/NEXUS-6526 in case customer finds it useful and to make patches easier.
