### PR TITLE
NEXUS-6537: Do a move when possible

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/util/file/DirSupport.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/util/file/DirSupport.java
@@ -10,6 +10,7 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
+
 package org.sonatype.nexus.util.file;
 
 import java.io.File;
@@ -319,12 +320,19 @@ public final class DirSupport
   // MOVE: recursive copy of whole directory tree and then deleting it
 
   /**
-   * Performs a move operation, but as a sequence of "copy" and then "delete" (not a real move!). This method accepts
+   * Performs a move operation. It will attempt a real move (if source and target are on same file store), but will
+   * fallback to a sequence of "copy" and then "delete" (not a real move!). This method accepts
    * existing Paths that might denote a regular file or a directory.
    */
   public static void move(final Path from, final Path to) throws IOException {
-    copy(from, to);
-    delete(from);
+    try {
+      Files.move(from, to, StandardCopyOption.REPLACE_EXISTING);
+    }
+    catch (IOException e) {
+      // give up, do copy+delete
+      copy(from, to);
+      delete(from);
+    }
   }
 
   /**


### PR DESCRIPTION
Perform real move when possible. Same limitation stands on Java7 Files class as before (move on non-empty directory is possible only if on same partition, subtree does not have to be moved), but this time there are means to detect does this stand or not.

Issue
https://issues.sonatype.org/browse/NEXUS-6537

CI
http://bamboo.s/browse/NX-OSSF78
