### PR TITLE
REVIEW: [NX-390] avoid use of Require-Bundle

### DIFF
--- a/components/nexus-extender/pom.xml
+++ b/components/nexus-extender/pom.xml
@@ -130,20 +130,9 @@
             <Embed-Directory>lib</Embed-Directory>
             <Embed-Transitive>true</Embed-Transitive>
             <_exportcontents>
-              !lib.*,
               !com.google.inject.internal.*,
-              javax.servlet;provider=nexus;mandatory:=provider,
-              javax.servlet.http;provider=nexus;mandatory:=provider,
-              com.*|eu.*|javax.*|net.*|org.*|io.*;-noimport:=true
+              com.*|eu.*|javax.*|net.*|org.*|io.*
             </_exportcontents>
-            <Require-Bundle>
-              system.bundle;visibility:=reexport,
-              org.sonatype.nexus.jettyapp;visibility:=reexport;resolution:=optional
-            </Require-Bundle>
-            <Import-Package>
-              javax.servlet;provider=!,
-              javax.servlet.http;provider=!
-            </Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/components/nexus-jettyapp/pom.xml
+++ b/components/nexus-jettyapp/pom.xml
@@ -111,13 +111,8 @@
             <Embed-Directory>lib</Embed-Directory>
             <Embed-Transitive>true</Embed-Transitive>
             <_exportcontents>
-              !lib.*,
-              org.slf4j;provider=nexus;mandatory:=provider,
-              ch.*|com.*|org.*;-noimport:=true
+              ch.*|com.*|org.*
             </_exportcontents>
-            <Import-Package>
-              *;resolution:=optional
-            </Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/components/nexus-plugin-api/pom.xml
+++ b/components/nexus-plugin-api/pom.xml
@@ -115,20 +115,9 @@
 
   <build>
     <plugins>
-      <!--
-      Generate OSGi metadata.
-      -->
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <!--
-            Re-export core packages to plugins (which in turn require this bundle)
-            -->
-            <Require-Bundle>org.sonatype.nexus.extender;visibility:=reexport</Require-Bundle>
-          </instructions>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/plugins/basic/nexus-crypto-plugin/pom.xml
+++ b/plugins/basic/nexus-crypto-plugin/pom.xml
@@ -69,19 +69,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              bcprov
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/basic/nexus-logging-plugin/pom.xml
+++ b/plugins/basic/nexus-logging-plugin/pom.xml
@@ -70,21 +70,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-groovy-plugin,
-              org.sonatype.nexus.plugins.nexus-extdirect-plugin,
-              org.sonatype.nexus.plugins.nexus-siesta-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/basic/nexus-lvo-plugin/pom.xml
+++ b/plugins/basic/nexus-lvo-plugin/pom.xml
@@ -89,20 +89,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-restlet1x-plugin,
-              org.sonatype.nexus.plugins.nexus-ui-extjs3-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/basic/nexus-plugin-console-plugin/pom.xml
+++ b/plugins/basic/nexus-plugin-console-plugin/pom.xml
@@ -81,20 +81,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-restlet1x-plugin,
-              org.sonatype.nexus.plugins.nexus-extdirect-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/basic/nexus-rrb-plugin/pom.xml
+++ b/plugins/basic/nexus-rrb-plugin/pom.xml
@@ -67,20 +67,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-restlet1x-plugin,
-              org.sonatype.nexus.plugins.nexus-ui-extjs3-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/basic/nexus-siesta-plugin/pom.xml
+++ b/plugins/basic/nexus-siesta-plugin/pom.xml
@@ -68,10 +68,10 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>
           <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-ui-extjs3-plugin
-            </Require-Bundle>
+            <Import-Package>
+              javax.annotation,
+              *;resolution:=optional
+            </Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/plugins/basic/nexus-site-repository-plugin/pom.xml
+++ b/plugins/basic/nexus-site-repository-plugin/pom.xml
@@ -60,19 +60,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-ui-extjs3-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/basic/nexus-timeline-plugin/pom.xml
+++ b/plugins/basic/nexus-timeline-plugin/pom.xml
@@ -90,21 +90,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-siesta-plugin,
-              org.sonatype.nexus.plugins.nexus-groovy-plugin,
-              org.sonatype.nexus.plugins.nexus-extdirect-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/basic/nexus-ui-extjs3-plugin/pom.xml
+++ b/plugins/basic/nexus-ui-extjs3-plugin/pom.xml
@@ -127,19 +127,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-webresources-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/basic/nexus-unpack-plugin/pom.xml
+++ b/plugins/basic/nexus-unpack-plugin/pom.xml
@@ -55,19 +55,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-restlet1x-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/capabilities/nexus-capabilities-plugin/pom.xml
+++ b/plugins/capabilities/nexus-capabilities-plugin/pom.xml
@@ -117,23 +117,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-siesta-plugin,
-              org.sonatype.nexus.plugins.nexus-crypto-plugin,
-              org.sonatype.nexus.plugins.nexus-atlas-plugin,
-              org.sonatype.nexus.plugins.nexus-groovy-plugin,
-              org.sonatype.nexus.plugins.nexus-extdirect-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/capabilities/nexus-capabilities-testsuite-helper/pom.xml
+++ b/plugins/capabilities/nexus-capabilities-testsuite-helper/pom.xml
@@ -45,19 +45,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-capabilities-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/indexer/nexus-indexer-lucene-plugin/pom.xml
+++ b/plugins/indexer/nexus-indexer-lucene-plugin/pom.xml
@@ -126,10 +126,7 @@
         <configuration>
           <instructions>
             <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-maven-bridge-plugin,
