### PR TITLE
REVIEW NEXUS-6692:  Fix url validation and error handling

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/configuration/application/DefaultNexusConfiguration.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/configuration/application/DefaultNexusConfiguration.java
@@ -78,13 +78,14 @@ import org.sonatype.security.usermanagement.xml.SecurityXmlUserManager;
 import org.sonatype.sisu.goodies.common.ComponentSupport;
 import org.sonatype.sisu.goodies.eventbus.EventBus;
 
+import com.google.common.base.Throwables;
+
 import com.google.common.base.Function;
 import com.google.common.base.Strings;
 import com.google.common.collect.Collections2;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.subject.Subject;
-
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -664,6 +665,7 @@ public class DefaultNexusConfiguration
       return instantiateRepository(configuration, klazz, repositoryModel.getProviderHint(), repositoryModel);
     }
     catch (Exception e) {
+      Throwables.propagateIfInstanceOf(e, ConfigurationException.class);
       throw new ConfigurationException("Cannot instantiate repository " + repositoryModel.getProviderRole() + ":"
           + repositoryModel.getProviderHint(), e);
     }

--- a/plugins/basic/nexus-ui-extjs3-plugin/src/main/resources/static/js/repoServer/RepoEditPanel.js
+++ b/plugins/basic/nexus-ui-extjs3-plugin/src/main/resources/static/js/repoServer/RepoEditPanel.js
@@ -15,7 +15,7 @@
  */
 
 define('repoServer/RepoEditPanel',['Sonatype/all', 'Sonatype/strings'], function(Sonatype, Strings){
-var REPO_REMOTE_STORAGE_REGEXP = /^(?:http|https|ftp):\/\//i;
+var REPO_REMOTE_STORAGE_REGEXP = /^(((https?)|(ftps?)):\/\/((\w)+(\.|\-|\w)*(:[0-9]{1,5})?)(\/(\.|\-|\w)*)*\/(\.|\-|\w)*$)/i;
 
 Sonatype.repoServer.AbstractRepositoryEditor = function(config) {
   var config = config || {};

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/ext/form/field/Url.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/ext/form/field/Url.js
@@ -22,7 +22,7 @@ Ext.define('NX.ext.form.field.Url', {
   // NOTE: The default 'url' vtype uses nearly same pattern, but misses ending $ which allows invalid urls like "http://foo.bar /"
   // FIXME: Figure out how to properly override Ext.form.field.VTypes.url with this fix and let vtype: 'url' work w/o this customization
 
-  urlRegEx: /(((^https?)|(^ftp)):\/\/((([\-\w]+\.)+\w{1,3}(\/[%\-\w]+(\.\w{1,})?)*(([\w\-\.\?\\\/+@&#;`~=%!]*)(\.\w{1,})?)*)|(localhost|LOCALHOST))\/?$)/i,
+  urlRegEx: /^(((https?)|(ftps?)):\/\/((\w)+(\.|\-|\w)*(:[0-9]{1,5})?)(\/(\.|\-|\w)*)*\/(\.|\-|\w)*$)/i,
 
   validator: function (value) {
     if (this.urlRegEx.test(value)) {

--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryPlexusResource.java
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryPlexusResource.java
@@ -25,9 +25,14 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 
 import org.sonatype.configuration.ConfigurationException;
+import org.sonatype.configuration.validation.InvalidConfigurationException;
+import org.sonatype.configuration.validation.ValidationMessage;
+import org.sonatype.configuration.validation.ValidationResponse;
 import org.sonatype.nexus.configuration.application.RepositoryDependentException;
+import org.sonatype.nexus.configuration.validator.ApplicationValidationResponse;
 import org.sonatype.nexus.proxy.AccessDeniedException;
 import org.sonatype.nexus.proxy.NoSuchRepositoryException;
+import org.sonatype.nexus.proxy.RemoteStorageException;
 import org.sonatype.nexus.proxy.StorageException;
 import org.sonatype.nexus.proxy.maven.ChecksumPolicy;
 import org.sonatype.nexus.proxy.maven.MavenProxyRepository;
@@ -178,7 +183,15 @@ public class RepositoryPlexusResource
             if (repository.getRepositoryKind().isFacetAvailable(ProxyRepository.class)) {
               ProxyRepository proxyRepo = repository.adaptToFacet(ProxyRepository.class);
 
-              proxyRepo.setRemoteUrl(model.getRemoteStorage().getRemoteStorageUrl());
+              try {
+                proxyRepo.setRemoteUrl(model.getRemoteStorage().getRemoteStorageUrl());
+              }
+              catch (RemoteStorageException e) {
+                ValidationResponse vr = new ApplicationValidationResponse();
+                ValidationMessage error = new ValidationMessage("remoteStorageUrl", e.getMessage(), e.getMessage());
+                vr.addValidationError(error);
+                throw new InvalidConfigurationException(vr);
+              }
               String oldPasswordForRemoteStorage = null;
               if (proxyRepo.getRemoteAuthenticationSettings() != null
                   && UsernamePasswordRemoteAuthenticationSettings.class.isInstance(proxyRepo


### PR DESCRIPTION
Changes:
- the regex was too strict, not allowing port numbers nor localhost with paths
- on repo creation, the validation error was swallowed (wrapped into another config ex)
- on repo update the validation was not handled resulting in generic config error
- aligned regex in legacy and rapture UI

Issue
https://issues.sonatype.org/browse/NEXUS-6692

CI
http://bamboo.s/browse/NX-OSSF164
