### PR TITLE
REVIEW: remove snappy

### DIFF
--- a/assemblies/nexus-base-template/pom.xml
+++ b/assemblies/nexus-base-template/pom.xml
@@ -332,7 +332,7 @@
                   <fileset refid="mvn:com.google.code.findbugs:jsr305:jar"/>
                 </copy>
                 <replace file="${project.build.directory}/assembly/etc/config.properties"
-                  token="packages.extra=" value="packages.extra=sun.misc,com.sun.net.httpserver,javax.annotation.security;version=1.2," />
+                  token="packages.extra=" value="packages.extra=sun.misc,com.sun.net.httpserver,javax.annotation.security;version=1.2,org.xerial.snappy," />
                 <replace file="${project.build.directory}/assembly/etc/org.apache.karaf.features.cfg">
                   <!-- trim out various enterprise/deployment features we don't need at the moment -->
                   <replacefilter token=",mvn:org.apache.karaf.features/enterprise/3.0.1/xml/features" />

--- a/buildsupport/db/pom.xml
+++ b/buildsupport/db/pom.xml
@@ -46,12 +46,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.xerial.snappy</groupId>
-        <artifactId>snappy-java</artifactId>
-        <version>1.1.1.3</version>
-      </dependency>
-
-      <dependency>
         <groupId>com.orientechnologies</groupId>
         <artifactId>orient-commons</artifactId>
         <version>${orientdb.version}</version>
@@ -61,6 +55,12 @@
         <groupId>com.orientechnologies</groupId>
         <artifactId>orientdb-core</artifactId>
         <version>${orientdb.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/internal/orient/DatabaseServerImpl.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/internal/orient/DatabaseServerImpl.java
@@ -144,6 +144,10 @@ public class DatabaseServerImpl
     config.security.users = Lists.newArrayList();
     config.security.resources = Lists.newArrayList();
 
+    // latest advice is to disable DB compression as it doesn't buy much,
+    // also snappy has issues with use of native lib (unpacked under tmp)
+    OGlobalConfiguration.STORAGE_COMPRESSION_METHOD.setValue("nothing");
+
     return config;
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -863,6 +863,11 @@
                     <exclude>org.bouncycastle:*-jdk15:*</exclude>
                     <exclude>bouncycastle:*-jdk14:*</exclude>
                     <exclude>bouncycastle:*-jdk15:*</exclude>
+
+                    <!--
+                    Ban snappy-java as there are lingering issues on OSGi when restarting.
+                    -->
+                    <exclude>org.xerial.snappy:snappy-java:*</exclude>
                   </excludes>
 
                   <!--


### PR DESCRIPTION
as it can have issues with unpacking/deleting of native lib under tmp when restarting, instead set OrientDB compression to 'nothing' based on latest advice: http://stackoverflow.com/a/25114789 (this is similar to H2 which turns off compression by default)

http://bamboo.s/browse/NX-OSSF204-2 :white_check_mark: 
