### PR TITLE
[2.11.x][NEXUS-7595] Disable insecure SSL protocols by default in jetty HTTPS sample configuration

### DIFF
--- a/assemblies/nexus-bundle-template/src/main/resources/content/conf/jetty-https.xml
+++ b/assemblies/nexus-bundle-template/src/main/resources/content/conf/jetty-https.xml
@@ -35,6 +35,14 @@
             <Set name="keyStorePassword">OBF:1v2j1uum1xtv1zej1zer1xtn1uvk1v1v</Set>
             <Set name="keyManagerPassword">OBF:1v2j1uum1xtv1zej1zer1xtn1uvk1v1v</Set>
             <Set name="trustStorePassword">OBF:1v2j1uum1xtv1zej1zer1xtn1uvk1v1v</Set>
+            <Set name="excludeProtocols">
+              <Array type="java.lang.String">
+                <Item>SSL</Item>
+                <Item>SSLv2</Item>
+                <Item>SSLv2Hello</Item>
+                <Item>SSLv3</Item>
+              </Array>
+            </Set>
           </New>
         </Arg>
         <Set name="host"><Property name="application-host"/></Set>


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-7595
