### PR TITLE
[CLM-3596] Added repository format to data on file node click.

### DIFF
--- a/plugins/basic/nexus-ui-extjs3-plugin/src/main/resources/static/js/Sonatype/repoServer/Maven2InformationPanel.js
+++ b/plugins/basic/nexus-ui-extjs3-plugin/src/main/resources/static/js/Sonatype/repoServer/Maven2InformationPanel.js
@@ -89,9 +89,6 @@ NX.define('Sonatype.repoServer.Maven2InformationPanel', {
   showArtifact : function(data, artifactContainer) {
     this.data = data;
     if (data) {
-      if(!data.format) {
-        data.format = 'maven2';
-      }
       Ext.Ajax.request({
         url : this.data.resourceURI + '?describe=maven2&isLocal=true',
         callback : function(options, isSuccess, response) {

--- a/plugins/indexer/nexus-indexer-lucene-plugin/src/main/resources/static/js/Sonatype/repoServer/RepositoryIndexBrowserContainer.js
+++ b/plugins/indexer/nexus-indexer-lucene-plugin/src/main/resources/static/js/Sonatype/repoServer/RepositoryIndexBrowserContainer.js
@@ -156,7 +156,8 @@ define('Sonatype/repoServer/RepositoryIndexBrowserContainer', function() {
                             extension : options.cbPassThru.node.attributes.extension,
                             artifactLink : options.cbPassThru.node.attributes.artifactUri,
                             pomLink : options.cbPassThru.node.attributes.pomUri,
-                            nodeName : options.cbPassThru.node.attributes.nodeName
+                            nodeName : options.cbPassThru.node.attributes.nodeName,
+                            format : options.cbPassThru.container.payload.data.format
                           });
                     }
                   },


### PR DESCRIPTION
https://issues.sonatype.org/browse/CLM-3596
http://bamboo.s/browse/NX-OSSF325-2

In order to send non-gav data to HDS we need the format and the repository ID to fetch the SHA1 hash. This was the only way I could see to scrape that data from the UI.

There are test failures but I believe they are unrelated to these changes.
