### PR TITLE
refactored dependency related tasks into more OO manner and

### DIFF
--- a/plugins/rubygem/nexus-ruby-plugin/src/main/java/org/sonatype/nexus/plugins/ruby/group/GroupNexusStorage.java
+++ b/plugins/rubygem/nexus-ruby-plugin/src/main/java/org/sonatype/nexus/plugins/ruby/group/GroupNexusStorage.java
@@ -37,6 +37,7 @@ import org.sonatype.nexus.proxy.repository.GroupItemNotFoundException;
 import org.sonatype.nexus.proxy.storage.UnsupportedStorageOperationException;
 import org.sonatype.nexus.ruby.BundlerApiFile;
 import org.sonatype.nexus.ruby.DependencyFile;
+import org.sonatype.nexus.ruby.DependencyHelper;
 import org.sonatype.nexus.ruby.RubygemsFile;
 import org.sonatype.nexus.ruby.RubygemsGateway;
 import org.sonatype.nexus.ruby.SpecsIndexType;
@@ -180,30 +181,22 @@ public class GroupNexusStorage
   private StorageItem merge(DependencyFile file, List<StorageItem> dependencies)
       throws UnsupportedStorageOperationException, IllegalOperationException, IOException
   {
-    List<InputStream> streams = new LinkedList<InputStream>();
-    InputStream content = null;
-    try {
-      for (StorageItem item : dependencies) {
-        streams.add(((StorageFileItem) item).getInputStream());
+    DependencyHelper deps = gateway.newDependencyHelper();
+    for (StorageItem item : dependencies) {
+      try (InputStream is = ((StorageFileItem) item).getInputStream()) {
+        deps.add(is);
       }
-      content = gateway.mergeDependencies(streams, true);
-      ContentLocator cl = new PreparedContentLocator(content,
-          file.type().mime(),
-          PreparedContentLocator.UNKNOWN_LENGTH);
+    }
+    ContentLocator cl = new PreparedContentLocator(deps.getInputStream(true),
+        file.type().mime(),
+        PreparedContentLocator.UNKNOWN_LENGTH);
 
-      DefaultStorageFileItem item =
-          new DefaultStorageFileItem(repository,
-              new ResourceStoreRequest(file.storagePath()),
-              true, true, cl);
-      repository.storeItem(false, item);
-      return item;
-    }
-    finally {
-      IOUtil.close(content);
-      for (InputStream is : streams) {
-        IOUtil.close(is);
-      }
-    }
+    DefaultStorageFileItem item =
+        new DefaultStorageFileItem(repository,
+            new ResourceStoreRequest(file.storagePath()),
+            true, true, cl);
+    repository.storeItem(false, item);
+    return item;
   }
 
   @Override

--- a/plugins/rubygem/nexus-ruby-tools/src/main/java/org/sonatype/nexus/ruby/DefaultRubygemsGateway.java
+++ b/plugins/rubygem/nexus-ruby-tools/src/main/java/org/sonatype/nexus/ruby/DefaultRubygemsGateway.java
@@ -13,9 +13,7 @@
 package org.sonatype.nexus.ruby;
 
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.jruby.embed.PathType;
 import org.jruby.embed.ScriptingContainer;
@@ -52,6 +50,11 @@ public class DefaultRubygemsGateway
   protected Object newScript() {
     IRubyObject nexusRubygemsClass = scriptingContainer.parse(PathType.CLASSPATH, "nexus/rubygems.rb").run();
     return scriptingContainer.callMethod(nexusRubygemsClass, "new", Object.class);
+  }
+
+  @Override
+  public DependencyHelper newDependencyHelper() {
+    return callMethod("new_dependency_helper", DependencyHelper.class);
   }
 
   @Override
@@ -119,54 +122,6 @@ public class DefaultRubygemsGateway
             latest
         },
         List.class);
