### PR TITLE
REVIEW: [NX-538] OrientDB Component Metadata Impl

### DIFF
--- a/components/nexus-componentmetadata/pom.xml
+++ b/components/nexus-componentmetadata/pom.xml
@@ -1,0 +1,48 @@
+<!--
+
+    Sonatype Nexus (TM) Open Source Version
+    Copyright (c) 2007-2014 Sonatype, Inc.
+    All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+
+    This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+    which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+
+    Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+    of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+    Eclipse Foundation. All other trademarks are the property of their respective owners.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.sonatype.nexus</groupId>
+    <artifactId>nexus-components</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>nexus-componentmetadata</artifactId>
+  <name>${project.groupId}:${project.artifactId}</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-orient</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-test-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/FieldDefinition.java
+++ b/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/FieldDefinition.java
@@ -1,0 +1,139 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.componentmetadata;
+
+import com.google.common.base.Objects;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Defines the name, type, and attributes of a field.
+ *
+ * @since 3.0
+ */
+public class FieldDefinition
+{
+  private final String name;
+
+  private final Class type;
+
+  private boolean notNull;
+
+  private boolean indexed;
+
+  private boolean unique;
+
+  /**
+   * Creates a minimally valid field definition.
+   *
+   * @param name the name of the field.
+   * @param type the Java class of the field.
+   */
+  public FieldDefinition(String name, Class type) {
+    this.name = checkNotNull(name);
+    this.type = checkNotNull(type);
+  }
+
+  /**
+   * Gets the name of the field.
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Gets the Java class of the field.
+   */
+  public Class getType() {
+    return type;
+  }
+
+  /**
+   * Gets whether a value for the field must be specified.
+   *
+   * @see #withNotNull(boolean)
+   */
+  public boolean isNotNull() {
+    return notNull;
+  }
+
+  /**
+   * @see #isNotNull()
+   */
+  public FieldDefinition withNotNull(final boolean notNull) {
+    this.notNull = notNull;
+    return this;
+  }
+
+  /**
+   * Gets whether the field should be indexed.
+   *
+   * @see #withIndexed(boolean)
+   */
+  public boolean isIndexed() {
+    return indexed;
+  }
+
+  /**
+   * @see #isIndexed()
+   */
+  public FieldDefinition withIndexed(final boolean indexed) {
+    this.indexed = indexed;
+    return this;
+  }
+
+  /**
+   * If {@link #isIndexed()}, gets whether the field's values must be unique.
+   *
+   * @see #withUnique(boolean)
+   */
+  public boolean isUnique() {
+    return unique;
+  }
+
+  /**
+   * @see #withUnique(boolean)
+   */
+  public FieldDefinition withUnique(final boolean unique) {
+    this.unique = unique;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null) return false;
+    if (!(obj instanceof FieldDefinition)) return false;
+    final FieldDefinition other = (FieldDefinition) obj;
+    return Objects.equal(getName(), other.getName())
+        && Objects.equal(getType(), other.getType())
+        && Objects.equal(isNotNull(), other.isNotNull())
+        && Objects.equal(isIndexed(), other.isIndexed())
+        && Objects.equal(isUnique(), other.isUnique());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(getName(), getType(), isNotNull(), isIndexed(), isUnique());
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(FieldDefinition.class)
+        .add("name", getName())
+        .add("type", getType())
+        .add("notNull", isNotNull())
+        .add("indexed", isIndexed())
+        .add("unique", isUnique())
+        .toString();
+  }
+}

--- a/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/Record.java
+++ b/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/Record.java
@@ -1,0 +1,98 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.componentmetadata;
+
+import java.util.Set;
+
+/**
+ * A storage object containing a set of key-value pairs.
+ *
+ * @since 3.0
+ */
+public interface Record
+{
+  /**
+   * Gets the type of this record.
+   */
+  RecordType getType();
+
+  /**
+   * Tells whether this record has ever been {@link #save()}d. If {@code true}, it is guaranteed to have an id
+   * and version.
+   */
+  boolean isPersistent();
+
+  /**
+   * Gets the id of this record.
+   *
+   * @throws IllegalStateException if the record is not persistent.
+   * @see #isPersistent()
+   */
+  RecordId getId();
+
+  /**
+   * Gets the version of this record.
+   *
+   * @throws IllegalStateException if the record is not persistent.
+   * @see #isPersistent()
+   */
+  RecordVersion getVersion();
+
+  /**
+   * Tells whether the record has a value defined for the given field.
+   */
+  boolean has(String key);
+
+  /**
+   * Gets the value of a field.
+   *
+   * @throws NullPointerException if the value is undefined. If uncertain, callers should use {@link #has(String)} to
+   * determine if the value is defined first.
+   */
+  <T> T get(String key);
+
+  /**
+   * Gets the value of a {@code Record} field.
+   *
+   * @throws NullPointerException if the value is undefined. If uncertain, callers should use {@link #has(String)} to
+   * determine if the value is defined first.
+   */
+  Record getRecord(String key);
+
+  /**
+   * Sets the value of a field.
+   */
+  Record set(String key, Object value);
+
+  /**
+   * Removes a field by key. If the field does not exist, this has no effect.
+   */
+  void remove(String key);
+
+  /**
+   * Gets the list of field names.
+   */
+  Set<String> keySet();
+
+  /**
+   * Persists the current state of the record to the store.
+   *
+   * If this is the first time the record has been saved, it will be assigned a permanent
+   * id and an initial version. If the record already exists, the version will be incremented.
+   *
+   * @see #getId()
+   * @see #getVersion()
+   * @see #isPersistent()
+   */
+  Record save();
+}

--- a/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/RecordId.java
+++ b/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/RecordId.java
@@ -1,0 +1,70 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.componentmetadata;
+
+import com.google.common.base.Objects;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Opaque identifier of a stored record.
+ *
+ * @since 3.0
+ */
+public final class RecordId
+{
+  private final String typeName;
+
+  private final String value;
+
+  public RecordId(String typeName, String value) {
+    this.typeName = checkNotNull(typeName);
+    this.value = checkNotNull(value);
+  }
+
+  /**
+   * Gets the record type name.
+   */
+  public String getTypeName() {
+    return typeName;
+  }
+
+  /**
+   * Gets the value as a string.
+   */
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null) return false;
+    if (!(obj instanceof RecordId)) return false;
+    final RecordId other = (RecordId) obj;
+    return Objects.equal(getTypeName(), other.getTypeName())
+        && Objects.equal(getValue(), other.getValue());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(getTypeName(), getValue());
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(RecordId.class)
+        .add("typeName", getTypeName())
+        .add("value", getValue())
+        .toString();
+  }
+}

--- a/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/RecordQuery.java
+++ b/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/RecordQuery.java
@@ -1,0 +1,125 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.componentmetadata;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.Maps;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Specifies a query against a {@link RecordStore}.
+ *
+ * @since 3.0
+ */
+public class RecordQuery
+{
+  private final RecordType type;
+
+  private final Map<String, Object> filter = Maps.newLinkedHashMap();
+
+  private Integer limit;
+
+  private Integer skip;
+
+  private RecordId skipRecord;
+
+  private String orderBy;
+
+  private boolean descending;
+
+  public RecordQuery(RecordType type) {
+    this.type = checkNotNull(type);
+  }
+
+  public RecordType getType() {
+    return type;
+  }
+
+  public RecordQuery withEqual(String key, Object value) {
+    checkArgument(!(checkNotNull(key).isEmpty()), "Key cannot be empty");
+    checkNotNull(value);
+    filter.put(key, value);
+    return this;
+  }
+
+  /**
+   * Gets a map containing all the key value pairs added via {@link #withEqual(String, Object)}.
+   *
+   * Iterating over the keys of this map will provide them in insert order.
+   */
+  public Map<String, Object> getFilter() {
+    return filter;
+  }
+
+  public RecordQuery withSkip(Integer skip) {
+    checkArgument(checkNotNull(skip) >= 0, "Skip must be non-negative");
+    checkArgument(skipRecord == null, "Cannot skip; skip record is already specified");
+    this.skip = skip;
+    return this;
+  }
+
+  @Nullable
+  public Integer getSkip() {
+    return skip;
+  }
+
+  public RecordQuery withSkipRecord(RecordId skipRecord) {
+    checkNotNull(skipRecord);
+    checkArgument(skip == null, "Cannot skip record; skip is already specified");
+    checkArgument(orderBy == null, "Cannot skip record; order by is already specified");
+    this.skipRecord = skipRecord;
+    return this;
+  }
+
+  @Nullable
+  public RecordId getSkipRecord() {
+    return skipRecord;
+  }
+
+  public RecordQuery withOrderBy(String orderBy) {
+    checkArgument(!(checkNotNull(orderBy).isEmpty()), "Order by cannot be empty");
+    checkArgument(skipRecord == null, "Cannot order by; skip record is already specified");
+    this.orderBy = orderBy;
+    return this;
+  }
+
+  @Nullable
+  public String getOrderBy() {
+    return orderBy;
+  }
+
+  public RecordQuery withLimit(Integer limit) {
+    checkArgument(checkNotNull(limit) > 0, "Limit must be positive");
+    this.limit = limit;
+    return this;
+  }
+
+  @Nullable
+  public Integer getLimit() {
+    return this.limit;
+  }
+
+  public RecordQuery withDescending(boolean descending) {
+    this.descending = descending;
+    return this;
+  }
+
+  public boolean isDescending() {
+    return descending;
+  }
+}

