### PR TITLE
[2.11.x] DirSupport.move simplification

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSPeer.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSPeer.java
@@ -257,7 +257,7 @@ public class DefaultFSPeer
       log.debug("Moving file from {} to {}", fromTarget.getAbsolutePath(), toTarget.getAbsolutePath());
     }
     try {
-      if (!DirSupport.pseudoMoveIfExists(fromTarget.toPath(), toTarget.toPath(), DOTTED_FILE_FILTER)) {
+      if (!DirSupport.copyDeleteMoveIfExists(fromTarget.toPath(), toTarget.toPath(), DOTTED_FILE_FILTER)) {
         throw new ItemNotFoundException(reasonFor(from, repository,
             "Path %s not found in local storage of repository %s", from.getRequestPath(),
             RepositoryStringUtils.getHumanizedNameString(repository)));

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/util/file/DirSupport.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/util/file/DirSupport.java
@@ -428,7 +428,7 @@ public final class DirSupport
    * or a directory. While this method is not a real move (like {@link #move(Path, Path)} is), it is a bit more capable:
    * it can move a complete directory structure to it's one sub-directory.
    */
-  public static void pseudoMove(final Path from, final Path to, final @Nullable Predicate<Path> excludeFilter)
+  public static void copyDeleteMove(final Path from, final Path to, final @Nullable Predicate<Path> excludeFilter)
       throws IOException
   {
     copy(from, to, excludeFilter);
@@ -436,15 +436,17 @@ public final class DirSupport
   }
 
   /**
-   * Invokes {@link #pseudoMove(Path, Path, Predicate)} if passed in "from" path exists and returns {@code true}. If
+   * Invokes {@link #copyDeleteMove(Path, Path, Predicate)} if passed in "from" path exists and returns {@code true}. If
    * "from" path does not exists, {@code false} is returned.
    */
-  public static boolean pseudoMoveIfExists(final Path from, final Path to, final @Nullable Predicate<Path> excludeFilter)
+  public static boolean copyDeleteMoveIfExists(final Path from,
+                                               final Path to,
+                                               final @Nullable Predicate<Path> excludeFilter)
       throws IOException
   {
     checkNotNull(from);
     if (Files.exists(from)) {
-      pseudoMove(from, to, excludeFilter);
+      copyDeleteMove(from, to, excludeFilter);
       return true;
     }
     else {

--- a/components/nexus-core/src/test/java/org/sonatype/nexus/util/file/DirSupportTest.java
+++ b/components/nexus-core/src/test/java/org/sonatype/nexus/util/file/DirSupportTest.java
@@ -178,9 +178,10 @@ public class DirSupportTest
   }
 
   @Test
-  public void pseudoMoveToSubdir() throws IOException {
+  public void copyDeleteMoveToSubdir() throws IOException {
     final Path target = root.toPath().resolve("dir2/dir21");
-    DirSupport.pseudoMove(root.toPath(), target, new Predicate<Path>() {
+    DirSupport.copyDeleteMove(root.toPath(), target, new Predicate<Path>()
+    {
       @Override
       public boolean apply(@Nullable final Path input) {
         return input.startsWith(target);
@@ -231,9 +232,9 @@ public class DirSupportTest
    * of repo local storage, the root was being moved under "/.nexus/trash".
    */
   @Test(expected = FileSystemException.class)
-  public void pseudoMoveToSubdirNullFilter() throws IOException {
+  public void copyDeleteMoveToSubdirNullFilter() throws IOException {
     final Path target = root.toPath().resolve("dir2/dir21");
-    DirSupport.pseudoMove(root.toPath(), target, null);
+    DirSupport.copyDeleteMove(root.toPath(), target, null);
   }
 
   @Test


### PR DESCRIPTION
The "fallback" was needed only in one case, when
a dir was moved to it's subdir. But, to achieve
that one must declare excludeFilter. Hence,
from now on, WITHOUT filter that is impossible,
and in the same time, other IOEx from Files.move
should not be swallowed (ie. move over non-empty dir)

This is an experiment based on assumption, will continue
if CI proves me (or tells me am wrong).

CI
http://bamboo.s/browse/NX-OSSF315