-
-    return array == null ? null : new ByteArrayInputStream(array);
-  }
-
-  @Override
-  public Map<String, InputStream> splitDependencies(InputStream deps) {
-    @SuppressWarnings("unchecked")
-    Map<String, List<Long>> map = (Map<String, List<Long>>) callMethod("split_dependencies",
-        deps,
-        Map.class);
-
-    Map<String, InputStream> result = new HashMap<>();
-    for (Map.Entry<String, List<Long>> entry : map.entrySet()) {
-      result.put(entry.getKey(), new ByteArrayInputStream(entry.getValue()));
-    }
-    return result;
-  }
-
-  @Override
-  public InputStream mergeDependencies(List<InputStream> deps) {
-    return mergeDependencies(deps, false);
-  }
-
-  @Override
-  public InputStream mergeDependencies(List<InputStream> deps, boolean unique) {
-    Object[] args = new Object[deps.size() + 1];
-    args[0] = unique;
-    int index = 1;
-    for (InputStream is : deps) {
-      args[index++] = is;
-    }
-    @SuppressWarnings("unchecked")
-    List<Long> array = (List<Long>) callMethod("merge_dependencies",
-        args,
-        List.class);
-
-    return array == null ? null : new ByteArrayInputStream(array);
-  }
-
-  @Override
-  public InputStream createDependencies(List<InputStream> gemspecs) {
-    @SuppressWarnings("unchecked")
-    List<Long> array = (List<Long>) (gemspecs.size() == 0 ?
-        callMethod("create_dependencies",
-            List.class) :
-        callMethod("create_dependencies",
-            gemspecs.toArray(),
-            List.class));
 
     return array == null ? null : new ByteArrayInputStream(array);
   }

--- a/plugins/rubygem/nexus-ruby-tools/src/main/java/org/sonatype/nexus/ruby/DependencyHelper.java
+++ b/plugins/rubygem/nexus-ruby-tools/src/main/java/org/sonatype/nexus/ruby/DependencyHelper.java
@@ -1,0 +1,65 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2014 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.ruby;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+/**
+ * helper to collect or merge dependency data from <code>DependencyFile</code>s
+ * or extract the dependency data from a given <code>GemspecFile</code>.
+ * the remote data from <code>BundlerApiFile</code> is collection of the same
+ * dependency data format which can added as well.
+ * 
+ * after adding all the data, you can retrieve the list of gemnames for which
+ * there are dependency data and retrieve them as marshalled stream (same format as
+ * <code>DependencyFile</code> or <code>BundlerApiFile</code>).
+ * 
+ * @author christian
+ *
+ */
+public interface DependencyHelper {
+  
+  /**
+   * add dependency data to instance
+   * @param marshalledDependencyData stream of the marshalled "ruby" data
+   */
+  void add(InputStream marshalledDependencyData);
+  
+  /**
+   * add dependency data to instance from a rzipped gemspec object.
+   * @param marshalledDependencyData rzipped stream of the marshalled gemspec object
+   */
+  void addGemspec(InputStream gemspec);
+
+  /**
+   * freezes the instance - no more added of data is allowed - and returns
+   * the list of gemnames for which dependency data was added.
+   * @return String[] of gemnames
+   */
+  String[] getGemnames();
+  
+  /**
+   * marshal ruby object with dependency data for the given gemname.
+   * @param gemname
+   * @return ByteArrayInputStream of binary data
+   */
+  ByteArrayInputStream getInputStreamOf(String gemname);
+  
+  /**
+   * marshal ruby object with dependency data for all the dependency data,
+   * either with or without duplicates.
+   * @return ByteArrayInputStream of binary data
+   */
+  ByteArrayInputStream getInputStream(boolean unique);
+}

--- a/plugins/rubygem/nexus-ruby-tools/src/main/java/org/sonatype/nexus/ruby/RubygemsGateway.java
+++ b/plugins/rubygem/nexus-ruby-tools/src/main/java/org/sonatype/nexus/ruby/RubygemsGateway.java
@@ -14,7 +14,6 @@ package org.sonatype.nexus.ruby;
 
 import java.io.InputStream;
 import java.util.List;
