### PR TITLE
WIP [NX-416] Expose optimistic versioning to Capabilities

### DIFF
--- a/plugins/capabilities/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/CapabilityIdentity.java
+++ b/plugins/capabilities/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/CapabilityIdentity.java
@@ -15,7 +15,7 @@ package org.sonatype.nexus.plugins.capabilities;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Indentity of a capability.
+ * Identity of a capability.
  *
  * @since capabilities 2.0
  */

--- a/plugins/capabilities/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/DefaultCapabilityRegistry.java
+++ b/plugins/capabilities/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/DefaultCapabilityRegistry.java
@@ -177,6 +177,7 @@ public class DefaultCapabilityRegistry
 
       final Map<String, String> encryptedProps = encryptValuesIfNeeded(reference.descriptor(), props);
 
+      // FIXME: Handle false return for error
       capabilityStorage.update(id, new CapabilityStorageItem(
           reference.descriptor().version(), reference.type().toString(), enabled, notes, encryptedProps)
       );
@@ -350,6 +351,8 @@ public class DefaultCapabilityRegistry
           );
           continue;
         }
+
+        // FIXME: Handle false return for error
         capabilityStorage.update(id, new CapabilityStorageItem(
             descriptor.version(), item.getType(), item.isEnabled(), item.getNotes(), properties)
         );

--- a/plugins/capabilities/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/storage/DefaultCapabilityStorage.java
+++ b/plugins/capabilities/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/storage/DefaultCapabilityStorage.java
@@ -22,9 +22,11 @@ import javax.inject.Singleton;
 import org.sonatype.nexus.plugins.capabilities.CapabilityIdentity;
 import org.sonatype.sisu.goodies.lifecycle.LifecycleSupport;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 import io.kazuki.v0.store.KazukiException;
 import io.kazuki.v0.store.Key;
+import io.kazuki.v0.store.Version;
 import io.kazuki.v0.store.keyvalue.KeyValueIterable;
 import io.kazuki.v0.store.keyvalue.KeyValuePair;
 import io.kazuki.v0.store.keyvalue.KeyValueStore;
@@ -34,7 +36,10 @@ import io.kazuki.v0.store.schema.SchemaStore;
 import io.kazuki.v0.store.schema.TypeValidation;
 import io.kazuki.v0.store.schema.model.Attribute.Type;
 import io.kazuki.v0.store.schema.model.Schema;
+import io.kazuki.v0.store.sequence.KeyImpl;
+import io.kazuki.v0.store.sequence.VersionImpl;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -90,35 +95,99 @@ public class DefaultCapabilityStorage
     lifecycle.shutdown();
   }
 
+  /**
+   * Deconstruct KZ {@link Key} and {@link VersionImpl} details into a {@link CapabilityIdentity}.
+   */
+  private CapabilityIdentity identityOf(final KeyValuePair<CapabilityStorageItem> entity) {
+    Key key = entity.getKey();
+    VersionImpl version = (VersionImpl) entity.getVersion(); // HACK simple internal identifier is not exposed
+    String kv = key.getIdPart() + KeyVersion.SEPARATOR + version.getInternalIdentifier();
+    return new CapabilityIdentity(kv);
+  }
+
+  /**
+   * Container for KZ {@link Key} and {@link Version}.
+   */
+  private static class KeyVersion
+  {
+    /**
+     * URL-safe token to separate parts and avoid URL encoding.
+     */
+    public static final String SEPARATOR = ".";
+
+    public final Key key;
+
+    public final Version version;
+
+    /**
+     * Reconstruct KZ {@link Key} and {@link Version} from simple string.
+     */
+    public KeyVersion(final String value) {
+      checkNotNull(value);
+      String[] parts = split(value);
+
+      // HACK: Using internal KZ apis here :-(
+      this.key = KeyImpl.valueOf("@" + CAPABILITY_SCHEMA + ":" + parts[0]);
+      this.version = new VersionImpl(key, Long.parseLong(parts[1])) {
+        // HACK: Must sub-class to access protected constructor
+      };
+    }
+
+    /**
+     * Split value by {@link #SEPARATOR} into 2 parts.  Not using String.split() to avoid REGEX overhead and semantics.
+     */
+    private String[] split(final String value) {
+      int i = value.indexOf(SEPARATOR);
+      int l = value.length();
+      checkArgument(i != -1);
+      checkArgument(i + 1 < l);
+      String first = value.substring(0, i);
+      String last = value.substring(i + 1, l);
+      return new String[] {
+          first,
+          last
+      };
+    }
+
+    /**
+     * Reconstruct KZ {@link Key} and {@link Version} from a {@link CapabilityIdentity}.
+     */
+    public KeyVersion(final CapabilityIdentity identity) {
+      this(identity.toString());
+    }
+  }
+
   @Override
   public CapabilityIdentity add(final CapabilityStorageItem item) throws IOException {
     try {
-      return asCapabilityIdentity(
-          keyValueStore.create(CAPABILITY_SCHEMA, CapabilityStorageItem.class, item, TypeValidation.STRICT).getKey()
-      );
+      KeyValuePair<CapabilityStorageItem> entity =
+          keyValueStore.create(CAPABILITY_SCHEMA, CapabilityStorageItem.class, item, TypeValidation.STRICT);
+      return identityOf(entity);
     }
     catch (KazukiException e) {
-      throw new IOException("Capability could not be added", e);
+      throw Throwables.propagate(e);
     }
   }
 
   @Override
   public boolean update(final CapabilityIdentity id, final CapabilityStorageItem item) throws IOException {
     try {
-      return keyValueStore.update(asKey(id), CapabilityStorageItem.class, item);
+      KeyVersion kv = new KeyVersion(id);
+      return keyValueStore.updateVersioned(kv.key, kv.version, CapabilityStorageItem.class, item) != null;
     }
     catch (KazukiException e) {
-      throw new IOException("Capability could not be updated", e);
+      throw Throwables.propagate(e);
     }
   }
 
   @Override
   public boolean remove(final CapabilityIdentity id) throws IOException {
     try {
-      return keyValueStore.delete(asKey(id));
+      KeyVersion kv = new KeyVersion(id);
+      return keyValueStore.deleteVersioned(kv.key, kv.version);
     }
     catch (KazukiException e) {
-      throw new IOException("Capability could not be removed", e);
+      throw Throwables.propagate(e);
     }
   }
 
@@ -130,19 +199,10 @@ public class DefaultCapabilityStorage
         CAPABILITY_SCHEMA, CapabilityStorageItem.class, SortDirection.ASCENDING
     )) {
       for (KeyValuePair<CapabilityStorageItem> entry : entries) {
-        items.put(asCapabilityIdentity(entry.getKey()), entry.getValue());
+        items.put(identityOf(entry), entry.getValue());
       }
     }
 
     return items;
   }
-
-  private Key asKey(final CapabilityIdentity id) {
-    return keyValueStore.toKey("@" + CAPABILITY_SCHEMA + ":" + id.toString());
-  }
-
-  private CapabilityIdentity asCapabilityIdentity(final Key key) {
-    return new CapabilityIdentity(key.getIdPart());
-  }
-
 }


### PR DESCRIPTION
This has a bunch of problems... but this is as far as I've gotten ATM.

Specifically, this won't work as the usage of CapabilityIdentity is not expect to change, and its not update on a change to reflect.  The UI uses this as part of URL and if it did update to reflect version it would have to update the bookmark too.

Unsure if hiding version inside of CapabilityIdentity is proper, though the alternative is to expose API changes to pass this around which I'm also unsure of.
