### PR TITLE
REVIEW: upgrade pax-swissbox to 1.7.1

### DIFF
--- a/assemblies/nexus-base-feature/pom.xml
+++ b/assemblies/nexus-base-feature/pom.xml
@@ -33,6 +33,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.ops4j.pax.swissbox</groupId>
+      <artifactId>pax-swissbox-bnd</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.codahale.metrics</groupId>
       <artifactId>metrics-core</artifactId>
     </dependency>

--- a/assemblies/nexus-base-template/pom.xml
+++ b/assemblies/nexus-base-template/pom.xml
@@ -341,8 +341,10 @@
                   <replacefilter token=",kar,ssh,management" />
                   <replacefilter token=",region" />
                 </replace>
-                <replace file="${project.build.directory}/assembly/etc/startup.properties"
-                  token="${mvn:pax-logging-service}" value="${mvn:metrics-core} = 8${line.separator}${mvn:metrics-logback} = 8${line.separator}${mvn:pax-logging-metrics} = 8${line.separator}${mvn:pax-logging-logback}" />
+                <replace file="${project.build.directory}/assembly/etc/startup.properties">
+                  <replacefilter token="${mvn:pax-logging-service}" value="${mvn:metrics-core} = 8${line.separator}${mvn:metrics-logback} = 8${line.separator}${mvn:pax-logging-metrics} = 8${line.separator}${mvn:pax-logging-logback}" />
+                  <replacefilter token="mvn\:org.ops4j.pax.swissbox/pax-swissbox-bnd/1.7.0" value="${mvn:pax-swissbox-bnd}" />
+                </replace>
               </target>
             </configuration>
           </execution>

--- a/assemblies/nexus-base-template/src/main/overlaid-resources/etc/logback.xml
+++ b/assemblies/nexus-base-template/src/main/overlaid-resources/etc/logback.xml
@@ -44,8 +44,6 @@
   <logger name="org.apache.felix" level="WARN"/>
   <logger name="org.apache.karaf" level="WARN"/>
 
-  <logger name="org.ops4j.pax.swissbox.bnd.BndUtils" level="ERROR"/>
-
   <root level="${nexus.log.level:-INFO}">
     <appender-ref ref="osgi"/>
     <appender-ref ref="console"/>

--- a/buildsupport/osgi/pom.xml
+++ b/buildsupport/osgi/pom.xml
@@ -82,6 +82,18 @@
         <type>xml</type>
       </dependency>
 
+      <dependency>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bndlib</artifactId>
+        <version>2.2.0</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.ops4j.pax.swissbox</groupId>
+        <artifactId>pax-swissbox-bnd</artifactId>
+        <version>1.7.1</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
To pick up https://ops4j1.jira.com/browse/PAXSB-75 fix which removes the misleading 'Bundle could not be generated' warning that can occur when a bundle loaded with a wrap: URL has its MANIFEST.MF examined without reading the entire bundle contents.

http://bamboo.s/browse/NX-OSSF205-2 :white_check_mark: 
