### PR TITLE
REVIEW: [NEXUS-6786] Allow exclusion of specific User Agents from browser detection (NX2)

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/web/internal/BrowserDetector.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/web/internal/BrowserDetector.java
@@ -58,17 +58,17 @@ public class BrowserDetector
 
   @Inject
   public BrowserDetector(final @Named("${nexus.browserdetector.disable:-false}") boolean disable,
-                         final @Named("${nexus.browserdetector.exclude}") @Nullable String exclude) {
+                         final @Named("${nexus.browserdetector.excludedUserAgents}") @Nullable String excludedUserAgents) {
     this.disable = disable;
     if (disable) {
       log.info("Browser detector disabled");
     }
 
-    if (exclude != null) {
-      for (String userAgent : Splitter.on(Pattern.compile("\r?\n")).split(exclude)) {
+    if (excludedUserAgents != null) {
+      for (String userAgent : Splitter.on(Pattern.compile("\r?\n")).trimResults().split(excludedUserAgents)) {
         if (userAgent.length() > 0) {
           log.info("Browser detector excluding User-Agent: {}", userAgent);
-          excludedUserAgents.add(userAgent);
+          this.excludedUserAgents.add(userAgent);
         }
       }
     }

--- a/components/nexus-core/src/test/java/org/sonatype/nexus/web/internal/BrowserDetectorTest.java
+++ b/components/nexus-core/src/test/java/org/sonatype/nexus/web/internal/BrowserDetectorTest.java
@@ -73,8 +73,8 @@ public class BrowserDetectorTest
   }
 
   @Test
-  public void firefox_whenMultipleExcluded() {
-    underTest = new BrowserDetector(false, "foo\nbar\nMozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:25.0) Gecko/20100101 Firefox/25.0");
+  public void firefox_whenMultipleExcludedWithExtraWhitespace() {
+    underTest = new BrowserDetector(false, "foo\n Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:25.0) Gecko/20100101 Firefox/25.0 \nbar");
     whenUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:25.0) Gecko/20100101 Firefox/25.0");
     assertThat(underTest.isBrowserInitiated(request), is(false));
   }


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-6786

This allows one to specify one or more specific user agent strings in $NEXUS_HOME/config/nexus.properties (using the property nexus.browserdetector.excludedUserAgents, which is \n delimited) which will be skipped and therefore presumed to be NON-browser user agents for the purpose of browser detection. This will result in Nexus providing the WWW-Authenticate response header with all 401 responses from such UAs.

Here's an example to specify multiple UAs in nexus.properties: (the trailing \ is not required, but allows you to specify one per line in the file, for readability)

nexus.browserdetector.excludedUserAgents=UserAgentString1\n\
    UserAgentString2\n\
    etc..

To test this with your browser, note your browser's User-Agent string and set it as the value of this property, restart nexus, make sure your browser is logged out, and issue an HTTP GET for http://localhost:8081/nexus/service/local  You should get a 401 with a WWW-Authenticate header, causing the browser to launch a basic auth dialog.