--- a/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/RecordStore.java
+++ b/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/RecordStore.java
@@ -1,0 +1,26 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.componentmetadata;
+
+/**
+ * Main API entry point. Provides {@link RecordStoreSession}s for working with the store.
+ *
+ * @since 3.0
+ */
+public interface RecordStore
+{
+  /**
+   * Opens a session for working with the store.
+   */
+  RecordStoreSession openSession();
+}

--- a/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/RecordStoreSchema.java
+++ b/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/RecordStoreSchema.java
@@ -1,0 +1,48 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.componentmetadata;
+
+/**
+ * Manages the {@link RecordType}es associated with a {@link RecordStore}.
+ *
+ * @since 3.0
+ */
+public interface RecordStoreSchema
+    extends Iterable<RecordType>
+{
+  /**
+   * Conditionally adds a type for use with the store.
+   *
+   * @return whether the type was added. It will not be added if a type with the given name already exists.
+   */
+  boolean addType(RecordType type);
+
+  /**
+   * Gets the type with the given name.
+   *
+   * @throws IllegalArgumentException if a type with the given name does not exist.
+   */
+  RecordType getType(String name);
+
+  /**
+   * Tells whether a type with the given name exists.
+   */
+  boolean hasType(String name);
+
+  /**
+   * Removes the given type from the schema. All associated records and indexes will be removed.
+   *
+   * @throws IllegalArgumentException if a type with the given name does not exist.
+   */
+  void dropType(String name);
+}

--- a/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/RecordStoreSession.java
+++ b/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/RecordStoreSession.java
@@ -1,0 +1,72 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.componentmetadata;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+/**
+ * A session for working with records in a {@link RecordStore}.
+ *
+ * @since 3.0
+ */
+public interface RecordStoreSession
+    extends AutoCloseable
+{
+  /**
+   * Gets the schema.
+   */
+  RecordStoreSchema getSchema();
+
+  /**
+   * Creates a record. It will not be persisted until it or the record it resides within is {@link Record#save()}d.
+   *
+   * @throws IllegalArgumentException if the type does not exist or is abstract.
+   */
+  Record create(RecordType type);
+
+  /**
+   * Gets a record, or {@code null} if it doesn't exist.
+   */
+  @Nullable
+  Record get(RecordId id);
+
+  /**
+   * Gets a list of matching records.
+   *
+   * @throws IllegalArgumentException if the type does not exist.
+   */
+  List<Record> find(RecordQuery query);
+
+  /**
+   * Gets the number of matching records.
+   *
+   * @throws IllegalArgumentException if the type does not exist.
+   */
+  long count(RecordQuery query);
+
+  /**
+   * Deletes the given record. If it doesn't exist in storage, this has no effect.
+   */
+  void delete(Record record);
+
+  /**
+   * Closes the session, releasing any underlying resources.
+   *
+   * After calling this, all attempts to use this session or any records associated with it will
+   * fail with an {@link IllegalStateException}.
+   */
+  @Override
+  void close();
+}

--- a/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/RecordType.java
+++ b/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/RecordType.java
@@ -1,0 +1,152 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.componentmetadata;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.Maps;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * Defines a type of record.
+ *
+ * @since 3.0
+ */
+public class RecordType
+    implements Iterable<FieldDefinition>
+{
+  private final Map<String, FieldDefinition> fields = Maps.newLinkedHashMap();
+
+  private final String name;
+
+  private boolean strict;
+
+  private RecordType superType;
+
+  private boolean isAbstract;
+
+  public RecordType(String name) {
+    this.name = checkNotNull(name);
+  }
+
+  /**
+   * Gets the name of the type.
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Adds the given field.
+   *
+   * @throws IllegalStateException if a field with the same name already exists.
+   */
+  public RecordType withField(FieldDefinition field) {
+    checkState(!fields.containsKey(field.getName()), "Field '%s' is already defined for %s", field.getName(), name);
+    fields.put(field.getName(), field);
+    return this;
+  }
+
+  /**
+   * @see #isStrict()
+   */
+  public RecordType withStrict(boolean strict) {
+    this.strict = strict;
+    return this;
+  }
+
+  /**
+   * Gets whether the records of this type must only consist of fields that have been defined for it.
+   *
+   * @see #withStrict(boolean)
+   */
+  public boolean isStrict() {
+    return strict;
+  }
+
+  /**
+   * @see #getSuperType()
+   */
+  public RecordType withSuperType(RecordType superType) {
+    this.superType = superType;
+    return this;
+  }
+
+  /**
+   * Gets the supertype, or {@code null} if one has not been defined for this type.
+   */
+  @Nullable
+  public RecordType getSuperType() {
+    return superType;
+  }
+
+  /**
+   * @see #isAbstract()
+   */
+  public RecordType withAbstract(boolean isAbstract) {
+    this.isAbstract = isAbstract;
+    return this;
+  }
+
+  /**
+   * Gets whether the type has been declared as abstract or not.
+   *
+   * If records only need to stored at the subtype level, it's more efficient to declare the supertype as abstract
+   * so storage doesn't need to be allocated for it.
+   */
+  public boolean isAbstract() {
+    return isAbstract;
+  }
+
+  /**
+   * Gets an iterator over all explicitly-defined fields for this type.
+   */
+  @Override
+  public Iterator<FieldDefinition> iterator() {
+    return fields.values().iterator();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null) return false;
+    if (!(obj instanceof RecordType)) return false;
+    final RecordType other = (RecordType) obj;
+    return Objects.equal(getName(), other.getName())
+        && Objects.equal(fields, other.fields)
+        && Objects.equal(isStrict(), other.isStrict())
+        && Objects.equal(getSuperType(), other.getSuperType())
+        && Objects.equal(isAbstract(), other.isAbstract());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(getName(), fields, isStrict(), getSuperType(), isAbstract());
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(RecordType.class)
+        .add("name", getName())
+        .add("fields", fields)
+        .add("strict", isStrict())
+        .add("superType", getSuperType())
+        .add("abstract", isAbstract())
+        .toString();
+  }
+}

--- a/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/RecordVersion.java
+++ b/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/RecordVersion.java
@@ -1,0 +1,58 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.componentmetadata;
+
+import com.google.common.base.Objects;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Version of a stored record.
+ *
+ * @since 3.0
+ */
+public final class RecordVersion
+{
+  private final String value;
+
+  public RecordVersion(String value) {
+    this.value = checkNotNull(value);
+  }
+
+  /**
+   * Gets the value as a string.
+   */
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null) return false;
+    if (!(obj instanceof RecordVersion)) return false;
+    final RecordVersion other = (RecordVersion) obj;
+    return Objects.equal(getValue(), other.getValue());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(getValue());
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(RecordVersion.class)
+        .add("value", getValue())
+        .toString();
+  }
+}

--- a/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/internal/OrientQueryBuilder.java
+++ b/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/internal/OrientQueryBuilder.java
@@ -1,0 +1,113 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.componentmetadata.internal;
+
+import org.sonatype.nexus.componentmetadata.RecordQuery;
+import org.sonatype.nexus.orient.RecordIdObfuscator;
+
+import com.orientechnologies.orient.core.metadata.schema.OClass;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Helper to convert a {@link RecordQuery} into an OrientDB SELECT statement.
+ *
+ * @since 3.0
+ */
+class OrientQueryBuilder
+{
+  private final RecordQuery query;
+
+  private final RecordIdObfuscator recordIdObfuscator;
+
+  private final OClass oClass;
+
+  private boolean count;
+
+  /**
+   * @param query the source query.
+   * @param oClass the Orient class corresponding to the type specified by the query.
+   * @param recordIdObfuscator the id obfuscator to use when decoding record ids.
+   */
+  public OrientQueryBuilder(RecordQuery query,
+                            OClass oClass,
+                            RecordIdObfuscator recordIdObfuscator) {
+    this.query = checkNotNull(query);
+    this.oClass = checkNotNull(oClass);
+    this.recordIdObfuscator = checkNotNull(recordIdObfuscator);
+  }
+
+  /**
+   * Specifies whether this is a COUNT query.
+   */
+  public OrientQueryBuilder withCount(boolean count) {
+    this.count = count;
+    return this;
+  }
+
+  /**
+   * Builds the OrientDB SELECT statement.
+   */
+  public String build() {
+    // SELECT [COUNT(*)] FROM typeName
+
+    StringBuilder builder = new StringBuilder("SELECT ");
+    if (count) {
+      builder.append("COUNT(*) ");
+    }
+    builder.append("FROM ");
+    builder.append(query.getType().getName());
+
+    // [ WHERE [@rid > lowerRid] [[ AND ] filterKey1 = :filterKey1 [AND filterKey2 = :filterKey2 [..]]]]
+
+    StringBuilder whereBuilder = null;
+
+    if (query.getSkipRecord() != null) {
+      String ridString = recordIdObfuscator.decode(oClass, query.getSkipRecord().getValue()).toString();
+      whereBuilder = new StringBuilder(" WHERE @rid > ").append(ridString);
+    }
+    if (query.getFilter().size() > 0) {
+      for (String key : query.getFilter().keySet()) {
+        if (whereBuilder == null) {
+          whereBuilder = new StringBuilder(" WHERE ");
+        }
+        else {
+          whereBuilder.append(" AND ");
+        }
+        whereBuilder.append(key).append(" = :").append(key);
+      }
+    }
+    if (whereBuilder != null) {
+      builder.append(whereBuilder.toString());
+    }
+
+    // [ ORDER BY orderBy [DESC]] [ SKIP skip] [ LIMIT limit]
+
+    if (!count) {
+      if (query.getOrderBy() != null) {
+        builder.append(" ORDER BY ").append(query.getOrderBy());
+        if (query.isDescending()) {
+          builder.append(" DESC");
+        }
+      }
+      if (query.getSkip() != null) {
+        builder.append(" SKIP ").append(query.getSkip());
+      }
+      if (query.getLimit() != null) {
+        builder.append(" LIMIT ").append(query.getLimit());
+      }
+    }
+
+    return builder.toString();
+  }
+}

