### PR TITLE
NEXUS-7628: On delete of collection purge NFC for children

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
@@ -917,9 +917,11 @@ public abstract class AbstractRepository
 
         // if we are deleting a collection, perform recursive notification about this too
         if (item instanceof StorageCollectionItem) {
-          if (log.isDebugEnabled()) {
-            log.debug(
-                "We are deleting a collection, starting a walker to send delete notifications per-file.");
+          log.debug("deleting a collection '{}'", item.getPath());
+
+          // NEXUS-7628: If collection is being deleted, purge all of it's children from NFC
+          if (isNotFoundCacheActive()) {
+            getNotFoundCache().removeWithChildren(request.getRequestPath());
           }
 
           // it is collection, walk it and below and fire events for all files


### PR DESCRIPTION
deleteItem method originally operated on file items only. Later, it was "extended" to cope with collections too (by adding that Walker thingy to perform notifications recursively), but NFC was never handled properly if collection was being deleted.

Issue
https://issues.sonatype.org/browse/NEXUS-7628
