### PR TITLE
REVIEW: [NX-610] Make https://repo1.maven.org/maven2/ the default URL for central

### DIFF
--- a/components/nexus-oss-edition/src/main/filtered-resources/META-INF/nexus/nexus.xml
+++ b/components/nexus-oss-edition/src/main/filtered-resources/META-INF/nexus/nexus.xml
@@ -48,7 +48,7 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <url>http://repo1.maven.org/maven2/</url>
+        <url>https://repo1.maven.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
         <proxyMode>ALLOW</proxyMode>


### PR DESCRIPTION
https://issues.sonatype.org/browse/NX-610