-import java.util.Map;
 
 public interface RubygemsGateway
 {
@@ -40,14 +39,6 @@ public interface RubygemsGateway
 
   InputStream mergeSpecs(List<InputStream> streams, boolean latest);
 
-  Map<String, InputStream> splitDependencies(InputStream bundlerResult);
-
-  InputStream mergeDependencies(List<InputStream> deps);
-
-  InputStream mergeDependencies(List<InputStream> deps, boolean unique);
-
-  InputStream createDependencies(List<InputStream> gemspecs);
-
   String filename(Object spec);
 
   String name(Object spec);
@@ -55,4 +46,10 @@ public interface RubygemsGateway
   DependencyData dependencies(InputStream inputStream, String name, long modified);
 
   List<String> listAllVersions(String name, InputStream inputStream, long modified, boolean prerelease);
+
+  /**
+   * create a new instance of <code>DependencyHelper</code>
+   * @return an empty DependencyHelper
+   */
+  DependencyHelper newDependencyHelper();
 }

--- a/plugins/rubygem/nexus-ruby-tools/src/main/java/org/sonatype/nexus/ruby/layout/HostedPOSTLayout.java
+++ b/plugins/rubygem/nexus-ruby-tools/src/main/java/org/sonatype/nexus/ruby/layout/HostedPOSTLayout.java
@@ -79,8 +79,9 @@ public class HostedPOSTLayout
           }
           break;
         case API_V1:
-          store.create(store.getInputStream(file),
-              ((ApiV1File) file).gem(filename));
+          try (InputStream is = store.getInputStream(file)) {
+            store.create(is, ((ApiV1File) file).gem(filename));
+          }
           store.delete(file);
           break;
         default:

--- a/plugins/rubygem/nexus-ruby-tools/src/main/resources/nexus/dependency_helper_impl.rb
+++ b/plugins/rubygem/nexus-ruby-tools/src/main/resources/nexus/dependency_helper_impl.rb
@@ -1,0 +1,126 @@
+#
+# Sonatype Nexus (TM) Open Source Version
+# Copyright (c) 2007-2014 Sonatype, Inc.
+# All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+#
+# This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+# which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+#
+# Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+# of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+# Eclipse Foundation. All other trademarks are the property of their respective owners.
+#
+require 'nexus/rubygems_helper'
+
+java_import org.sonatype.nexus.ruby.DependencyHelper
+
+# this class can collect dependency data (which are an array of hashes).
+# the collected data can be added as either marshaled stream of dependency
+# data or marshaled stream of rzipped gemspec files.
+#
+# the basic idea is either to merge those dependency data and then
+# marshal them again. or to have an array of dependecy data and
+# split or group with their gemname as criterium.
+#
+# @author Christian Meier
+module Nexus
+  class DependencyHelperImpl
+    include DependencyHelper
+    include RubygemsHelper
+
+    # create an object with no dependencies added
+    def initialize
+      @result = []
+    end
+
+    # add dependencies
+    # @param dep [IO, String] can be filename or an IO object
+    def add( is )
+      @result += marshal_load( is )
+    end
+
+    # add dependency from given (rzipped) gemspec file
+    # @param dep [IO, String] can be filename or an IO object
+    def add_gemspec( is )
+      spec = runzip( is )
+      @result << dependency_data( spec.name, 
+                                  spec.version.to_s,
+                                  spec.platform.to_s, 
+                                  deps_from( spec ) )
+    end
+
+    # return the list of gemnames from the dependency added so far.
+    # freezes the state, i.e. adding more dependencies or gemspecs will
+    # raise errors.
+    # @return [Array[String]]
+    def gemnames
+      map.keys
+    end
+
+    # get the marshaled array of dependencies as stream for the
+    # given gemname. this method will freeze the state, i.e. adding
+    # more dependencies or gemspecs will raise errors.
+    # @param gemname [String]
+    # @return [IO] array of dependencies as stream
+    def input_stream_of( gemname )
+      marshal_dump( map[ gemname ] )
+    end
+    alias :get_input_stream_of :input_stream_of
+
+    # get the marshaled array of all dependencies as stream with or
+    # without duplicates
+    # @param unique [boolean]
+    # @return [IO] array of dependencies as stream
+    def input_stream( unique )
+      r = if unique
+            @result.uniq { |n| "#{n[:name]}-#{n[:number]}-#{n[:platform]}" }
+          else
+            @result
+          end
+      marshal_dump( r )
+    end
+    alias :get_input_stream :input_stream
+
+    # string representation with internal data
+    # @return [String]
+    def to_s
+      @result.inspect
+    end
+
+    private
+
+    def map
+      @map ||= split
+    end
+    
+    def split
+      @result.freeze
+      map = {}
+      @result.each do |d|
+        bucket = map[ d[:name] ] ||= []
+        bucket << d
+      end 
+      map
+    end
+
+    def deps_from( spec )
+      spec.runtime_dependencies.collect do |d|
+        # issue https://github.com/sonatype/nexus-ruby-support/issues/25
+        name = case d.name
+               when Array
+                 d.name.first
+               else
+                 d.name
+               end
+        [ name, d.requirement.to_s ]
+      end
+    end
+
+    def dependency_data( gemname, number, platform, deps )
+      { :name => gemname,
+        :number => number,
+        :platform => platform,
+        :dependencies => deps }
+    end
+  end
+end

