### PR TITLE
EXT: NEXUS-6582 - Yum Generate Metadata does not detect new rpms added on filesystem

### DIFF
--- a/plugins/yum/nexus-yum-repository-plugin/src/main/java/org/sonatype/nexus/yum/internal/task/GenerateMetadataTaskDescriptor.java
+++ b/plugins/yum/nexus-yum-repository-plugin/src/main/java/org/sonatype/nexus/yum/internal/task/GenerateMetadataTaskDescriptor.java
@@ -19,12 +19,14 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.sonatype.nexus.formfields.FormField;
+import org.sonatype.nexus.formfields.CheckboxFormField;
 import org.sonatype.nexus.formfields.RepoComboFormField;
 import org.sonatype.nexus.formfields.StringTextFormField;
 import org.sonatype.nexus.tasks.descriptors.AbstractScheduledTaskDescriptor;
 
 import static org.sonatype.nexus.formfields.FormField.MANDATORY;
 import static org.sonatype.nexus.formfields.FormField.OPTIONAL;
+import static org.sonatype.nexus.yum.internal.task.GenerateMetadataTask.PARAM_FORCE_FULL_SCAN;
 import static org.sonatype.nexus.yum.internal.task.GenerateMetadataTask.PARAM_REPO_DIR;
 import static org.sonatype.nexus.yum.internal.task.GenerateMetadataTask.PARAM_REPO_ID;
 
@@ -53,6 +55,13 @@ public class GenerateMetadataTaskDescriptor
       OPTIONAL
   );
 
+  private final CheckboxFormField forceFullScan = new CheckboxFormField(
+      PARAM_FORCE_FULL_SCAN,
+      "Force Full Scan",
+      "Forces a full scan and does not use the cached RPM file list.",
+      OPTIONAL
+  ).withInitialValue(false);
+
   @Override
   public String getId() {
     return GenerateMetadataTask.ID;
@@ -65,7 +74,7 @@ public class GenerateMetadataTaskDescriptor
 
   @Override
   public List<FormField> formFields() {
-    return Arrays.<FormField>asList(repoField, outputField);
+    return Arrays.<FormField>asList(repoField, outputField, forceFullScan);
   }
 
 }


### PR DESCRIPTION
Hi,

This is my first time submitting a pull request for nexus-oss so apologies if i have did something wrong.

This change adds a checkbox to the Yum Generate Metadata Task Configure screen to allow you to force a full scan and not use the previously generated RPM list file.  This will allow the Yum Generate Metadata task to pick up new RPMs which have been added directly to the filesystem

thanks
Geoff