--- a/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/internal/OrientRecord.java
+++ b/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/internal/OrientRecord.java
@@ -1,0 +1,179 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.componentmetadata.internal;
+
+import java.util.Set;
+
+import org.sonatype.nexus.componentmetadata.Record;
+import org.sonatype.nexus.componentmetadata.RecordId;
+import org.sonatype.nexus.componentmetadata.RecordType;
+import org.sonatype.nexus.componentmetadata.RecordVersion;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.Sets;
+import com.orientechnologies.orient.core.record.impl.ODocument;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * OrientDB implementation of {@link Record}.
+ *
+ * @since 3.0
+ */
+class OrientRecord
+    implements Record
+{
+  private final OrientRecordStoreSession session;
+
+  private final RecordType type;
+
+  protected ODocument document;
+
+  public OrientRecord(final OrientRecordStoreSession session,
+                      final RecordType type,
+                      final ODocument document) {
+    this.session = session;
+    this.type = type;
+    this.document = document;
+  }
+
+  @Override
+  public RecordType getType() {
+    session.checkOpen();
+
+    return type;
+  }
+
+  @Override
+  public boolean isPersistent() {
+    session.checkOpen();
+
+    return document.getIdentity().isPersistent();
+  }
+
+  @Override
+  public RecordId getId() {
+    session.checkOpen();
+    checkPersistent();
+
+    return session.getRecordId(document.getSchemaClass(), document.getIdentity());
+  }
+
+  @Override
+  public RecordVersion getVersion() {
+    session.checkOpen();
+    checkPersistent();
+
+    return new RecordVersion(Integer.valueOf(document.getVersion()).toString());
+  }
+
+  @Override
+  public boolean has(String key) {
+    session.checkOpen();
+
+    return document.field(key) != null;
+  }
+
+  @Override
+  public <T> T get(final String key) {
+    session.checkOpen();
+
+    return checkValueNotNull(key);
+  }
+
+  @Override
+  public Record getRecord(String key) {
+    session.checkOpen();
+
+    Object value = checkValueNotNull(key);
+    if (value instanceof ODocument) {
+      return session.getRecord((ODocument) value);
+    }
+    throw new ClassCastException(String.format("Cannot convert to Record: %s", value.getClass()));
+  }
+
+  @Override
+  public Record set(final String key, final Object value) {
+    session.checkOpen();
+    checkNotNull(value);
+
+    if (value instanceof OrientRecord) {
+      document.field(key, ((OrientRecord) value).document);
+    }
+    else if (value instanceof RecordId) {
+      document.field(key, session.getRid((RecordId) value));
+    }
+    else {
+      document.field(key, value);
+    }
+    return this;
+  }
+
+  @Override
+  public void remove(final String key) {
+    session.checkOpen();
+
+    document.removeField(key);
+  }
+
+  @Override
+  public Set<String> keySet() {
+    session.checkOpen();
+
+    return Sets.newHashSet(document.fieldNames());
+  }
+
+  @Override
+  public Record save() {
+    session.checkOpen();
+    System.out.println(type);
+    document = document.save();
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null) return false;
+    if (!(obj instanceof OrientRecord)) return false;
+    final OrientRecord other = (OrientRecord) obj;
+    return Objects.equal(getType(), other.getType())
+        && Objects.equal(getId(), other.getId())
+        && Objects.equal(getVersion(), other.getVersion())
+        && Objects.equal(document, other.document);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(getType(), getId(), getVersion(), document);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(OrientRecord.class)
+        .add("type", getType())
+        .add("id", getId())
+        .add("version", getVersion())
+        .add("document", document)
+        .toString();
+  }
+
+  private <T> T checkValueNotNull(String key) {
+    T value = document.field(key);
+    return checkNotNull(value, String.format("Undefined value for field: %s", key));
+  }
+
+  private void checkPersistent() {
+    checkState(isPersistent(), "Record has not been saved yet");
+  }
+}

--- a/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/internal/OrientRecordStore.java
+++ b/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/internal/OrientRecordStore.java
@@ -1,0 +1,74 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.componentmetadata.internal;
+
+import javax.inject.Inject;
+
+import org.sonatype.nexus.componentmetadata.RecordStore;
+import org.sonatype.nexus.componentmetadata.RecordStoreSession;
+import org.sonatype.nexus.orient.DatabaseManager;
+import org.sonatype.nexus.orient.DatabasePool;
+import org.sonatype.nexus.orient.RecordIdObfuscator;
+import org.sonatype.sisu.goodies.lifecycle.LifecycleSupport;
+
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * OrientDB implementation of {@link RecordStore}.
+ *
+ * @since 3.0
+ */
+public class OrientRecordStore
+    extends LifecycleSupport
+    implements RecordStore
+{
+  public static final String DB_NAME = "componentmd";
+
+  private final DatabaseManager databaseManager;
+
+  private final RecordIdObfuscator recordIdObfuscator;
+
+  private DatabasePool databasePool;
+
+  @Inject
+  public OrientRecordStore(final DatabaseManager databaseManager,
+                           final RecordIdObfuscator recordIdObfuscator) {
+    this.databaseManager = checkNotNull(databaseManager);
+    this.recordIdObfuscator = checkNotNull(recordIdObfuscator);
+  }
+
+  @Override
+  protected void doStart() {
+    // make sure the db exists and init connection pool
+    databaseManager.connect(DB_NAME, true).close();
+    databasePool = databaseManager.pool(DB_NAME);
+  }
+
+  @Override
+  protected void doStop() {
+    databasePool.close();
+    databasePool = null;
+  }
+
+  @Override
+  public RecordStoreSession openSession() {
+    return new OrientRecordStoreSession(openDb(), recordIdObfuscator);
+  }
+
+  protected ODatabaseDocumentTx openDb() {
+    ensureStarted();
+    return databasePool.acquire();
+  }
+}

