### PR TITLE
REVIEW: [NEXUS-6744] disable eviction of bundles when system is shutting down

### DIFF
--- a/components/nexus-extender/src/main/java/org/sonatype/nexus/extender/NexusBundleTracker.java
+++ b/components/nexus-extender/src/main/java/org/sonatype/nexus/extender/NexusBundleTracker.java
@@ -37,8 +37,11 @@ public class NexusBundleTracker
 {
   private static final Logger log = LoggerFactory.getLogger(NexusBundleTracker.class);
 
+  private final Bundle systemBundle;
+
   public NexusBundleTracker(final BundleContext context, final MutableBeanLocator locator) {
     super(context, Bundle.STARTING | Bundle.ACTIVE, locator);
+    systemBundle = context.getBundle(0);
   }
 
   @Override
@@ -67,6 +70,12 @@ public class NexusBundleTracker
       prepareDependencies(bundle);
     }
     return null;
+  }
+
+  @Override
+  protected boolean evictBundle(Bundle bundle) {
+    // when system is shutting down we disable eviction of bundles to keep things stable
+    return super.evictBundle(bundle) && (systemBundle.getState() & Bundle.STOPPING) == 0;
   }
 
   private void prepareDependencies(final Bundle bundle) {


### PR DESCRIPTION
This ensures that those components registered with the system at the time shutdown begins are kept around at least until shutdown is complete. This should make things more stable while still allowing plugins/features to be added and removed while Nexus is still running.

https://issues.sonatype.org/browse/NEXUS-6744
http://bamboo.s/browse/NX-OSSF207-1 :white_check_mark: 
