### PR TITLE
EXT: set default jmx-host value in jetty-jmx.xml

### DIFF
--- a/assemblies/nexus-bundle-template/src/main/resources/content/conf/jetty-jmx.xml
+++ b/assemblies/nexus-bundle-template/src/main/resources/content/conf/jetty-jmx.xml
@@ -24,8 +24,8 @@
   <!--
   ==== JMX USAGE ====
   Set the following inside nexus.properties:
-  jmx-host: the remote host name, commonly the IP address, to remotely access Nexus using JMX from another host
-  jmx-port: the port to remotely access Nexus over JMX (1099)
+  jmx-host: the remote host name, commonly the IP address, to remotely access Nexus using JMX from another host (default: 0.0.0.0)
+  jmx-port: the port to remotely access Nexus over JMX (default: 1099)
   -->
 
   <!-- explicitly setting rmi server hostname as IP address here can help avoid network routing issues -->
@@ -33,7 +33,7 @@
   <Call name="setProperty" class="java.lang.System">
     <Arg>java.rmi.server.hostname</Arg>
     <Arg>
-      <Property name="jmx-host" />
+      <Property name="jmx-host" default="0.0.0.0"/>
     </Arg>
   </Call>
 
@@ -107,9 +107,9 @@
     <Arg>
       <New class="javax.management.remote.JMXServiceURL">
         <Arg type="java.lang.String">rmi</Arg>
-        <Arg type="java.lang.String"><Property name="jmx-host"/></Arg>
+        <Arg type="java.lang.String"><Property name="jmx-host" default="0.0.0.0"/></Arg>
         <Arg type="java.lang.Integer"><Property name="jmx-port" default="1099"/></Arg>
-        <Arg type="java.lang.String">/jndi/rmi://<Property name="jmx-host"/>:<Property name="jmx-port" default="1099"/>/jmxrmi</Arg>
+        <Arg type="java.lang.String">/jndi/rmi://<Property name="jmx-host" default="0.0.0.0"/>:<Property name="jmx-port" default="1099"/>/jmxrmi</Arg>
       </New>
     </Arg>
     <Arg>org.eclipse.jetty:name=rmiconnectorserver</Arg>


### PR DESCRIPTION
defaulting jmx-host to 0.0.0.0 because nobody reads the doc.
