### PR TITLE
REVIEW: [NEXUS-6786] Allow exclusion of specific User Agents from browser detection (NX3)

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/web/internal/BrowserDetector.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/web/internal/BrowserDetector.java
@@ -58,17 +58,17 @@ public class BrowserDetector
 
   @Inject
   public BrowserDetector(final @Named("${nexus.browserdetector.disable:-false}") boolean disable,
-                         final @Named("${nexus.browserdetector.exclude}") @Nullable String exclude) {
+                         final @Named("${nexus.browserdetector.excludedUserAgents}") @Nullable String excludedUserAgents) {
     this.disable = disable;
     if (disable) {
       log.info("Browser detector disabled");
     }
 
-    if (exclude != null) {
-      for (String userAgent : Splitter.on(Pattern.compile("\r?\n")).split(exclude)) {
+    if (excludedUserAgents != null) {
+      for (String userAgent : Splitter.on(Pattern.compile("\r?\n")).trimResults().split(excludedUserAgents)) {
         if (userAgent.length() > 0) {
           log.info("Browser detector excluding User-Agent: {}", userAgent);
-          excludedUserAgents.add(userAgent);
+          this.excludedUserAgents.add(userAgent);
         }
       }
     }

--- a/components/nexus-core/src/test/java/org/sonatype/nexus/web/internal/BrowserDetectorTest.java
+++ b/components/nexus-core/src/test/java/org/sonatype/nexus/web/internal/BrowserDetectorTest.java
@@ -73,8 +73,8 @@ public class BrowserDetectorTest
   }
 
   @Test
-  public void firefox_whenMultipleExcluded() {
-    underTest = new BrowserDetector(false, "foo\nbar\nMozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:25.0) Gecko/20100101 Firefox/25.0");
+  public void firefox_whenMultipleExcludedWithExtraWhitespace() {
+    underTest = new BrowserDetector(false, "foo\n Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:25.0) Gecko/20100101 Firefox/25.0 \nbar");
     whenUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:25.0) Gecko/20100101 Firefox/25.0");
     assertThat(underTest.isBrowserInitiated(request), is(false));
   }


### PR DESCRIPTION
Same change as PR #693, but for Nexus 3 (master branch).

Note that for NX3, nexus.properties has moved to $NEXUS_HOME/etc/
