### PR TITLE
NEXUS-6763: Per-Request checksum policy override chatty

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/AbstractChecksumContentValidator.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/AbstractChecksumContentValidator.java
@@ -39,15 +39,16 @@ public abstract class AbstractChecksumContentValidator
       throws LocalStorageException
   {
     ChecksumPolicy checksumPolicy = getChecksumPolicy(proxy, item);
-    if (checksumPolicy == null || !checksumPolicy.shouldCheckChecksum()) {
-      return true;
-    }
 
     final ChecksumPolicy requestChecksumPolicy =
         (ChecksumPolicy) req.getRequestContext().get(ChecksumPolicy.REQUEST_CHECKSUM_POLICY_KEY);
     if (requestChecksumPolicy != null) {
       // found, it overrides the repository-set checksum policy then
       checksumPolicy = requestChecksumPolicy;
+    }
+
+    if (checksumPolicy == null || !checksumPolicy.shouldCheckChecksum()) {
+      return true;
     }
 
     RemoteHashResponse remoteHash = retrieveRemoteHash(item, proxy, baseUrl);


### PR DESCRIPTION
As the condition (or the override, as you look at it) was at
wrong place. The code did not expect to start with policy
IGNORE which became possible with the per-request overrides

Ported from
1b28867af208b48137a3cee081c5f9bd3bcfda62

Issue
https://issues.sonatype.org/browse/NEXUS-6763

CI
TBD
