### PR TITLE
Temporary patch for KARAF-3249

### DIFF
--- a/assemblies/nexus-base-template/pom.xml
+++ b/assemblies/nexus-base-template/pom.xml
@@ -347,6 +347,12 @@
                   </fileset>
                 </delete>
 
+                <!-- temporary patch for KARAF-3249: dirname error if the distribution path contains spaces -->
+                <replace file="${project.build.directory}/assembly/bin/karaf" token='name $0' value='name "$0"'/>
+                <replace file="${project.build.directory}/assembly/bin/start" token='name $0' value='name "$0"'/>
+                <replace file="${project.build.directory}/assembly/bin/status" token='name $0' value='name "$0"'/>
+                <replace file="${project.build.directory}/assembly/bin/stop" token='name $0' value='name "$0"'/>
+
                 <!-- include a few additional extra packages required by our environment -->
                 <replace file="${project.build.directory}/assembly/etc/config.properties"
                   token="packages.extra="

--- a/assemblies/nexus-base-template/src/main/resources/overlay/bin/nexus
+++ b/assemblies/nexus-base-template/src/main/resources/overlay/bin/nexus
@@ -1,6 +1,6 @@
 #!/bin/sh
-DIRNAME=`dirname $0`
-PROGNAME=`basename $0`
+DIRNAME=`dirname "$0"`
+PROGNAME=`basename "$0"`
 
 usage() {
     echo "${PROGNAME} { console | start | stop | restart | status }"
@@ -12,7 +12,7 @@ if [ "x$1" == "x" ]; then
 fi
 
 run() {
-    case $1 in
+    case "$1" in
         'console')
             shift
             exec "${DIRNAME}/karaf" "$@"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KARAF-3249: dirname error if the distribution path contains spaces
