### PR TITLE
POC: defer Jetty activation

### DIFF
--- a/components/nexus-bootstrap/src/main/java/org/sonatype/nexus/bootstrap/Launcher.java
+++ b/components/nexus-bootstrap/src/main/java/org/sonatype/nexus/bootstrap/Launcher.java
@@ -147,10 +147,18 @@ public class Launcher
   }
 
   public void start() throws Exception {
+    start(true);
+  }
+
+  public void startAsync() throws Exception {
+    start(false);
+  }
+
+  private void start(boolean waitForServer) throws Exception {
     maybeEnableCommandMonitor();
     maybeEnableShutdownIfNotAlive();
 
-    server.start();
+    server.start(waitForServer);
   }
 
   private String getProperty(final String name, final String defaultValue) {

--- a/components/nexus-bootstrap/src/main/java/org/sonatype/nexus/bootstrap/osgi/BootstrapListener.java
+++ b/components/nexus-bootstrap/src/main/java/org/sonatype/nexus/bootstrap/osgi/BootstrapListener.java
@@ -132,11 +132,8 @@ public class BootstrapListener
       filterTracker = new FilterTracker(bundleContext, "nexus");
       filterTracker.open();
 
-      if (containingBundle == null) {
-        // wait for embedded framework
-        listenerTracker.waitForService(0);
-        filterTracker.waitForService(0);
-      }
+      listenerTracker.waitForService(0);
+      filterTracker.waitForService(0);
     }
     catch (Exception e) {
       log.error("Failed to start Nexus", e);

--- a/components/nexus-bootstrap/src/main/java/org/sonatype/nexus/bootstrap/osgi/DelegatingFilter.java
+++ b/components/nexus-bootstrap/src/main/java/org/sonatype/nexus/bootstrap/osgi/DelegatingFilter.java
@@ -20,6 +20,7 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * Filter that delegates to a cached (static) instance populated by {@link FilterTracker}.
@@ -70,6 +71,12 @@ public final class DelegatingFilter
     Filter filter = delegate;
     if (filter != null) {
       filter.doFilter(request, response, chain);
+    }
+    else if (response instanceof HttpServletResponse) {
+      ((HttpServletResponse) response).setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+    }
+    else {
+      chain.doFilter(request, response);
     }
   }
 

--- a/components/nexus-bootstrap/src/main/java/org/sonatype/nexus/bootstrap/osgi/LauncherActivator.java
+++ b/components/nexus-bootstrap/src/main/java/org/sonatype/nexus/bootstrap/osgi/LauncherActivator.java
@@ -36,12 +36,14 @@ public class LauncherActivator
 
     MDC.put("userId", SYSTEM_USERID);
     server = new Launcher(basePath, null, null, args.split(","));
-    server.start();
+    server.startAsync();
   }
 
   public void stop(BundleContext bundleContext) throws Exception {
     try {
-      server.stop();
+      if (server != null) {
+        server.stop();
+      }
     }
     finally {
       server = null;


### PR DESCRIPTION
Currently on master Jetty will finish bootstrapping and use a placeholder (that just serves empty content) while Nexus finishes its initialisation (at which point the web context will delegate to the newly registered services). This loose-coupling lets us manage Jetty and Nexus separately rather than as a monolithic application, but it does means that port 8081 is visible before Nexus is fully initialised.

It's important to note that none of Nexus internal components are actually reachable via that connection until Nexus has fully initialised (ditto for the shutdown case). Despite this, people may still prefer Jetty to only make the 8081 port available when the service is actually ready to handle requests.

This can be achieved by deferring Jetty activation until Nexus is ready. This PR launches Jetty in async mode rather than synchronously on the OSGi activation thread. This means we can then wait for the internal Nexus services to be ready in the BootstrapListener without blocking activation of other bundle activators.

http://bamboo.s/browse/NX-OSSF161-2 :white_check_mark: 

WDYT?