--- a/plugins/rubygem/nexus-ruby-tools/src/main/resources/nexus/rubygems_helper.rb
+++ b/plugins/rubygem/nexus-ruby-tools/src/main/resources/nexus/rubygems_helper.rb
@@ -1,0 +1,67 @@
+#
+# Sonatype Nexus (TM) Open Source Version
+# Copyright (c) 2007-2014 Sonatype, Inc.
+# All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+#
+# This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+# which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+#
+# Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+# of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+# Eclipse Foundation. All other trademarks are the property of their respective owners.
+#
+java_import java.io.ByteArrayInputStream
+
+# this module just has a bunch of helper method dealing
+# with reading binary data from a file or stream. marshalling
+# and unmarshalling binary data, dito. rzip and runzip them.
+#
+# @author Christian Meier
+module Nexus
+  module RubygemsHelper
+
+    # read binary data either from a file or a stream
+    # @param io [IO, String] either a stream or a filename
+    # @return [String] packed as character data
+    def read_binary( io )
+      case io
+      when String
+        Gem.read_binary( io )
+      else
+        result = []
+        while ( ( b = io.read ) != -1 ) do
+          result << b
+        end
+        result.pack 'C*'
+      end
+    end
+
+    # ruby-unzip a stream or file and unmarshal it to an object.
+    # @param io [IO, String] stream or filename
+    # @return [Object] unmarshalled object
+    def runzip( io )
+      Marshal.load( Gem.inflate( read_binary( io ) ) )
+    end
+    
+    # marshal a given object and turn it into a ruby-zip stream.
+    # @param obj [Object] any ruby object
+    # @return [IO] stream with rzipped marshalled object
+    def rzip( obj )
+      ByteArrayInputStream.new( Gem.deflate( Marshal.dump( obj ) ).to_java.bytes )
+    end
+
+    # unmarshal object from stream or file
+    # @param io [IO, String] stream or filename
+    # @return [Object] unmarshalled object
+    def marshal_load( io )
+      Marshal.load( read_binary( io ) )
+    end
+
+    # marshal given object and turn it to a stream
+    # @param obj [Object] any ruby object
+    # @return [IO] stream of the marshalled object
+    def marshal_dump( obj)
+      ByteArrayInputStream.new( Marshal.dump( obj ).to_java.bytes )
+    end
+  end
+end

