### PR TITLE
REVIEW: [NX-451] first go at a normalized component abstraction

### DIFF
--- a/components/nexus-component-model/pom.xml
+++ b/components/nexus-component-model/pom.xml
@@ -1,0 +1,53 @@
+<!--
+
+    Sonatype Nexus (TM) Open Source Version
+    Copyright (c) 2007-2014 Sonatype, Inc.
+    All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+
+    This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+    which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+
+    Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+    of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+    Eclipse Foundation. All other trademarks are the property of their respective owners.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.sonatype.nexus</groupId>
+    <artifactId>nexus-components</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>nexus-component-model</artifactId>
+  <name>${project.groupId}:${project.artifactId}</name>
+  <packaging>bundle</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-orient</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-componentmetadata</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-test-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/components/nexus-component-model/src/main/java/org/sonatype/nexus/component/model/Asset.java
+++ b/components/nexus-component-model/src/main/java/org/sonatype/nexus/component/model/Asset.java
@@ -1,0 +1,73 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.component.model;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.annotation.Nullable;
+
+import org.sonatype.nexus.componentmetadata.Record;
+
+import org.joda.time.DateTime;
+
+/**
+ * Represents an identifiable asset of a component.
+ * 
+ * @since 3.0
+ */
+public interface Asset
+{
+  /**
+   * @return canonical id of this asset in the component system
+   */
+  AssetId getAssetId();
+
+  /**
+   * @return current metadata record for this asset
+   */
+  Record getMetadata();
+
+  /**
+   * @return relative path to this asset in the containing component
+   */
+  String getPath();
+
+  /**
+   * @return length of this asset in bytes, {@code -1} if unknown
+   */
+  long getContentLength();
+
+  /**
+   * @return content type of this asset, {@code null} if unknown
+   */
+  @Nullable
+  String getContentType();
+
+  /**
+   * @return when this asset was first created, {@code null} if unknown
+   */
+  @Nullable
+  DateTime getFirstCreated();
+
+  /**
+   * @return when this asset was last modified, {@code null} if unknown
+   */
+  @Nullable
+  DateTime getLastModified();
+
+  /**
+   * @return input stream for reading the content of this asset
+   */
+  InputStream openStream() throws IOException;
+}

--- a/components/nexus-component-model/src/main/java/org/sonatype/nexus/component/model/AssetId.java
+++ b/components/nexus-component-model/src/main/java/org/sonatype/nexus/component/model/AssetId.java
@@ -1,0 +1,22 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.component.model;
+
+/**
+ * Opaque {@link Asset} id in the normalized component system.
+ * 
+ * @since 3.0
+ */
+public interface AssetId
+{
+}

--- a/components/nexus-component-model/src/main/java/org/sonatype/nexus/component/model/Component.java
+++ b/components/nexus-component-model/src/main/java/org/sonatype/nexus/component/model/Component.java
@@ -1,0 +1,40 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.component.model;
+
+import java.util.Map;
+
+import org.sonatype.nexus.componentmetadata.Record;
+
+/**
+ * Represents an identifiable component.
+ * 
+ * @since 3.0
+ */
+public interface Component
+{
+  /**
+   * @return canonical id of this component in the component system
+   */
+  ComponentId getComponentId();
+
+  /**
+   * @return current metadata record for this component
+   */
+  Record getMetadata();
+
+  /**
+   * @return assets belonging to this component, by asset path
+   */
+  Map<String, Asset> getAssets();
+}

--- a/components/nexus-component-model/src/main/java/org/sonatype/nexus/component/model/ComponentId.java
+++ b/components/nexus-component-model/src/main/java/org/sonatype/nexus/component/model/ComponentId.java
@@ -1,0 +1,22 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.component.model;
+
+/**
+ * Opaque {@link Component} id in the normalized component system.
+ * 
+ * @since 3.0
+ */
+public interface ComponentId
+{
+}

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -35,6 +35,7 @@
     <module>nexus-bootstrap</module>
     <module>nexus-client-core</module>
     <module>nexus-componentmetadata</module>
+    <module>nexus-component-model</module>
     <module>nexus-configuration-model</module>
     <module>nexus-core</module>
     <module>nexus-ehcache</module>


### PR DESCRIPTION
Highlights:
- Opaque types for component and asset ids to avoid overuse of strings (and limit implicit meaning)
- Components can have zero-to-many assets, which could be part of an overall archive or exploded
- API signature contains `Record` type from `nexus-componentmetadata` for general metadata access
- Module is `components/nexus-componentbase` for now, need to find proper location for these types
- Prefer immutable types without set methods, thinking any modification should go through a service?
  Something like `componentService.addAsset(component, asset);` as it should make managing concurrency easier

https://issues.sonatype.org/browse/NX-451
http://bamboo.s/browse/NX-OSSF249-1 :white_check_mark: 
