### PR TITLE
fix regex to avoid "BUG" log entries

### DIFF
--- a/plugins/rubygem/nexus-ruby-plugin/src/main/java/org/sonatype/nexus/plugins/ruby/proxy/DefaultProxyRubyRepository.java
+++ b/plugins/rubygem/nexus-ruby-plugin/src/main/java/org/sonatype/nexus/plugins/ruby/proxy/DefaultProxyRubyRepository.java
@@ -165,7 +165,7 @@ public class DefaultProxyRubyRepository
     getExternalConfiguration(true).setMetadataMaxAge(metadataMaxAge);
   }
 
-  private static Pattern BUNDLER_API_REQUEST = Pattern.compile("[?]gems=.+,.+");
+  private static Pattern BUNDLER_API_REQUEST = Pattern.compile(".*[?]gems=.+,.+");
 
   public AbstractStorageItem doCacheItem(AbstractStorageItem item)
       throws LocalStorageException


### PR DESCRIPTION
no functional change but no more longish BUG warnings in log. the bundler API request do not have locally stored/cached files.