-              org.sonatype.nexus.plugins.nexus-restlet1x-plugin,
-              org.sonatype.nexus.plugins.nexus-ui-extjs3-plugin
+              org.sonatype.nexus.plugins.nexus-restlet1x-plugin
             </Require-Bundle>
           </instructions>
         </configuration>

--- a/plugins/internal/nexus-atlas-plugin/pom.xml
+++ b/plugins/internal/nexus-atlas-plugin/pom.xml
@@ -81,22 +81,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-groovy-plugin,
-              org.sonatype.nexus.plugins.nexus-siesta-plugin,
-              org.sonatype.nexus.plugins.nexus-wonderland-plugin,
-              org.sonatype.nexus.plugins.nexus-extdirect-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/internal/nexus-groovyremote-plugin/pom.xml
+++ b/plugins/internal/nexus-groovyremote-plugin/pom.xml
@@ -80,19 +80,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-groovy-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/internal/nexus-wonderland-plugin/pom.xml
+++ b/plugins/internal/nexus-wonderland-plugin/pom.xml
@@ -91,22 +91,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-groovy-plugin,
-              org.sonatype.nexus.plugins.nexus-siesta-plugin,
-              org.sonatype.nexus.plugins.nexus-crypto-plugin,
-              org.sonatype.nexus.plugins.nexus-ui-extjs3-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/maven/nexus-archetype-plugin/pom.xml
+++ b/plugins/maven/nexus-archetype-plugin/pom.xml
@@ -67,20 +67,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-indexer-lucene-plugin,
-              org.sonatype.nexus.plugins.nexus-restlet1x-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/maven/nexus-maven-bridge-plugin/pom.xml
+++ b/plugins/maven/nexus-maven-bridge-plugin/pom.xml
@@ -77,6 +77,18 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Require-Bundle>
+              org.sonatype.nexus.extender
+            </Require-Bundle>
+          </instructions>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/osgi/nexus-obr-plugin/pom.xml
+++ b/plugins/osgi/nexus-obr-plugin/pom.xml
@@ -118,20 +118,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-restlet1x-plugin,
-              org.sonatype.nexus.plugins.nexus-ui-extjs3-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/p2/nexus-p2-bridge-plugin/pom.xml
+++ b/plugins/p2/nexus-p2-bridge-plugin/pom.xml
@@ -156,6 +156,12 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>
           <instructions>
+            <_exportcontents>
+              org.sonatype.p2.*
+            </_exportcontents>
+            <DynamicImport-Package>
+              javax.*,org.w3c.*
+            </DynamicImport-Package>
             <Include-Resource>
               /p2-bridge/org.sonatype.p2.bridge.api.manifest=
                 ${project.build.directory}/dependency/org.sonatype.p2.bridge.api/META-INF/MANIFEST.MF,

--- a/plugins/p2/nexus-p2-repository-plugin/pom.xml
+++ b/plugins/p2/nexus-p2-repository-plugin/pom.xml
@@ -72,20 +72,6 @@
 
   <build>
     <plugins>
-       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-capabilities-plugin,
-              org.sonatype.nexus.plugins.nexus-p2-bridge-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
       <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -460,22 +460,23 @@
           <configuration>
             <instructions>
               <!--
-              Nexus plugin default instructions (based on Require-Bundle model)
+              Nexus plugin default instructions
               -->
               <Bundle-Name>${pluginName}</Bundle-Name>
               <Bundle-Description>${pluginDescription}</Bundle-Description>
               <Bundle-DocURL>http://links.sonatype.com/products/nexus/oss/home</Bundle-DocURL>
-              <Require-Bundle>org.sonatype.nexus.plugin-api</Require-Bundle>
               <!--
               Global ban on embedded dependencies already in core
               -->
               <Embed-Dependency>
                 *;scope=compile|runtime;artifactId=!
+                  activation|
                   aether-api|
                   aether-spi|
                   aether-util|
                   annotations|
                   aopalliance|
+                  bcprov-jdk15on|
                   bval-core|
                   bval-guice|
                   bval-jsr303|
@@ -487,6 +488,7 @@
                   commons-io|
                   commons-lang|
                   commons-lang3|