--- a/plugins/rubygem/nexus-ruby-tools/src/main/resources/nexus/specs_helper.rb
+++ b/plugins/rubygem/nexus-ruby-tools/src/main/resources/nexus/specs_helper.rb
@@ -1,0 +1,153 @@
+#
+# Sonatype Nexus (TM) Open Source Version
+# Copyright (c) 2007-2014 Sonatype, Inc.
+# All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+#
+# This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+# which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+#
+# Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+# of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+# Eclipse Foundation. All other trademarks are the property of their respective owners.
+#
+require 'nexus/rubygems_helper'
+
+java_import org.sonatype.nexus.ruby.SpecsHelper
+
+# this class can collect dependency data (which are an array of hashes).
+# the collected data can be added as either marshaled stream of dependency
+# data or marshaled stream of rzipped gemspec files.
+#
+# the basic idea is either to merge those dependency data and then
+# marshal them again. or to have an array of dependecy data and
+# split or group with their gemname as criterium.
+#
+# @author Christian Meier
+module Nexus
+  class SpecsHelperImpl
+    include SpecsHelper
+    include RubygemsHelper
+
+    def initialize
+      @result = []
+    end
+
+    def empty_specs
+      dump_specs( [] )
+    end
+    
+    def add( source )
+      sources.each do |s|
+        @result += load_specs( s )
+      end
+    end
+
+    def input_stream( latest )
+      @result.freeze
+      if latest
+        dump_specs( regenerate_latest( @result ) )
+      else
+        dump_specs( @result )
+      end
+    end
+
+    def add_spec( spec, source, type )
+      case type.downcase.to_sym
+      when :latest
+        do_add_spec( spec, source, true )
+      when :release
+        do_add_spec( spec, source ) unless spec.version.prerelease?
+      when :prerelease
+        do_add_spec( spec, source ) if spec.version.prerelease?
+      end
+    end
+
+    def delete_spec( spec, source, type )
+      specs = load_specs( source )
+      old_entry = [ spec.name, spec.version, spec.platform.to_s ]
+      if specs.member? old_entry
+        specs.delete old_entry
+        case type.downcase.to_sym
+        when :latest
+          if @releases
+            # assume @releases is up to date
+            specs = regenerate_latest( @releases )
+            @releases = nil
+          end
+        when :release
+          @release = specs
+        end
+        dump_specs( specs )
+      end
+    end
+
+    # string representation with internal data
+    # @return [String]
+    def to_s
+      @result.inspect
+    end
+
+    private
+
+    def load_specs( io )
+      marshal_load( io )
+    end
+
+    def dump_specs( specs )
+      specs.uniq!
+      specs.sort!
+      marshal_dump( compact_specs( specs ) )
+    end
+
+    def compact_specs( specs )
+      names = {}
+      versions = {}
+      platforms = {}
+
+      specs.map do |( name, version, platform )|
+        names[ name ] = name unless names.include? name
+        versions[ version ] = version unless versions.include? version
+        platforms[ platform ] = platform unless platforms.include? platform
+
+        [ names[ name ], versions[ version ], platforms[ platform ] ]
+      end
+    end
+
+    def do_add_spec( spec, source, latest = false )
+      specs = load_specs( source )
+      new_entry = [ spec.name, spec.version, spec.platform.to_s ]
+      unless specs.member?( new_entry )
+        if latest
+          new_specs = regenerate_latest( specs + [ new_entry ] )
+          dump_specs( new_specs ) if new_specs != specs
+        else
+          specs << new_entry
+          dump_specs( specs )
+        end
+      end
+    end
+
+    def regenerate_latest( specs )
+      specs.sort!
+      specs.uniq!
+      map = {}
+      specs.each do |s|
+        list = map[ s[ 0 ] ] ||= []
+        list << s
+      end
+      result = []
+      map.each do |name, list|
+        list.sort!
+        list.uniq!
+        lastest_versions = {}
+        list.each do |i|
+          version = i[1]
+          platform = i[2]
+          lastest_versions[ platform ] = i
+        end
+        result += lastest_versions.collect { |k, v| v }
+      end
+      result
+    end
+  end
+end

