### PR TITLE
NEXUS-7575: User agent not set on HC4 tunneled connections

### DIFF
--- a/components/nexus-core/src/test/java/org/sonatype/nexus/apachehttpclient/Hc4ProviderRemoteTest.java
+++ b/components/nexus-core/src/test/java/org/sonatype/nexus/apachehttpclient/Hc4ProviderRemoteTest.java
@@ -41,11 +41,13 @@ import org.fest.util.Strings;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Matchers;
 import org.mockito.Mock;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
 /**
@@ -105,7 +107,7 @@ public class Hc4ProviderRemoteTest
     when(remoteHttpProxySettings.getHostname()).thenReturn("localhost");
     when(remoteHttpProxySettings.getPort()).thenReturn(port);
 
-    when(userAgentBuilder.formatGenericUserAgentString()).thenReturn(UA);
+    when(userAgentBuilder.formatUserAgentString(Matchers.<RemoteStorageContext>any())).thenReturn(UA);
     when(applicationConfiguration.getGlobalRemoteStorageContext()).thenReturn(globalRemoteStorageContext);
   }
 


### PR DESCRIPTION
When HC4 tunnels HTTPS connection over HTTP, using
CONNECT, the user agent is not set even if it is configured
(HTTPCLIENT-1526). This change applies the fix
mentioned in issue comment and adds a test
that verifies it works.

Issue
https://issues.sonatype.org/browse/NEXUS-7575

CI
http://bamboo.s/browse/NX-OSSF331
