### PR TITLE
REVIEW: [NX-412] Fix quick tips being shown on all grids after they are used for a tree node

### DIFF
--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/app/Application.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/app/Application.js
@@ -54,6 +54,7 @@ Ext.define('NX.app.Application', {
     'NX.ext.grid.column.Icon',
     'NX.ext.grid.column.Link',
     'NX.ext.grid.column.Timestamp',
+    'NX.ext.tree.View',
     'NX.Conditions'
   ],
 

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/ext/tree/View.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/ext/tree/View.js
@@ -1,0 +1,42 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+/**
+ * **{@link Ext.tree.View}** override, that fixes bug about quick tips being rendered in all grids if set in a
+ * tree.
+ *
+ * @since 3.0
+ */
+Ext.define('NX.ext.tree.View', {
+  override: 'Ext.tree.View',
+
+  initComponent: function ()
+  {
+    var me = this;
+
+    me.treeRowTpl = Ext.XTemplate.getTpl(this, 'treeRowTpl');
+    me.treeRowTpl.set(
+        [
+          '{%',
+          'this.processRowValues(values);',
+          'this.nextTpl.applyOut(values, out, parent);',
+          'delete values.rowAttr["data-qtip"];',
+          'delete values.rowAttr["data-qtitle"];',
+          '%}'
+        ].join(''),
+        me.treeRowTpl.compiled
+    );
+
+    me.callParent(arguments);
+  }
+
+});


### PR DESCRIPTION
https://issues.sonatype.org/browse/NX-412

Used the fix from http://www.sencha.com/forum/showthread.php?264228-Unwanted-data-qtip-attributes-on-gridpanel-rows&p=968430&viewfull=1#post968430
Opened a ticked with Sencha.
