### PR TITLE
Gateway should be singleton, not a prototype

### DIFF
--- a/plugins/rubygem/nexus-ruby-plugin/src/main/java/org/sonatype/nexus/plugins/ruby/NexusRubygemsGateway.java
+++ b/plugins/rubygem/nexus-ruby-plugin/src/main/java/org/sonatype/nexus/plugins/ruby/NexusRubygemsGateway.java
@@ -13,11 +13,13 @@
 package org.sonatype.nexus.plugins.ruby;
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.sonatype.nexus.ruby.DefaultRubygemsGateway;
 
 // just make a "component" out of the DefaultRubygemsGateway
 @Named
+@Singleton
 public class NexusRubygemsGateway
     extends DefaultRubygemsGateway
 {


### PR DESCRIPTION
This is the culprit of ITs being way too slow (it is basically the repo creation that takes minutes in ITs!): this object is created for every repository instance (and JRuby ScriptContainer is very very heavyweight). I think this is a mistake, that several script containers are created.

Still, according to Kristian, there is some change needed, as state is kept in case of hosted layout or such.

This change lessens Ruby ITs execution a lot (on CI the modern0 shard executes in 43 minutes, instead of 96 minutes without this change).

CI
http://bamboo.s/browse/NX-OSSF311-1
