### PR TITLE
REVIEW: [NX-445] add management feature

### DIFF
--- a/assemblies/nexus-base-template/pom.xml
+++ b/assemblies/nexus-base-template/pom.xml
@@ -345,6 +345,10 @@
                   <replacefilter token="${mvn:pax-logging-service}" value="${mvn:metrics-core} = 8${line.separator}${mvn:metrics-logback} = 8${line.separator}${mvn:pax-logging-metrics} = 8${line.separator}${mvn:pax-logging-logback}" />
                   <replacefilter token="mvn\:org.ops4j.pax.swissbox/pax-swissbox-bnd/1.7.0" value="${mvn:pax-swissbox-bnd}" />
                 </replace>
+                <replace file="${project.build.directory}/assembly/etc/org.apache.karaf.management.cfg">
+                  <replacefilter token="rmiRegistryPort = 1099" value="rmiRegistryPort = 8099" />
+                  <replacefilter token="rmiServerPort = 44444" value="rmiServerPort = 8044" />
+                </replace>
               </target>
             </configuration>
           </execution>
@@ -408,6 +412,9 @@
             <feature>nexus-extdirect-plugin</feature>
             <feature>nexus-coreui-plugin</feature>
 	  </bootFeatures>
+	  <installedFeatures>
+            <feature>management</feature>
+	  </installedFeatures>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
https://issues.sonatype.org/browse/NX-445
http://bamboo.s/browse/NX-OSSF209-1

This PR adds the Karaf management feature to the installation, but does not enable it by default. It also changes the RMI port to avoid potential clashes with other applications that use the default RMI settings.

To use the management feature you need to install it from the Karaf console:

```
feature:install management
```

You should now be able to connect using `jconsole` and this service URL:

```
service:jmx:rmi:///jndi/rmi://localhost:8099/karaf-root
```

Note that Karaf has its own built-in security so you'll also need to give a username and password when connecting (the default admin user is 'karaf', with password 'karaf'). You can change or add users in the `etc/users.properties` configuration file. The local JMX connection unfortunately isn't currently working due to ACL issues, but a fix is being worked on: https://issues.apache.org/jira/browse/KARAF-3147

See http://karaf.apache.org/manual/latest/users-guide/monitoring.html for more details
