### PR TITLE
fix ordering issue on dependency_helper_spec

### DIFF
--- a/plugins/rubygem/nexus-ruby-tools/src/test/minispecs/dependency_helper_spec.rb
+++ b/plugins/rubygem/nexus-ruby-tools/src/test/minispecs/dependency_helper_spec.rb
@@ -70,7 +70,7 @@ describe Nexus::DependencyHelperImpl do
 
     begin
       is = subject.input_stream( false )
-      subject.marshal_load( is ).must_equal [{:name=>"hufflepuf", :number=>"0.2.0", :platform=>"universal-java-1.5", :dependencies=>[]}, {:name=>"hufflepuf", :number=>"0.2.0", :platform=>"x86-mswin32-60", :dependencies=>[]}, {:name=>"hufflepuf", :number=>"0.1.0", :platform=>"ruby", :dependencies=>[]}, {:name=>"hufflepuf", :number=>"0.1.0", :platform=>"universal-java-1.5", :dependencies=>[]}]
+      subject.marshal_load( is ).sort{ |n,m| "#{n[:name]}-#{n[:number]}-#{n[:platform]}" <=> "#{m[:name]}-#{m[:number]}-#{m[:platform]}" }.must_equal [{:name=>"hufflepuf", :number=>"0.1.0", :platform=>"ruby", :dependencies=>[]}, {:name=>"hufflepuf", :number=>"0.1.0", :platform=>"universal-java-1.5", :dependencies=>[]}, {:name=>"hufflepuf", :number=>"0.2.0", :platform=>"universal-java-1.5", :dependencies=>[]}, {:name=>"hufflepuf", :number=>"0.2.0", :platform=>"x86-mswin32-60", :dependencies=>[]}, ]
     ensure
       is.close if is
     end


### PR DESCRIPTION
somehow the ordering of the array on the compare was matching on my machine but did have a different order on other machine :( 

since ordering here is of no importance it is OK to order it nicely.