--- a/plugins/rubygem/nexus-ruby-tools/src/test/java/org/sonatype/nexus/ruby/HostedDELETELayoutTest.java
+++ b/plugins/rubygem/nexus-ruby-tools/src/test/java/org/sonatype/nexus/ruby/HostedDELETELayoutTest.java
@@ -264,7 +264,7 @@ public class HostedDELETELayoutTest
   @Test
   public void testBundlerApi() throws Exception {
     String[] pathes = {"/api/v1/dependencies?gems=zip,pre"};
-    assertFiletypeWithPayload(pathes, FileType.BUNDLER_API, org.sonatype.nexus.ruby.ByteArrayInputStream.class);
+    assertFiletypeWithPayload(pathes, FileType.BUNDLER_API, ByteArrayInputStream.class);
   }
 
   @Test

--- a/plugins/rubygem/nexus-ruby-tools/src/test/java/org/sonatype/nexus/ruby/HostedGETLayoutTest.java
+++ b/plugins/rubygem/nexus-ruby-tools/src/test/java/org/sonatype/nexus/ruby/HostedGETLayoutTest.java
@@ -253,7 +253,7 @@ public class HostedGETLayoutTest
   @Test
   public void testBundlerApi() throws Exception {
     String[] pathes = {"/api/v1/dependencies?gems=zip,pre"};
-    assertFiletypeWithPayload(pathes, FileType.BUNDLER_API, org.sonatype.nexus.ruby.ByteArrayInputStream.class);
+    assertFiletypeWithPayload(pathes, FileType.BUNDLER_API, ByteArrayInputStream.class);
   }
 
 

--- a/plugins/rubygem/nexus-ruby-tools/src/test/java/org/sonatype/nexus/ruby/ProxiesGETLayoutTest.java
+++ b/plugins/rubygem/nexus-ruby-tools/src/test/java/org/sonatype/nexus/ruby/ProxiesGETLayoutTest.java
@@ -260,7 +260,7 @@ public class ProxiesGETLayoutTest
   @Test
   public void testBundlerApi() throws Exception {
     String[] pathes = {"/api/v1/dependencies?gems=zip,pre"};
-    assertFiletypeWithPayload(pathes, FileType.BUNDLER_API, org.sonatype.nexus.ruby.ByteArrayInputStream.class);
+    assertFiletypeWithPayload(pathes, FileType.BUNDLER_API, ByteArrayInputStream.class);
   }
 
   @Test

