### PR TITLE
REVIEW NEXUS-6692: Remote URL Validation

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/storage/remote/AbstractHTTPRemoteRepositoryStorage.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/storage/remote/AbstractHTTPRemoteRepositoryStorage.java
@@ -12,8 +12,8 @@
  */
 package org.sonatype.nexus.proxy.storage.remote;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import javax.inject.Provider;
 
@@ -64,14 +64,14 @@ public abstract class AbstractHTTPRemoteRepositoryStorage
       throws RemoteStorageException
   {
     try {
-      URL u = new URL(url);
+      URI u = new URI(url);
 
-      if (!"http".equals(u.getProtocol().toLowerCase()) && !"https".equals(u.getProtocol().toLowerCase())) {
+      if (!"http".equals(u.getScheme().toLowerCase()) && !"https".equals(u.getScheme().toLowerCase())) {
         throw new RemoteStorageException("Unsupported protocol, only HTTP/HTTPS protocols are supported: "
-            + u.getProtocol().toLowerCase());
+            + u.getScheme().toLowerCase());
       }
     }
-    catch (MalformedURLException e) {
+    catch (URISyntaxException e) {
       throw new RemoteStorageException("Malformed URL", e);
     }
   }


### PR DESCRIPTION
Ancient code doing proxy repository URL validation is not sufficient. Especially as RRS powered by HttpClient 4.x uses java.net.URI too, and hence will choke on bad URLs not caught by core validation.

Issue
https://issues.sonatype.org/browse/NEXUS-6692

CI
http://bamboo.s/browse/NX-OSSF154
