### PR TITLE
upgrade nexus-oss to KZ 0.5.2

### DIFF
--- a/buildsupport/db/pom.xml
+++ b/buildsupport/db/pom.xml
@@ -38,13 +38,13 @@
       <dependency>
         <groupId>io.kazuki</groupId>
         <artifactId>kazuki-api</artifactId>
-        <version>0.4.2</version>
+        <version>0.5.2</version>
       </dependency>
 
       <dependency>
         <groupId>io.kazuki</groupId>
         <artifactId>kazuki-impl</artifactId>
-        <version>0.4.2</version>
+        <version>0.5.2</version>
       </dependency>
 
       <dependency>

--- a/plugins/capabilities/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/storage/DefaultCapabilityStorage.java
+++ b/plugins/capabilities/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/storage/DefaultCapabilityStorage.java
@@ -94,7 +94,7 @@ public class DefaultCapabilityStorage
   public CapabilityIdentity add(final CapabilityStorageItem item) throws IOException {
     try {
       return asCapabilityIdentity(
-          keyValueStore.create(CAPABILITY_SCHEMA, CapabilityStorageItem.class, item, TypeValidation.STRICT)
+          keyValueStore.create(CAPABILITY_SCHEMA, CapabilityStorageItem.class, item, TypeValidation.STRICT).getKey()
       );
     }
     catch (KazukiException e) {


### PR DESCRIPTION
@mrprescott @jdillon @cstamas @adreghiciu 

Only backwards-incompatible change was kvStore.create returns a Version now
instead of just the Key. Feel free to merge it into your feature branches.

I'll file another PR for pro tomorrow.
