### PR TITLE
REVIEW [2.9] NEXUS-6666: Download indexes task should not process out of service reposes

### DIFF
--- a/plugins/indexer/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexerManager.java
+++ b/plugins/indexer/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexerManager.java
@@ -1136,7 +1136,7 @@ public class DefaultIndexerManager
   {
     TaskUtil.checkInterruption();
 
-    if (!INDEXABLE(repository) || !ISPROXY(repository)) {
+    if (!INDEXABLE(repository) || !INSERVICE(repository) || !ISPROXY(repository)) {
       return;
     }
 


### PR DESCRIPTION
Download indexes task should not process out of service repositories.

Issue
https://issues.sonatype.org/browse/NEXUS-6666

CI
http://bamboo.s/browse/NX-OSSF149
