### PR TITLE
REVIEW: Remove "Enterprise" word from LDAP plugin

### DIFF
--- a/plugins/security/nexus-ldap-plugin/pom.xml
+++ b/plugins/security/nexus-ldap-plugin/pom.xml
@@ -27,7 +27,7 @@
   <packaging>bundle</packaging>
 
   <properties>
-    <pluginName>Nexus Enterprise LDAP Plugin</pluginName>
+    <pluginName>Nexus LDAP Plugin</pluginName>
     <pluginDescription>Adds an LDAP realm to Nexus.</pluginDescription>
   </properties>
 

--- a/plugins/security/nexus-ldap-plugin/src/main/java/com/sonatype/security/ldap/realms/EnterpriseLdapAuthenticatingRealm.java
+++ b/plugins/security/nexus-ldap-plugin/src/main/java/com/sonatype/security/ldap/realms/EnterpriseLdapAuthenticatingRealm.java
@@ -26,7 +26,7 @@ import org.eclipse.sisu.Description;
 
 @Named(LdapPlugin.REALM_NAME)
 @Singleton
-@Description("Enterprise LDAP Authentication Realm")
+@Description("LDAP Authentication Realm")
 public class EnterpriseLdapAuthenticatingRealm
     extends AbstractLdapAuthenticatingRealm
 {

--- a/plugins/security/nexus-ldap-plugin/src/main/resources/META-INF/security/nexus-ldap-plugin-security.xml
+++ b/plugins/security/nexus-ldap-plugin/src/main/resources/META-INF/security/nexus-ldap-plugin-security.xml
@@ -18,7 +18,7 @@
     <roles>
         <role>
             <id>ui-enterprise-ldap-admin</id>
-            <name>UI: Enterprise LDAP Administrator</name>
+            <name>UI: LDAP Administrator</name>
             <description>Gives access to create and edit LDAP Servers.</description>
             <sessionTimeout>60</sessionTimeout>
             <privileges>
@@ -35,7 +35,7 @@
         <privilege>
             <id>enterprise-ldap-create</id>
             <type>method</type>
-            <name>LDAP Enterprise (create,read)</name>
+            <name>LDAP (create,read)</name>
             <description>Give permission to create new LDAP Servers.</description>
             <properties>
                 <property>
@@ -51,7 +51,7 @@
         <privilege>
             <id>enterprise-ldap-read</id>
             <type>method</type>
-            <name>LDAP Enterprise (read)</name>
+            <name>LDAP (read)</name>
             <description>Give permission to read LDAP Server configurations.</description>
             <properties>
                 <property>
@@ -67,7 +67,7 @@
         <privilege>
             <id>enterprise-ldap-update</id>
             <type>method</type>
-            <name>LDAP Enterprise (update,read)</name>
+            <name>LDAP (update,read)</name>
             <description>Give permission to update LDAP Server configurations.</description>
             <properties>
                 <property>
@@ -83,7 +83,7 @@
         <privilege>
             <id>enterprise-ldap-delete</id>
             <type>method</type>
-            <name>LDAP Enterprise (delete,read)</name>
+            <name>LDAP (delete,read)</name>
             <description>Give permission to delete LDAP Servers.</description>
             <properties>
                 <property>

--- a/plugins/security/nexus-ldap-plugin/src/main/resources/com/sonatype/nexus/ldap/internal/ssl/ssl.key.ldap-about.vm
+++ b/plugins/security/nexus-ldap-plugin/src/main/resources/com/sonatype/nexus/ldap/internal/ssl/ssl.key.ldap-about.vm
@@ -13,5 +13,5 @@
 Enables usage of Nexus SSL Trust Store per LDAP server.
 <br/>
 <br/>
-<span style="font-weight: bold;">This capability is managed by Enterprise LDAP / SSL tab and is not meant to be created manually!</span>
+<span style="font-weight: bold;">This capability is managed by LDAP / SSL tab and is not meant to be created manually!</span>
 <br/>


### PR DESCRIPTION
Removed from:
- plugin name 
- description shown in realms configuration
- rights/privileges name