+                  geronimo-jta_1.0.1B_spec|
                   goodies-common|
                   goodies-eventbus|
                   goodies-i18n|
@@ -507,9 +509,13 @@
                   javax.annotation-api|
                   javax.inject|
                   javax.servlet|
+                  javax.ws.rs|
+                  jaxb-api|
+                  jboss-annotations-api_1.1_spec|
                   jcl-over-slf4j|
                   joda-time|
                   jsoup|
+                  jsr173_api|
                   jsr250-api|
                   jsr305|
                   jul-to-slf4j|
@@ -549,7 +555,7 @@
               <Embed-Transitive>true</Embed-Transitive>
               <Private-Package>!*;-split-package:=first</Private-Package>
               <_exportcontents>
-                ![A-Z]*|lib*|static*|docs*|*-*|.*,*;-noimport:=true
+                ![A-Z]*|lib*|static*|docs*|*-*|.*,*
               </_exportcontents>
             </instructions>
           </configuration>

--- a/plugins/rapture/nexus-coreui-plugin/pom.xml
+++ b/plugins/rapture/nexus-coreui-plugin/pom.xml
@@ -93,24 +93,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-groovy-plugin,
-              org.sonatype.nexus.plugins.nexus-rapture-plugin,
-              org.sonatype.nexus.plugins.nexus-extdirect-plugin,
-              org.sonatype.nexus.plugins.nexus-wonderland-plugin,
-              org.sonatype.nexus.plugins.nexus-restlet1x-plugin,
-              org.sonatype.nexus.plugins.nexus-indexer-lucene-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/rapture/nexus-rapture-plugin/pom.xml
+++ b/plugins/rapture/nexus-rapture-plugin/pom.xml
@@ -90,14 +90,6 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>
           <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-extdirect-plugin,
-              org.sonatype.nexus.plugins.nexus-groovy-plugin,
-              org.sonatype.nexus.plugins.nexus-webresources-plugin,
-              org.sonatype.nexus.plugins.nexus-capabilities-plugin,
-              org.sonatype.nexus.plugins.nexus-wonderland-plugin
-            </Require-Bundle>
             <Embed-Dependency>
               nexus-rapture-baseapp;inline=true
             </Embed-Dependency>

--- a/plugins/restlet1x/nexus-restlet1x-plugin/pom.xml
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/pom.xml
@@ -83,19 +83,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-content-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/security/nexus-ldap-realm-plugin/pom.xml
+++ b/plugins/security/nexus-ldap-realm-plugin/pom.xml
@@ -86,21 +86,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-restlet1x-plugin,
-              org.sonatype.nexus.plugins.nexus-ui-extjs3-plugin,
-              org.sonatype.nexus.plugins.nexus-crypto-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/security/nexus-rutauth-plugin/pom.xml
+++ b/plugins/security/nexus-rutauth-plugin/pom.xml
@@ -56,19 +56,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-capabilities-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/plugins/yum/nexus-yum-repository-plugin/pom.xml
+++ b/plugins/yum/nexus-yum-repository-plugin/pom.xml
@@ -90,20 +90,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-restlet1x-plugin,
-              org.sonatype.nexus.plugins.nexus-capabilities-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -593,16 +593,13 @@
               <Include-Resource>
                 /=${project.build.outputDirectory},{maven-resources}
               </Include-Resource>
-
-              <!--
-              Defaults while plugins use Require-Bundle.
-              -->
-              <Import-Package>!*</Import-Package>
-              <_nouses>true</_nouses>
-              <_nodefaultversion>true</_nodefaultversion>
+              <!-- remove build-only headers from final manifest -->
               <_removeheaders>
                 Embed*,Include-Resource,Private-Package
               </_removeheaders>
+              <Import-Package>
+                *;resolution:=optional
+              </Import-Package>
             </instructions>
           </configuration>
         </plugin>

--- a/testsupport/nexus-it-helper-plugin/pom.xml
+++ b/testsupport/nexus-it-helper-plugin/pom.xml
@@ -67,20 +67,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-restlet1x-plugin,
-              org.sonatype.nexus.plugins.nexus-extdirect-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>

--- a/testsupport/nexus-testsuite-ui-plugin/pom.xml
+++ b/testsupport/nexus-testsuite-ui-plugin/pom.xml
@@ -57,20 +57,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Require-Bundle>
-              org.sonatype.nexus.plugin-api,
-              org.sonatype.nexus.plugins.nexus-ui-extjs3-plugin,
-              org.sonatype.nexus.plugins.nexus-rapture-plugin
-            </Require-Bundle>
-          </instructions>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
       </plugin>


### PR DESCRIPTION
This PR moves Nexus from the "named plugin" dependency model to pure package-based resolution.

Note: one use of Require-Bundle is still needed in the indexer plugin to workaround a legacy split-package involving `org.sonatype.nexus.rest.model` with the restlet1x plugin, pending re-working of the REST API.
