### PR TITLE
remove yecht dependency from jruby 

### DIFF
--- a/plugins/rubygem/nexus-ruby-tools/pom.xml
+++ b/plugins/rubygem/nexus-ruby-tools/pom.xml
@@ -30,6 +30,12 @@
       <groupId>org.jruby</groupId>
       <artifactId>jruby</artifactId>
       <type>pom</type>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jruby</groupId>
+          <artifactId>yecht</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
since it has an unclear license and the library is not used. all tests pass locally.
