### PR TITLE
REVIEW [NX-485] minor Jersey-related upgrades...

### DIFF
--- a/buildsupport/rest/pom.xml
+++ b/buildsupport/rest/pom.xml
@@ -30,8 +30,8 @@
   <properties>
     <siesta1.version>1.7</siesta1.version>
     <siesta2.version>2.0.1</siesta2.version>
-    <jersey1.version>1.17.1</jersey1.version>
-    <jackson2.version>2.3.3</jackson2.version>
+    <jersey1.version>1.18.1</jersey1.version>
+    <jackson2.version>2.4.1</jackson2.version>
   </properties>
 
   <dependencyManagement>
@@ -164,6 +164,24 @@
       <!--
       Siesta 1.x (for legacy REST client based on Jersey 1.x)
       -->
+
+      <dependency>
+        <groupId>com.sun.jersey</groupId>
+        <artifactId>jersey-client</artifactId>
+        <version>${jersey1.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.sun.jersey</groupId>
+        <artifactId>jersey-core</artifactId>
+        <version>${jersey1.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.sun.jersey.contribs</groupId>
+        <artifactId>jersey-apache-client4</artifactId>
+        <version>${jersey1.version}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.sonatype.sisu.siesta</groupId>


### PR DESCRIPTION
...to make versions consistent between analytics (which uses Jersey 1.18.1, aligned with DropWizard) and siesta 1.x client (which used Jersey 1.17.1). Also bumped jackson2 up to 2.4.1 so it depends on the same version of Joda as used in nexus-core. Otherwise was running into some OSGi resolution issues because previous version of jackson2 specifically declared it was only compatible with Joda 2.1 and not 2.2.

https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.4

http://bamboo.s/browse/NX-OSSF200-1
