### PR TITLE
NEXUS-6836: Bump nexus-client-core XStream version to latest

### DIFF
--- a/buildsupport/rest/pom.xml
+++ b/buildsupport/rest/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.4.5</version>
+        <version>1.4.7</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
As current xstream version has a bug preventing it to work
on Oracle Java8 (XSTR-746) that is fixed in 1.4.6+

Note: nexus-client-core does NOT use the patched xstream with whitelist support.

Issue
https://issues.sonatype.org/browse/NEXUS-6836

CI
TBD