--- a/plugins/rubygem/nexus-ruby-tools/src/test/java/org/sonatype/nexus/ruby/RubygemsGatewayTest.java
+++ b/plugins/rubygem/nexus-ruby-tools/src/test/java/org/sonatype/nexus/ruby/RubygemsGatewayTest.java
@@ -17,7 +17,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.sonatype.sisu.litmus.testsupport.TestSupport;
@@ -116,7 +115,9 @@ public class RubygemsGatewayTest
   public void testEmptyDependencies() throws Exception {
     File empty = new File("target/empty");
 
-    dumpStream(gateway.createDependencies(new ArrayList<InputStream>()), empty);
+    // create empty dependencies file
+    DependencyHelper deps = gateway.newDependencyHelper();
+    dumpStream(deps.getInputStream(false), empty);
 
     int size = scriptingContainer.callMethod(check,
         "specs_size",

--- a/plugins/rubygem/nexus-ruby-tools/src/test/minispecs/dependency_helper_spec.rb
+++ b/plugins/rubygem/nexus-ruby-tools/src/test/minispecs/dependency_helper_spec.rb
@@ -1,0 +1,80 @@
+require 'nexus/dependency_helper_impl'
+require 'minitest/spec'
+require 'minitest/autorun'
+require 'stringio'
+
+describe Nexus::DependencyHelperImpl do
+
+  let( :a ) { [ {:name=>"jbundler", :number=>"0.5.5", :platform=>"ruby", :dependencies=>[["bundler", "~> 1.5"], ["ruby-maven", "< 3.1.2, >= 3.1.1.0.1"]]}, {:name=>"jbundler", :number=>"0.5.4", :platform=>"ruby", :dependencies=>[["bundler", "~> 1.2"], ["ruby-maven", "< 3.1.2, >= 3.1.1.0.1"]]}, {:name=>"jbundler", :number=>"0.5.3", :platform=>"ruby", :dependencies=>[["bundler", "~> 1.2"], ["ruby-maven", "< 3.1.1, >= 3.1.0.0.1"]]} ] }
+  
+  let( :aa ) { [ {:name=>"jbundler", :number=>"0.5.5", :platform=>"ruby", :dependencies=>[["bundler", "~> 1.5"]] }] }
+
+  let( :b ) { [ {:name=>"bundler", :number=>"1.6.0.rc2", :platform=>"ruby", :dependencies=>[]}, {:name=>"bundler", :number=>"1.6.0.rc", :platform=>"ruby", :dependencies=>[]} ] }
+
+  subject { Nexus::DependencyHelperImpl.new }
+
+  it 'should merge dependencies' do
+    subject.add( subject.marshal_dump( b ) )
+    subject.add( subject.marshal_dump( a ) )
+
+    begin
+      is = subject.input_stream( false )
+      subject.marshal_load( is ).must_equal b + a
+    ensure
+      is.close if is
+    end
+    subject.gemnames.must_equal ["bundler", "jbundler"]
+    subject.marshal_load( subject.input_stream_of( "bundler" ) ).must_equal b
+    subject.marshal_load( subject.input_stream_of( "jbundler" ) ).must_equal a
+  end
+
+  it 'should merge dependencies with duplicates' do
+    subject.add( subject.marshal_dump( b ) )
+    subject.add( subject.marshal_dump( aa ) )
+    subject.add( subject.marshal_dump( a ) )
+
+    begin
+      is = subject.input_stream( false )
+      subject.marshal_load( is ).must_equal b + aa + a
+    ensure
+      is.close if is
+    end
+    subject.gemnames.must_equal ["bundler", "jbundler"]
+    subject.marshal_load( subject.input_stream_of( "bundler" ) ).must_equal b
+    subject.marshal_load( subject.input_stream_of( "jbundler" ) ).must_equal aa + a
+  end
+
+  it 'should merge dependencies without duplicates' do
+    subject.add( subject.marshal_dump( b ) )
+    subject.add( subject.marshal_dump( a ) )
+    subject.add( subject.marshal_dump( aa ) )
+
+    begin
+      is = subject.input_stream( true )
+      subject.marshal_load( is ).must_equal b + a
+    ensure
+      is.close if is
+    end
+    subject.gemnames.must_equal ["bundler", "jbundler"]
+    subject.marshal_load( subject.input_stream_of( "bundler" ) ).must_equal b
+    # duplicates are not eliminated here
+    subject.marshal_load( subject.input_stream_of( "jbundler" ) ).must_equal a + aa
+  end
+
+  it 'should merge dependencies from gemspec.rz files' do
+    dir = File.join( File.dirname( __FILE__ ), '../repo/quick/Marshal.4.8/h' )
+    
+    Dir[ File.join( dir, '*rz' ) ].each do |f|
+      subject.add_gemspec( f )
+    end
+
+    begin
+      is = subject.input_stream( false )
+      subject.marshal_load( is ).must_equal [{:name=>"hufflepuf", :number=>"0.2.0", :platform=>"universal-java-1.5", :dependencies=>[]}, {:name=>"hufflepuf", :number=>"0.2.0", :platform=>"x86-mswin32-60", :dependencies=>[]}, {:name=>"hufflepuf", :number=>"0.1.0", :platform=>"ruby", :dependencies=>[]}, {:name=>"hufflepuf", :number=>"0.1.0", :platform=>"universal-java-1.5", :dependencies=>[]}]
+    ensure
+      is.close if is
+    end
+    subject.gemnames.must_equal ["hufflepuf"]
+  end
+end
+    

--- a/plugins/rubygem/nexus-ruby-tools/src/test/minispecs/rubygems_spec.rb
+++ b/plugins/rubygem/nexus-ruby-tools/src/test/minispecs/rubygems_spec.rb
@@ -79,27 +79,6 @@ describe Nexus::Rubygems do
     Marshal.load( StringIO.new( dump ) ).must_equal [ a2java, a2, b4 ]
   end
 
-  it 'should merge dependencies' do
-    a = [ {:name=>"jbundler", :number=>"0.5.5", :platform=>"ruby", :dependencies=>[["bundler", "~> 1.5"], ["ruby-maven", "< 3.1.2, >= 3.1.1.0.1"]]}, {:name=>"jbundler", :number=>"0.5.4", :platform=>"ruby", :dependencies=>[["bundler", "~> 1.2"], ["ruby-maven", "< 3.1.2, >= 3.1.1.0.1"]]}, {:name=>"jbundler", :number=>"0.5.3", :platform=>"ruby", :dependencies=>[["bundler", "~> 1.2"], ["ruby-maven", "< 3.1.1, >= 3.1.0.0.1"]]} ]
-
-    aa = [ {:name=>"jbundler", :number=>"0.5.5", :platform=>"ruby", :dependencies=>[["bundler", "~> 1.5"]] }]
-
-    b = [ {:name=>"bundler", :number=>"1.6.0.rc2", :platform=>"ruby", :dependencies=>[]}, {:name=>"bundler", :number=>"1.6.0.rc", :platform=>"ruby", :dependencies=>[]} ]
-    
-    dump = subject.merge_dependencies( false, java.io.ByteArrayInputStream.new( Marshal.dump( b ).to_java.bytes ),
-                                       java.io.ByteArrayInputStream.new( Marshal.dump( a ).to_java.bytes ) ).pack 'C*'
-    Marshal.load( StringIO.new( dump ) ).must_equal b + a
-
-    dump = subject.merge_dependencies( true, java.io.ByteArrayInputStream.new( Marshal.dump( b ).to_java.bytes ),
-                                       java.io.ByteArrayInputStream.new( Marshal.dump( a ).to_java.bytes ),
-                                       java.io.ByteArrayInputStream.new( Marshal.dump( aa ).to_java.bytes ) ).pack 'C*'
-    Marshal.load( StringIO.new( dump ) ).must_equal b + a
-
-    map = subject.split_dependencies( java.io.ByteArrayInputStream.new( Marshal.dump( a + b ).to_java.bytes ) )
-    Marshal.load( StringIO.new( map['jbundler'].pack( 'C*' ) ) ).must_equal a
-    Marshal.load( StringIO.new( map['bundler'].pack( 'C*' ) ) ).must_equal b
-  end
-
   it 'purge api files' do
     subject.purge_broken_depencency_files( broken_to )
     dirs = Dir[ File.join( broken_to, 'api', '**', '*' ) ]


### PR DESCRIPTION
use better integration of java and ruby.

this also avoids opening many streams (to files) instead it needs only one stream at a time.

this patch deals with dependency data cached from bundler API calls to ruby repositories.

specs.4.8 files also get merged where a similar patch needs to wrapped the parallel streams into a sequence order.

can set the label - should be REVIEW