--- a/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/internal/OrientRecordStoreSchema.java
+++ b/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/internal/OrientRecordStoreSchema.java
@@ -1,0 +1,181 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.componentmetadata.internal;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.sonatype.nexus.componentmetadata.FieldDefinition;
+import org.sonatype.nexus.componentmetadata.RecordType;
+import org.sonatype.nexus.componentmetadata.RecordStoreSchema;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.orientechnologies.orient.core.exception.OSchemaException;
+import com.orientechnologies.orient.core.index.OIndex;
+import com.orientechnologies.orient.core.index.OIndexDefinition;
+import com.orientechnologies.orient.core.metadata.schema.OClass;
+import com.orientechnologies.orient.core.metadata.schema.OClass.INDEX_TYPE;
+import com.orientechnologies.orient.core.metadata.schema.OProperty;
+import com.orientechnologies.orient.core.metadata.schema.OSchema;
+import com.orientechnologies.orient.core.metadata.schema.OType;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * OrientDB implementation of {@link RecordStoreSchema}.
+ *
+ * @since 3.0
+ */
+class OrientRecordStoreSchema
+    implements RecordStoreSchema
+{
+  public static final Map<Class, OType> OTYPES = Maps.newHashMap();
+
+  static {
+    OTYPES.put(BigDecimal.class, OType.DECIMAL);
+    OTYPES.put(Byte.class, OType.BYTE);
+    OTYPES.put(Date.class, OType.DATETIME);
+    OTYPES.put(Double.class, OType.DOUBLE);
+    OTYPES.put(Float.class, OType.FLOAT);
+    OTYPES.put(Integer.class, OType.INTEGER);
+    OTYPES.put(Long.class, OType.LONG);
+    OTYPES.put(Short.class, OType.SHORT);
+    OTYPES.put(String.class, OType.STRING);
+  }
+
+  private final OrientRecordStoreSession session;
+
+  private final OSchema oSchema;
+
+  public OrientRecordStoreSchema(OrientRecordStoreSession session, OSchema oSchema) {
+    this.session = checkNotNull(session);
+    this.oSchema = checkNotNull(oSchema);
+  }
+
+  @Override
+  public boolean addType(final RecordType type) {
+    session.checkOpen();
+    checkTypes(checkNotNull(type));
+
+    if (!oSchema.existsClass(type.getName())) {
+      OClass oClass;
+      if (type.isAbstract()) {
+        oClass = oSchema.createAbstractClass(type.getName());
+      }
+      else {
+        oClass = oSchema.createClass(type.getName());
+      }
+      for (FieldDefinition field : type) {
+        createProperty(oClass, field);
+      }
+      oClass.setStrictMode(type.isStrict());
+      RecordType superType = type.getSuperType();
+      if (superType != null) {
+        OClass oSuperClass = oSchema.getClass(superType.getName());
+        checkState(oSuperClass != null,
+            "Supertype of %s does not exist yet: %s", type.getName(), superType.getName());
+        oClass.setSuperClass(oSuperClass);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public RecordType getType(final String name) {
+    session.checkOpen();
+    checkArgument(hasType(checkNotNull(name)), "No such type: %s", name);
+
+    return getRecordType(oSchema.getClass(name));
+  }
+
+  @Override
+  public boolean hasType(final String name) {
+    session.checkOpen();
+
+    return oSchema.existsClass(checkNotNull(name));
+  }
+
+  @Override
+  public void dropType(final String name) {
+    session.checkOpen();
+    checkArgument(hasType(checkNotNull(name)), "No such type: %s", name);
+
+    session.execute(String.format("DELETE FROM %s", name));
+    try {
+      oSchema.dropClass(name);
+    }
+    catch (OSchemaException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Override
+  public Iterator<RecordType> iterator() {
+    session.checkOpen();
+
+    List<RecordType> types = Lists.newArrayList();
+    for (OClass oClass : oSchema.getClasses()) {
+      types.add(getRecordType(oClass));
+    }
+    return types.iterator();
+  }
+
+  private void createProperty(OClass oClass, FieldDefinition field) {
+    OProperty oProperty = oClass.createProperty(field.getName(), OTYPES.get(field.getType()));
+    if (field.isNotNull()) {
+      oProperty.setNotNull(true);
+      oProperty.setMandatory(true);
+    }
+    if (field.isIndexed()) {
+      final String indexName = String.format("%s.%s", oClass.getName(), field.getName());
+      oClass.createIndex(indexName, field.isUnique() ? INDEX_TYPE.UNIQUE : INDEX_TYPE.NOTUNIQUE, field.getName());
+    }
+  }
+
+  private static RecordType getRecordType(OClass oClass) {
+    RecordType type = new RecordType(oClass.getName());
+    for (OProperty oProperty : oClass.properties()) {
+      OType oType = oProperty.getType();
+      FieldDefinition field = new FieldDefinition(oProperty.getName(), oType.getDefaultJavaType());
+      field.withNotNull(oProperty.isNotNull());
+      for (OIndex oIndex : oProperty.getAllIndexes()) {
+        OIndexDefinition def = oIndex.getDefinition();
+        if (def.isAutomatic() && def.getFields().size() == 1) {
+          boolean unique = oIndex.getType().equalsIgnoreCase(INDEX_TYPE.UNIQUE.name());
+          field.withIndexed(true).withUnique(unique);
+        }
+      }
+      type.withField(field);
+    }
+    type.withStrict(oClass.isStrictMode());
+    OClass oSuperClass = oClass.getSuperClass();
+    if (oSuperClass != null) {
+      type.withSuperType(getRecordType(oSuperClass));
+    }
+    type.withAbstract(oClass.isAbstract());
+    return type;
+  }
+
+  private static void checkTypes(RecordType type) {
+    for (FieldDefinition field : type) {
+      checkArgument(OTYPES.containsKey(field.getType()), "Unsupported field type: %s", field.getType());
+    }
+  }
+}

--- a/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/internal/OrientRecordStoreSession.java
+++ b/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/internal/OrientRecordStoreSession.java
@@ -1,0 +1,186 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.componentmetadata.internal;
+
+import java.util.List;
+
+import org.sonatype.nexus.componentmetadata.Record;
+import org.sonatype.nexus.componentmetadata.RecordId;
+import org.sonatype.nexus.componentmetadata.RecordQuery;
+import org.sonatype.nexus.componentmetadata.RecordStoreSchema;
+import org.sonatype.nexus.componentmetadata.RecordStoreSession;
+import org.sonatype.nexus.componentmetadata.RecordType;
+import org.sonatype.nexus.orient.RecordIdObfuscator;
+
+import com.google.common.collect.Lists;
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import com.orientechnologies.orient.core.exception.OSchemaException;
+import com.orientechnologies.orient.core.id.ORID;
+import com.orientechnologies.orient.core.metadata.schema.OClass;
+import com.orientechnologies.orient.core.metadata.schema.OSchema;
+import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.sql.OCommandSQL;
+import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * OrientDB implementation of {@link RecordStoreSession}.
+ *
+ * @since 3.0
+ */
+class OrientRecordStoreSession
+    implements RecordStoreSession
+{
+  private final ODatabaseDocumentTx db;
+
+  private final RecordIdObfuscator recordIdObfuscator;
+
+  private final OSchema oSchema;
+
+  private final RecordStoreSchema schema;
+
+  private boolean closed;
+
+  public OrientRecordStoreSession(final ODatabaseDocumentTx db,
+                                  final RecordIdObfuscator recordIdObfuscator) {
+    this.db = db;
+    this.recordIdObfuscator = recordIdObfuscator;
+    this.oSchema = db.getMetadata().getSchema();
+    this.schema = new OrientRecordStoreSchema(this, oSchema);
+  }
+
+  @Override
+  public RecordStoreSchema getSchema() {
+    return schema;
+  }
+
+  @Override
+  public Record create(final RecordType type) {
+    checkOpen();
+    checkType(type);
+
+    try {
+      ODocument document = db.newInstance(type.getName());
+      return new OrientRecord(this, type, document);
+    }
+    catch (OSchemaException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  @Override
+  public Record get(final RecordId recordId) {
+    checkOpen();
+    checkNotNull(recordId);
+    OClass oClass = checkOrientClass(recordId.getTypeName());
+
+    ODocument document = db.load(recordIdObfuscator.decode(oClass, recordId.getValue()));
+    if (document == null) {
+      return null;
+    }
+    return getRecord(document);
+  }
+
+  @Override
+  public List<Record> find(final RecordQuery query)
+  {
+    checkOpen();
+    checkNotNull(query);
+    checkType(query.getType());
+
+    String queryText = new OrientQueryBuilder(
+        query,
+        checkOrientClass(query.getType().getName()),
+        recordIdObfuscator)
+            .build();
+    List<ODocument> documents = db.query(new OSQLSynchQuery<ODocument>(queryText), query.getFilter());
+    List<Record> records = Lists.newArrayListWithCapacity(documents.size());
+    for (ODocument document : documents) {
+      records.add(new OrientRecord(this, query.getType(), document));
+    }
+    return records;
+  }
+
+  @Override
+  public long count(final RecordQuery query) {
+    checkOpen();
+    checkNotNull(query);
+    checkType(query.getType());
+
+    if (query.getFilter().isEmpty()) {
+      return db.countClass(query.getType().getName());
+    }
+
+    String queryText = new OrientQueryBuilder(
+        query,
+        checkOrientClass(query.getType().getName()),
+        recordIdObfuscator)
+            .withCount(true)
+            .build();
+    List<ODocument> results = db.query(new OSQLSynchQuery<>(queryText), query.getFilter());
+    return results.get(0).field("COUNT");
+  }
+
+  @Override
+  public void delete(final Record record) {
+    checkOpen();
+
+    db.delete(getRid(record.getId()));
+  }
+
+  @Override
+  public void close() {
+    db.close();
+    closed = true;
+  }
+
+  protected void execute(String sql) {
+    db.command(new OCommandSQL(sql)).execute();
+  }
+
+  protected void checkOpen() {
+    checkState(!closed, "Session is closed");
+  }
+
+  protected ORID getRid(RecordId recordId) {
+    return recordIdObfuscator.decode(checkOrientClass(recordId.getTypeName()), (recordId.getValue()));
+  }
+
+  protected RecordId getRecordId(OClass oClass, ORID rid) {
+    return new RecordId(oClass.getName(), recordIdObfuscator.encode(oClass, rid));
+  }
+
+  protected Record getRecord(ODocument document) {
+    RecordType type = schema.getType(document.getClassName());
+    checkArgument(type != null, "Class is not registered: %s", document.getClassName());
+    return new OrientRecord(this, type, document);
+  }
+
+  private OClass checkOrientClass(String name) {
+    OClass oClass = oSchema.getClass(name);
+    checkArgument(oClass != null, "No such Orient class: %s", name);
+    return oClass;
+  }
+
+  private RecordType checkType(RecordType type) {
+    checkNotNull(type);
+    checkArgument(schema.hasType(type.getName()), "No such type in schema: %s", type.getName());
+    checkArgument(schema.getType(type.getName()).equals(type),
+        "A different definition for that type exists in the schema. Existing: %s, Given: %s",
+        schema.getType(type.getName()), type);
+    return type;
+  }
+}

--- a/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/internal/package-info.java
+++ b/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/internal/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+/**
+ * Implementation details.
+ *
+ * @since 3.0
+ */
+package org.sonatype.nexus.componentmetadata.internal;

--- a/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/package-info.java
+++ b/components/nexus-componentmetadata/src/main/java/org/sonatype/nexus/componentmetadata/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+/**
+ * The component metadata api.
+ *
+ * @since 3.0
+ */
+package org.sonatype.nexus.componentmetadata;

--- a/components/nexus-componentmetadata/src/test/java/org/sonatype/nexus/componentmetadata/RecordQueryTest.java
+++ b/components/nexus-componentmetadata/src/test/java/org/sonatype/nexus/componentmetadata/RecordQueryTest.java
@@ -1,0 +1,173 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.componentmetadata;
+
+import org.sonatype.sisu.litmus.testsupport.TestSupport;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class RecordQueryTest
+    extends TestSupport
+{
+  private final RecordType goodType = new RecordType("Test");
+
+  private final String goodKey = "key";
+
+  private final String goodValue = "value";
+
+  private final int goodSkip = 1;
+
+  private final RecordId goodSkipRecord = new RecordId("Test", "skipRecord");
+
+  private final String goodOrderBy = "orderBy";
+
+  private final int goodLimit = 2;
+
+  // ctor/getType
+
+  @Test(expected = NullPointerException.class)
+  public void typeBadNull() {
+    new RecordQuery(null);
+  }
+
+  @Test
+  public void typeGood() {
+    assertThat(new RecordQuery(goodType).getType(), is(goodType));
+  }
+
+  // withEqual/getFilter
+
+  @Test(expected = NullPointerException.class)
+  public void equalBadKeyNull() {
+    new RecordQuery(goodType).withEqual(null, goodValue);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void equalBadKeyEmpty() {
+    new RecordQuery(goodType).withEqual("", goodValue);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void equalBadValueNull() {
+    new RecordQuery(goodType).withEqual(goodKey, null);
+  }
+
+  @Test
+  public void equalGood() {
+    RecordQuery query = new RecordQuery(goodType);
+    assertThat(query.getFilter().size(), is(0));
+
+    query.withEqual(goodKey, goodValue);
+    assertThat(query.getFilter().size(), is(1));
+    assertThat(query.getFilter().get(goodKey), is((Object) goodValue));
+  }
+
+  // withSkip/getSkip
+
+  @Test(expected = NullPointerException.class)
+  public void skipBadNull() {
+    new RecordQuery(goodType).withSkip(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void skipBadNegative() {
+    new RecordQuery(goodType).withSkip(-1);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void skipBadSkipRecordSpecified() {
+    new RecordQuery(goodType).withSkipRecord(goodSkipRecord).withSkip(goodSkip);
+  }
+
+  @Test
+  public void skipGood() {
+    assertThat(new RecordQuery(goodType).getSkip(), nullValue());
+    assertThat(new RecordQuery(goodType).withSkip(goodSkip).getSkip(), is(goodSkip));
+  }
+
+  // withSkipRecord/getSkipRecord
+
+  @Test(expected = NullPointerException.class)
+  public void skipRecordBadNull() {
+    new RecordQuery(goodType).withSkipRecord(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void skipRecordBadSkipSpecified() {
+    new RecordQuery(goodType).withSkip(goodSkip).withSkipRecord(goodSkipRecord);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void skipRecordBadOrderBySpecified() {
+    new RecordQuery(goodType).withOrderBy(goodOrderBy).withSkipRecord(goodSkipRecord);
+  }
+
+  @Test
+  public void skipRecordGood() {
+    assertThat(new RecordQuery(goodType).getSkipRecord(), is(nullValue()));
+    assertThat(new RecordQuery(goodType).withSkipRecord(goodSkipRecord).getSkipRecord(), is(goodSkipRecord));
+  }
+
+  // withOrderBy/getOrderBy
+
+  @Test(expected = NullPointerException.class)
+  public void orderByBadNull() {
+    new RecordQuery(goodType).withOrderBy(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void orderByBadEmpty() {
+    new RecordQuery(goodType).withOrderBy("");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void orderByBadSkipRecordSpecified() {
+    new RecordQuery(goodType).withSkipRecord(goodSkipRecord).withOrderBy(goodOrderBy);
+  }
+
+  @Test
+  public void orderByGood() {
+    assertThat(new RecordQuery(goodType).getOrderBy(), is(nullValue()));
+    assertThat(new RecordQuery(goodType).withOrderBy(goodOrderBy).getOrderBy(), is(goodOrderBy));
+  }
+
+  // withLimit/getLimit
+
+  @Test(expected = NullPointerException.class)
+  public void limitBadNull() {
+    new RecordQuery(goodType).withLimit(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void limitBadNonPositive() {
+    new RecordQuery(goodType).withLimit(0);
+  }
+
+  @Test
+  public void limitGood() {
+    assertThat(new RecordQuery(goodType).getLimit(), is(nullValue()));
+    assertThat(new RecordQuery(goodType).withLimit(goodLimit).getLimit(), is(goodLimit));
+  }
+
+  // withDescending/isDescending
+
+  @Test
+  public void withDescendingGood() {
+    assertThat(new RecordQuery(goodType).isDescending(), is(false));
+    assertThat(new RecordQuery(goodType).withDescending(true).isDescending(), is(true));
+  }
+}

--- a/components/nexus-componentmetadata/src/test/java/org/sonatype/nexus/componentmetadata/internal/OrientQueryBuilderTest.java
+++ b/components/nexus-componentmetadata/src/test/java/org/sonatype/nexus/componentmetadata/internal/OrientQueryBuilderTest.java
@@ -1,0 +1,159 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.componentmetadata.internal;
+
+import org.sonatype.nexus.componentmetadata.RecordId;
+import org.sonatype.nexus.componentmetadata.RecordQuery;
+import org.sonatype.nexus.componentmetadata.RecordType;
+import org.sonatype.nexus.orient.RecordIdObfuscator;
+import org.sonatype.sisu.litmus.testsupport.TestSupport;
+
+import com.orientechnologies.orient.core.id.ORID;
+import com.orientechnologies.orient.core.id.ORecordId;
+import com.orientechnologies.orient.core.metadata.schema.OClass;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class OrientQueryBuilderTest
+    extends TestSupport
+{
+  private final String typeName = "Test";
+
+  private final RecordType goodType = new RecordType(typeName);
+
+  private final String fakeRidString = "#11:34";
+
+  private final ORID fakeRid = new ORecordId(fakeRidString);
+
+  private RecordIdObfuscator recordIdObfuscator;
+
+  private OClass oClass;
+
+  private RecordQuery goodQuery;
+
+  @Before
+  public void setup() {
+    recordIdObfuscator = mock(RecordIdObfuscator.class);
+    when(recordIdObfuscator.encode(any(OClass.class), any(ORID.class))).thenReturn(fakeRidString);
+    when(recordIdObfuscator.decode(any(OClass.class), any(String.class))).thenReturn(new ORecordId(fakeRidString));
+
+    oClass = mock(OClass.class);
+    goodQuery = new RecordQuery(goodType);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void badQueryNull() {
+    new OrientQueryBuilder(null, oClass, recordIdObfuscator);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void badOrientClassNull() {
+    new OrientQueryBuilder(goodQuery, null, recordIdObfuscator);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void badIdObfuscatorNull() {
+    new OrientQueryBuilder(goodQuery, oClass, null);
+  }
+
+  @Test
+  public void buildGoodQuery() {
+    OrientQueryBuilder builder = goodBuilderWith(goodQuery);
+    assertThat(builder.build(), is("SELECT FROM Test"));
+  }
+
+  @Test
+  public void buildGoodQueryWithCount() {
+    OrientQueryBuilder builder = goodBuilderWith(goodQuery);
+    assertThat(builder.withCount(true).build(), is("SELECT COUNT(*) FROM Test"));
+  }
+
+  @Test
+  public void buildGoodQueryWithEqualOne() {
+    OrientQueryBuilder builder = goodBuilderWith(goodQuery
+        .withEqual("arg1", "val1"));
+    assertThat(builder.build(), is("SELECT FROM Test WHERE arg1 = :arg1"));
+  }
+
+  @Test
+  public void buildGoodQueryWithEqualOneAndSkipRecord() {
+    final RecordId skipRecord = new RecordId(typeName, recordIdObfuscator.encode(oClass, fakeRid));
+    OrientQueryBuilder builder = goodBuilderWith(goodQuery
+        .withEqual("arg1", "val1")
+        .withSkipRecord(skipRecord));
+    assertThat(builder.build(), is("SELECT FROM Test WHERE @rid > #11:34 AND arg1 = :arg1"));
+  }
+
+  @Test
+  public void buildGoodQueryWithEqualTwo() {
+    OrientQueryBuilder builder = goodBuilderWith(goodQuery
+        .withEqual("arg1", "val1")
+        .withEqual("arg2", "val2"));
+    assertThat(builder.build(), is("SELECT FROM Test WHERE arg1 = :arg1 AND arg2 = :arg2"));
+  }
+
+  @Test
+  public void buildGoodQueryWithSkip() {
+    OrientQueryBuilder builder = goodBuilderWith(goodQuery
+        .withSkip(1));
+    assertThat(builder.build(), is("SELECT FROM Test SKIP 1"));
+  }
+
+  @Test
+  public void buildGoodQueryWithSkipRecord() {
+    final ORID rid = new ORecordId("#11:34");
+    final RecordId skipRecord = new RecordId(typeName, recordIdObfuscator.encode(oClass, rid));
+    OrientQueryBuilder builder = goodBuilderWith(goodQuery
+        .withSkipRecord(skipRecord));
+    assertThat(builder.build(), is("SELECT FROM Test WHERE @rid > #11:34"));
+  }
+
+  @Test
+  public void buildGoodQueryWithOrderBy() {
+    OrientQueryBuilder builder = goodBuilderWith(goodQuery
+        .withOrderBy("orderBy"));
+    assertThat(builder.build(), is("SELECT FROM Test ORDER BY orderBy"));
+  }
+
+  @Test
+  public void buildGoodQueryWithOrderByAndDescending() {
+    OrientQueryBuilder builder = goodBuilderWith(goodQuery
+        .withOrderBy("orderBy")
+        .withDescending(true));
+    assertThat(builder.build(), is("SELECT FROM Test ORDER BY orderBy DESC"));
+  }
+
+  @Test
+  public void buildGoodQueryWithLimit() {
+    OrientQueryBuilder builder = goodBuilderWith(goodQuery
+        .withLimit(2));
+    assertThat(builder.build(), is("SELECT FROM Test LIMIT 2"));
+  }
+
+  @Test
+  public void buildGoodQueryWithDescending() {
+    OrientQueryBuilder builder = goodBuilderWith(goodQuery
+        .withDescending(true));
+    assertThat(builder.build(), is("SELECT FROM Test"));
+  }
+
+  private OrientQueryBuilder goodBuilderWith(RecordQuery query) {
+    return new OrientQueryBuilder(query, oClass, recordIdObfuscator);
+  }
+}

--- a/components/nexus-componentmetadata/src/test/java/org/sonatype/nexus/componentmetadata/internal/OrientRecordStoreCrudIT.java
+++ b/components/nexus-componentmetadata/src/test/java/org/sonatype/nexus/componentmetadata/internal/OrientRecordStoreCrudIT.java
@@ -1,0 +1,298 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.componentmetadata.internal;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+import org.sonatype.nexus.componentmetadata.Record;
+import org.sonatype.nexus.componentmetadata.RecordType;
+import org.sonatype.nexus.componentmetadata.RecordId;
+import org.sonatype.nexus.componentmetadata.RecordStoreSession;
+import org.sonatype.nexus.componentmetadata.RecordVersion;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.fail;
+
+public class OrientRecordStoreCrudIT
+    extends OrientRecordStoreITSupport
+{
+  // create
+
+  @Test(expected = IllegalStateException.class)
+  public void createBadSessionClosed() {
+    RecordStoreSession session = store.openSession();
+    session.getSchema().addType(RC_GOOD_EMPTY);
+    session.close();
+    session.create(RC_GOOD_EMPTY);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void createBadClassNull() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.create(null);
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void createBadClassNotFound() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.create(RC_GOOD_EMPTY);
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void createBadClassAbstract() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().addType(RC_GOOD_SUPERTYPE);
+      session.create(RC_GOOD_SUPERTYPE);
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void createBadClassDifferentDefinition() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().addType(RC_GOOD_EMPTY);
+      session.create(new RecordType(RC_GOOD_EMPTY.getName()).withStrict(true));
+    }
+  }
+
+  @Test
+  public void createSaveGetModifyGetDelete() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().addType(RC_GOOD_EMPTY);
+
+      // create a simple record first so we can point to it
+      Record otherRecord = session.create(RC_GOOD_EMPTY);
+      otherRecord.set("name", "other");
+      otherRecord.save();
+
+      Record record = session.create(RC_GOOD_EMPTY);
+
+      // check initial state of record
+      assertThat(record.getType(), is(RC_GOOD_EMPTY));
+      assertThat(record.isPersistent(), is(false));
+      assertGetIdThrowsIllegalStateException(record);
+      assertGetVersionThrowsIllegalStateException(record);
+      assertThat(record.has("recordField"), is(false));
+      assertThat(record.has("recordIdField"), is(false));
+      assertThat(record.has("bigDecimalField"), is(false));
+      assertThat(record.has("byteField"), is(false));
+      assertThat(record.has("dateField"), is(false));
+      assertThat(record.has("doubleField"), is(false));
+      assertThat(record.has("floatField"), is(false));
+      assertThat(record.has("integerField"), is(false));
+      assertThat(record.has("longField"), is(false));
+      assertThat(record.has("shortField"), is(false));
+      assertThat(record.has("stringField"), is(false));
+      assertGetRecordThrowsNullPointerException(record, "recordField");
+      assertGetThrowsNullPointerException(record, "bigDecimalField");
+      assertGetThrowsNullPointerException(record, "byteField");
+      assertGetThrowsNullPointerException(record, "dateField");
+      assertGetThrowsNullPointerException(record, "doubleField");
+      assertGetThrowsNullPointerException(record, "floatField");
+      assertGetThrowsNullPointerException(record, "integerField");
+      assertGetThrowsNullPointerException(record, "longField");
+      assertGetThrowsNullPointerException(record, "shortField");
+      assertGetThrowsNullPointerException(record, "stringField");
+      assertThat(record.keySet().size(), is(0));
+
+      // add fields, but don't save yet
+      record.set("recordField", otherRecord);
+      record.set("recordIdField", otherRecord.getId());
+      record.set("bigDecimalField", bigDecimalValue);
+      record.set("byteField", byteValue);
+      record.set("dateField", dateValue);
+      record.set("doubleField", doubleValue);
+      record.set("floatField", floatValue);
+      record.set("integerField", integerValue);
+      record.set("longField", longValue);
+      record.set("shortField", shortValue);
+      record.set("stringField", stringValue);
+
+      // check state again before saving
+      assertThat(record.getType(), is(RC_GOOD_EMPTY));
+      assertThat(record.isPersistent(), is(false));
+      assertGetIdThrowsIllegalStateException(record);
+      assertGetVersionThrowsIllegalStateException(record);
+      assertThat(record.has("recordField"), is(true));
+      assertThat(record.has("recordIdField"), is(true));
+      assertThat(record.has("bigDecimalField"), is(true));
+      assertThat(record.has("byteField"), is(true));
+      assertThat(record.has("dateField"), is(true));
+      assertThat(record.has("doubleField"), is(true));
+      assertThat(record.has("floatField"), is(true));
+      assertThat(record.has("integerField"), is(true));
+      assertThat(record.has("longField"), is(true));
+      assertThat(record.has("shortField"), is(true));
+      assertThat(record.has("stringField"), is(true));
+      assertThat(record.getRecord("recordField"), is(otherRecord));
+      assertThat((BigDecimal) record.get("bigDecimalField"), is(bigDecimalValue));
+      assertThat((Byte) record.get("byteField"), is(byteValue));
+      assertThat((Date) record.get("dateField"), is(dateValue));
+      assertThat((Double) record.get("doubleField"), is(doubleValue));
+      assertThat((Float) record.get("floatField"), is(floatValue));
+      assertThat((Integer) record.get("integerField"), is(integerValue));
+      assertThat((Long) record.get("longField"), is(longValue));
+      assertThat((Short) record.get("shortField"), is(shortValue));
+      assertThat((String) record.get("stringField"), is(stringValue));
+      assertThat(record.keySet().size(), is(11));
+
+      // save, then check state again (same as before, but isPersistent is true and id and version are defined)
+      record.save();
+      assertThat(record.getType(), is(RC_GOOD_EMPTY));
+      assertThat(record.isPersistent(), is(true));
+      assertThat(record.getId().getValue().length() > 0, is(true));
+      assertThat(record.getVersion().getValue().length() > 0, is(true));
+      assertThat(record.has("recordField"), is(true));
+      assertThat(record.has("recordIdField"), is(true));
+      assertThat(record.has("bigDecimalField"), is(true));
+      assertThat(record.has("byteField"), is(true));
+      assertThat(record.has("dateField"), is(true));
+      assertThat(record.has("doubleField"), is(true));
+      assertThat(record.has("floatField"), is(true));
+      assertThat(record.has("integerField"), is(true));
+      assertThat(record.has("longField"), is(true));
+      assertThat(record.has("shortField"), is(true));
+      assertThat(record.has("stringField"), is(true));
+      assertThat(record.getRecord("recordField"), is(otherRecord));
+      assertThat((BigDecimal) record.get("bigDecimalField"), is(bigDecimalValue));
+      assertThat((Byte) record.get("byteField"), is(byteValue));
+      assertThat((Date) record.get("dateField"), is(dateValue));
+      assertThat((Double) record.get("doubleField"), is(doubleValue));
+      assertThat((Float) record.get("floatField"), is(floatValue));
+      assertThat((Integer) record.get("integerField"), is(integerValue));
+      assertThat((Long) record.get("longField"), is(longValue));
+      assertThat((Short) record.get("shortField"), is(shortValue));
+      assertThat((String) record.get("stringField"), is(stringValue));
+      assertThat(record.keySet().size(), is(11));
+
+      // get, then check state again (same as before)
+      RecordId id = record.getId();
+      RecordVersion version = record.getVersion();
+      record = session.get(id);
+      if (record == null) {
+        fail("Record not found");
+      }
+      assertThat(record.getType(), is(RC_GOOD_EMPTY));
+      assertThat(record.isPersistent(), is(true));
+      assertThat(record.getId(), is(id));
+      assertThat(record.getVersion(), is(version));
+      assertThat(record.has("recordField"), is(true));
+      assertThat(record.has("recordIdField"), is(true));
+      assertThat(record.has("bigDecimalField"), is(true));
+      assertThat(record.has("byteField"), is(true));
+      assertThat(record.has("dateField"), is(true));
+      assertThat(record.has("doubleField"), is(true));
+      assertThat(record.has("floatField"), is(true));
+      assertThat(record.has("integerField"), is(true));
+      assertThat(record.has("longField"), is(true));
+      assertThat(record.has("shortField"), is(true));
+      assertThat(record.has("stringField"), is(true));
+      assertThat(record.getRecord("recordField"), is(otherRecord));
+      assertThat((BigDecimal) record.get("bigDecimalField"), is(bigDecimalValue));
+      assertThat((Byte) record.get("byteField"), is(byteValue));
+      assertThat((Date) record.get("dateField"), is(dateValue));
+      assertThat((Double) record.get("doubleField"), is(doubleValue));
+      assertThat((Float) record.get("floatField"), is(floatValue));
+      assertThat((Integer) record.get("integerField"), is(integerValue));
+      assertThat((Long) record.get("longField"), is(longValue));
+      assertThat((Short) record.get("shortField"), is(shortValue));
+      assertThat((String) record.get("stringField"), is(stringValue));
+      assertThat(record.keySet().size(), is(11));
+
+      // modify, save, get, then check state (same as before, but different version and stringValue)
+      record.set("stringField", "newStringValue");
+      record.save();
+      record = session.get(id);
+      if (record == null) {
+        fail("Record not found");
+      }
+      assertThat(record.getType(), is(RC_GOOD_EMPTY));
+      assertThat(record.isPersistent(), is(true));
+      assertThat(record.getId(), is(id));
+      assertThat(record.getVersion(), not(is(version)));
+      assertThat(record.has("recordField"), is(true));
+      assertThat(record.has("recordIdField"), is(true));
+      assertThat(record.has("bigDecimalField"), is(true));
+      assertThat(record.has("byteField"), is(true));
+      assertThat(record.has("dateField"), is(true));
+      assertThat(record.has("doubleField"), is(true));
+      assertThat(record.has("floatField"), is(true));
+      assertThat(record.has("integerField"), is(true));
+      assertThat(record.has("longField"), is(true));
+      assertThat(record.has("shortField"), is(true));
+      assertThat(record.has("stringField"), is(true));
+      assertThat(record.getRecord("recordField"), is(otherRecord));
+      assertThat((BigDecimal) record.get("bigDecimalField"), is(bigDecimalValue));
+      assertThat((Byte) record.get("byteField"), is(byteValue));
+      assertThat((Date) record.get("dateField"), is(dateValue));
+      assertThat((Double) record.get("doubleField"), is(doubleValue));
+      assertThat((Float) record.get("floatField"), is(floatValue));
+      assertThat((Integer) record.get("integerField"), is(integerValue));
+      assertThat((Long) record.get("longField"), is(longValue));
+      assertThat((Short) record.get("shortField"), is(shortValue));
+      assertThat((String) record.get("stringField"), is("newStringValue"));
+      assertThat(record.keySet().size(), is(11));
+
+      // delete then get
+      session.delete(record);
+      assertThat(session.get(id), is(nullValue()));
+    }
+  }
+
+  private static void assertGetIdThrowsIllegalStateException(Record record) {
+    try {
+      record.getId();
+      fail("Expected IllegalStateException");
+    }
+    catch (IllegalStateException e) {
+      // expected
+    }
+  }
+
+  private static void assertGetVersionThrowsIllegalStateException(Record record) {
+    try {
+      record.getVersion();
+      fail("Expected IllegalStateException");
+    }
+    catch (IllegalStateException e) {
+      // expected
+    }
+  }
+
+  private static void assertGetThrowsNullPointerException(Record record, String key) {
+    try {
+      record.get(key);
+      fail("Expected NullPointerException");
+    }
+    catch (NullPointerException e) {
+      // expected
+    }
+  }
+
+  private static void assertGetRecordThrowsNullPointerException(Record record, String key) {
+    try {
+      record.getRecord(key);
+      fail("Expected NullPointerException");
+    }
+    catch (NullPointerException e) {
+      // expected
+    }
+  }
+}

--- a/components/nexus-componentmetadata/src/test/java/org/sonatype/nexus/componentmetadata/internal/OrientRecordStoreITSupport.java
+++ b/components/nexus-componentmetadata/src/test/java/org/sonatype/nexus/componentmetadata/internal/OrientRecordStoreITSupport.java
@@ -1,0 +1,138 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.componentmetadata.internal;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+import org.sonatype.nexus.componentmetadata.FieldDefinition;
+import org.sonatype.nexus.componentmetadata.RecordStoreSchema;
+import org.sonatype.nexus.componentmetadata.RecordStoreSession;
+import org.sonatype.nexus.componentmetadata.RecordType;
+import org.sonatype.nexus.internal.orient.DatabaseManagerSupport;
+import org.sonatype.nexus.internal.orient.HexRecordIdObfuscator;
+import org.sonatype.nexus.internal.orient.MemoryDatabaseManager;
+import org.sonatype.nexus.orient.DatabaseManager;
+import org.sonatype.sisu.litmus.testsupport.TestSupport;
+
+import com.orientechnologies.common.log.OLogManager;
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+public class OrientRecordStoreITSupport
+    extends TestSupport
+{
+  protected static final BigDecimal bigDecimalValue = new BigDecimal(1);
+  protected static final Byte byteValue = Byte.MAX_VALUE;
+  protected static final Date dateValue = new Date(42);
+  protected static final Double doubleValue = Double.MAX_VALUE;
+  protected static final Float floatValue = Float.MAX_VALUE;
+  protected static final Integer integerValue = Integer.MAX_VALUE;
+  protected static final Long longValue = Long.MAX_VALUE;
+  protected static final Short shortValue = Short.MAX_VALUE;
+  protected static final String stringValue = "stringValue";
+
+  protected OrientRecordStore store;
+
+  protected RecordType RC_GOOD_EMPTY = new RecordType("GoodEmpty");
+
+  protected RecordType RC_GOOD_SUPERTYPE = new RecordType("GoodSuperclass").withAbstract(true);
+
+  protected RecordType RC_GOOD_SUBTYPE = new RecordType("GoodSubclass").withSuperType(RC_GOOD_SUPERTYPE);
+
+  protected RecordType RC_GOOD_ALLFIELDTYPES = new RecordType("GoodAllFieldTypes")
+      .withField(new FieldDefinition("bigDecimalField", BigDecimal.class))
+      .withField(new FieldDefinition("byteField", Byte.class))
+      .withField(new FieldDefinition("dateField", Date.class))
+      .withField(new FieldDefinition("doubleField", Double.class))
+      .withField(new FieldDefinition("floatField", Float.class))
+      .withField(new FieldDefinition("integerField", Integer.class)
+          .withNotNull(true)
+          .withIndexed(true)
+          .withUnique(true))
+      .withField(new FieldDefinition("longField", Long.class))
+      .withField(new FieldDefinition("shortField", Short.class))
+      .withField(new FieldDefinition("stringField", String.class));
+
+  protected RecordType RC_BAD_FIELDTYPE = new RecordType("BadFieldType")
+      .withField(new FieldDefinition("fieldName", Object.class));
+
+
+  @BeforeClass
+  public static void setUpClass() {
+    OLogManager.instance().setWarnEnabled(false);
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    DatabaseManager databaseManager = new MemoryDatabaseManager();
+
+    // uncomment to use a pre-existing db named 'test' listening on localhost
+    //databaseManager = new LocalTestDatabaseManager();
+
+    // initialize store
+    store = new OrientRecordStore(databaseManager, new HexRecordIdObfuscator());
+    store.start();
+
+    // drop all test classes
+    try (RecordStoreSession session = store.openSession()) {
+      RecordStoreSchema schema = session.getSchema();
+      // drop all non-built-in classes that have superclasses
+      for (RecordType type : schema) {
+        if (!isBuiltInClass(type.getName()) && type.getSuperType() != null) {
+          schema.dropType(type.getName());
+        }
+      }
+      // drop all remaining non-built-in classes
+      for (RecordType type : schema) {
+        if (!isBuiltInClass(type.getName())) {
+          schema.dropType(type.getName());
+        }
+      }
+    }
+  }
+
+  private static boolean isBuiltInClass(String name) {
+    if (name.length() == 1) {
+      return name.equals("V") || name.equals("E");
+    }
+    if (name.startsWith("O")) {
+      String secondCharacter = name.substring(1, 1);
+      return secondCharacter.toUpperCase().equals(secondCharacter);
+    }
+    return false;
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    store.stop();
+  }
+
+  private static class LocalTestDatabaseManager
+      extends DatabaseManagerSupport {
+
+    private static final String URI = "remote:localhost/test";
+
+    @Override
+    protected String connectionUri(final String name) {
+      return URI;
+    }
+
+    @Override
+    public ODatabaseDocumentTx connect(final String name, final boolean create) {
+      return new ODatabaseDocumentTx(URI);
+    }
+  }
+}

--- a/components/nexus-componentmetadata/src/test/java/org/sonatype/nexus/componentmetadata/internal/OrientRecordStoreQueryIT.java
+++ b/components/nexus-componentmetadata/src/test/java/org/sonatype/nexus/componentmetadata/internal/OrientRecordStoreQueryIT.java
@@ -1,0 +1,154 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.componentmetadata.internal;
+
+import java.util.List;
+
+import org.sonatype.nexus.componentmetadata.Record;
+import org.sonatype.nexus.componentmetadata.RecordType;
+import org.sonatype.nexus.componentmetadata.RecordQuery;
+import org.sonatype.nexus.componentmetadata.RecordStoreSession;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class OrientRecordStoreQueryIT
+    extends OrientRecordStoreITSupport
+{
+  // find
+
+  @Test(expected = IllegalStateException.class)
+  public void findBadSessionClosed() {
+    RecordStoreSession session = store.openSession();
+    session.getSchema().addType(RC_GOOD_EMPTY);
+    session.close();
+    session.find(new RecordQuery(RC_GOOD_EMPTY));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void findBadQueryNull() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().addType(RC_GOOD_EMPTY);
+      session.find(null);
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void findBadClassNotFound() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.find(new RecordQuery(RC_GOOD_EMPTY));
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void findBadClassDifferentDefinition() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().addType(RC_GOOD_EMPTY);
+      session.find(new RecordQuery(new RecordType(RC_GOOD_EMPTY.getName()).withStrict(true)));
+    }
+  }
+
+  @Test
+  public void findGoodNoFilter() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().addType(RC_GOOD_EMPTY);
+      Record record = session.create(RC_GOOD_EMPTY).set("stringField", stringValue).save();
+      List<Record> result = session.find(new RecordQuery(RC_GOOD_EMPTY));
+      assertThat(result.size(), is(1));
+      assertThat(result.get(0), is(record));
+    }
+  }
+
+  @Test
+  public void findGoodWithFilterMatching() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().addType(RC_GOOD_EMPTY);
+      Record record = session.create(RC_GOOD_EMPTY).set("stringField", stringValue).save();
+      List<Record> result = session.find(new RecordQuery(RC_GOOD_EMPTY).withEqual("stringField", stringValue));
+      assertThat(result.size(), is(1));
+      assertThat(result.get(0), is(record));
+    }
+  }
+
+  @Test
+  public void findGoodWithFilterNotMatching() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().addType(RC_GOOD_EMPTY);
+      Record record = session.create(RC_GOOD_EMPTY).set("stringField", stringValue).save();
+      List<Record> result = session.find(new RecordQuery(RC_GOOD_EMPTY).withEqual("stringField", "not " + stringValue));
+      assertThat(result.size(), is(0));
+    }
+  }
+
+  // count
+
+  @Test(expected = IllegalStateException.class)
+  public void countBadSessionClosed() {
+    RecordStoreSession session = store.openSession();
+    session.getSchema().addType(RC_GOOD_EMPTY);
+    session.close();
+    session.find(new RecordQuery(RC_GOOD_EMPTY));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void countBadQueryNull() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().addType(RC_GOOD_EMPTY);
+      session.find(null);
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void countBadClassNotFound() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.find(new RecordQuery(RC_GOOD_EMPTY));
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void countBadClassDifferentDefinition() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().addType(RC_GOOD_EMPTY);
+      session.find(new RecordQuery(new RecordType(RC_GOOD_EMPTY.getName()).withStrict(true)));
+    }
+  }
+
+  @Test
+  public void countGoodNoFilter() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().addType(RC_GOOD_EMPTY);
+      Record record = session.create(RC_GOOD_EMPTY).set("stringField", stringValue).save();
+      assertThat(session.count(new RecordQuery(RC_GOOD_EMPTY)), is(1L));
+    }
+  }
+
+  @Test
+  public void countGoodWithFilterMatching() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().addType(RC_GOOD_EMPTY);
+      Record record = session.create(RC_GOOD_EMPTY).set("stringField", stringValue).save();
+      assertThat(session.count(new RecordQuery(RC_GOOD_EMPTY).withEqual("stringField", stringValue)), is(1L));
+    }
+  }
+
+  @Test
+  public void countGoodWithFilterNotMatching() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().addType(RC_GOOD_EMPTY);
+      Record record = session.create(RC_GOOD_EMPTY).set("stringField", stringValue).save();
+      assertThat(session.count(new RecordQuery(RC_GOOD_EMPTY).withEqual("stringField", "not " + stringValue)), is(0L));
+    }
+  }
+}

--- a/components/nexus-componentmetadata/src/test/java/org/sonatype/nexus/componentmetadata/internal/OrientRecordStoreSchemaIT.java
+++ b/components/nexus-componentmetadata/src/test/java/org/sonatype/nexus/componentmetadata/internal/OrientRecordStoreSchemaIT.java
@@ -1,0 +1,189 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.componentmetadata.internal;
+
+import org.sonatype.nexus.componentmetadata.RecordStoreSchema;
+import org.sonatype.nexus.componentmetadata.RecordStoreSession;
+
+import com.google.common.collect.Sets;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class OrientRecordStoreSchemaIT
+    extends OrientRecordStoreITSupport
+{
+  // addType
+
+  @Test(expected = IllegalStateException.class)
+  public void addTypeBadSessionClosed() {
+    RecordStoreSession session = store.openSession();
+    RecordStoreSchema schema = session.getSchema();
+    session.close();
+    schema.addType(RC_GOOD_EMPTY);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void addTypeBadClassNull() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().addType(null);
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void addTypeBadFieldType() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().addType(RC_BAD_FIELDTYPE);
+    }
+  }
+
+  // addType+hasType+getType+dropType+iterate
+
+  @Test
+  public void addTypeWithAllFieldTypesHasClassGetClassDropClassIterate() {
+    try (RecordStoreSession session = store.openSession()) {
+      RecordStoreSchema schema = session.getSchema();
+      int origCount = Sets.newHashSet(schema).size();
+      assertThat(Sets.newHashSet(schema).contains(RC_GOOD_ALLFIELDTYPES), is(false));
+
+      assertThat(schema.addType(RC_GOOD_ALLFIELDTYPES), is(true));
+      assertThat(schema.hasType(RC_GOOD_ALLFIELDTYPES.getName()), is(true));
+      assertThat(schema.getType(RC_GOOD_ALLFIELDTYPES.getName()), is(RC_GOOD_ALLFIELDTYPES));
+      assertThat(Sets.newHashSet(schema).contains(RC_GOOD_ALLFIELDTYPES), is(true));
+      assertThat(Sets.newHashSet(schema).size(), is(origCount + 1));
+
+      schema.dropType(RC_GOOD_ALLFIELDTYPES.getName());
+      assertThat(schema.hasType(RC_GOOD_ALLFIELDTYPES.getName()), is(false));
+      assertThat(Sets.newHashSet(schema).contains(RC_GOOD_ALLFIELDTYPES), is(false));
+      assertThat(Sets.newHashSet(schema).size(), is(origCount));
+    }
+  }
+
+  @Test
+  public void addSimpleClassTwice() {
+    try (RecordStoreSession session = store.openSession()) {
+      RecordStoreSchema schema = session.getSchema();
+      int origCount = Sets.newHashSet(schema).size();
+      assertThat(schema.addType(RC_GOOD_EMPTY), is(true));
+      assertThat(Sets.newHashSet(schema).size(), is(origCount + 1));
+      assertThat(schema.addType(RC_GOOD_EMPTY), is(false));
+      assertThat(Sets.newHashSet(schema).size(), is(origCount + 1));
+    }
+  }
+
+  @Test
+  public void addSubclassGetSubclassDropSubclass() {
+    try (RecordStoreSession session = store.openSession()) {
+      RecordStoreSchema schema = session.getSchema();
+      int origCount = Sets.newHashSet(schema).size();
+      assertThat(schema.addType(RC_GOOD_SUPERTYPE), is(true));
+      assertThat(schema.addType(RC_GOOD_SUBTYPE), is(true));
+      assertThat(Sets.newHashSet(schema).size(), is(origCount + 2));
+
+      assertThat(schema.getType(RC_GOOD_SUBTYPE.getName()), is(RC_GOOD_SUBTYPE));
+
+      schema.dropType(RC_GOOD_SUBTYPE.getName());
+      assertThat(Sets.newHashSet(schema).size(), is(origCount + 1));
+    }
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void addSubclassBadMissingSuperclass() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().addType(RC_GOOD_SUBTYPE);
+    }
+  }
+
+  // getType
+
+  @Test(expected = IllegalStateException.class)
+  public void getTypeBadSessionClosed() {
+    RecordStoreSession session = store.openSession();
+    RecordStoreSchema schema = session.getSchema();
+    session.close();
+    schema.getType(RC_GOOD_EMPTY.getName());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void getTypeBadNull() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().getType(null);
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void getTypeBadMissing() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().getType(RC_GOOD_EMPTY.getName());
+    }
+  }
+
+  // hasType
+
+  @Test(expected = IllegalStateException.class)
+  public void hasTypeBadSessionClosed() {
+    RecordStoreSession session = store.openSession();
+    RecordStoreSchema schema = session.getSchema();
+    session.close();
+    schema.hasType(RC_GOOD_EMPTY.getName());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void hasTypeBadNull() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().hasType(null);
+    }
+  }
+
+  @Test
+  public void hasTypeFalse() {
+    try (RecordStoreSession session = store.openSession()) {
+      assertThat(session.getSchema().hasType(RC_GOOD_EMPTY.getName()), is(false));
+    }
+  }
+
+  // dropType
+
+  @Test(expected = IllegalStateException.class)
+  public void dropTypeBadSessionClosed() {
+    RecordStoreSession session = store.openSession();
+    RecordStoreSchema schema = session.getSchema();
+    session.close();
+    schema.hasType(RC_GOOD_EMPTY.getName());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void dropTypeBadNull() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().dropType(null);
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void dropTypeBadMissing() {
+    try (RecordStoreSession session = store.openSession()) {
+      session.getSchema().dropType(RC_GOOD_EMPTY.getName());
+    }
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void dropSuperclassBadSubclassExists() {
+    try (RecordStoreSession session = store.openSession()) {
+      RecordStoreSchema schema = session.getSchema();
+      schema.addType(RC_GOOD_SUPERTYPE);
+      schema.addType(RC_GOOD_SUBTYPE);
+      schema.dropType(RC_GOOD_SUPERTYPE.getName());
+    }
+  }
+}

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -34,6 +34,7 @@
     <module>nexus-blobstore-file</module>
     <module>nexus-bootstrap</module>
     <module>nexus-client-core</module>
+    <module>nexus-componentmetadata</module>
     <module>nexus-configuration-model</module>
     <module>nexus-core</module>
     <module>nexus-ehcache</module>

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,12 @@
 
       <dependency>
         <groupId>org.sonatype.nexus</groupId>
+        <artifactId>nexus-componentmetadata</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.sonatype.nexus</groupId>
         <artifactId>nexus-configuration-model</artifactId>
         <version>3.0.0-SNAPSHOT</version>
       </dependency>


### PR DESCRIPTION
Re-defining component metadata based on move to orientdb and feedback from POC PR #579

NOTE: This is now based on Orient's document API

https://issues.sonatype.org/browse/NX-538
