### PR TITLE
NEXUS-7653: re-enable Karaf's shutdown port

### DIFF
--- a/assemblies/nexus-base-template/src/main/resources/overlay/etc/custom.properties
+++ b/assemblies/nexus-base-template/src/main/resources/overlay/etc/custom.properties
@@ -13,7 +13,6 @@ karaf.systemBundlesStartLevel=50
 ${includes}=org.ops4j.pax.url.mvn.cfg
 
 karaf.lock.class=org.sonatype.nexus.karaf.NexusFileLock
-karaf.shutdown.port=-1
 
 nexus-base=${karaf.base}
 nexus-args=${karaf.base}/etc/jetty.xml,${karaf.base}/etc/jetty-requestlog.xml

--- a/components/nexus-launcher/src/main/java/org/sonatype/nexus/bundle/launcher/support/DefaultNexusBundleConfiguration.java
+++ b/components/nexus-launcher/src/main/java/org/sonatype/nexus/bundle/launcher/support/DefaultNexusBundleConfiguration.java
@@ -284,6 +284,12 @@ public class DefaultNexusBundleConfiguration
       );
     }
 
+    // disable Karaf's random shutdown port as we don't use it when testing
+    overlays.add(
+        fileTaskBuilder.properties(path("nexus/etc/custom.properties"))
+            .property("karaf.shutdown.port", "-1")
+    );
+
     if (getLogLevel() != null || getLogPattern() != null) {
       overlays.add(
           fileTaskBuilder.properties(path("sonatype-work/nexus/etc/logback.properties"))

--- a/testsupport/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/test/booter/EmbeddedNexusBooter.java
+++ b/testsupport/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/test/booter/EmbeddedNexusBooter.java
@@ -104,6 +104,9 @@ public class EmbeddedNexusBooter
     overrides.put("karaf.startRemoteShell", "false");
     overrides.put("karaf.clean.cache", "true");
 
+    // disable Karaf's random shutdown port as we don't use it when testing
+    overrides.put("karaf.shutdown.port", "-1");
+
     // move tmp under sonatype-work to avoid contamination between tests
     overrides.put("java.io.tmpdir", new File(workDir, "tmp").getPath());
 


### PR DESCRIPTION
Re-enabling Karaf's shutdown port in the distribution because Karaf needs it to correctly handle the status and stop commands and it is non-trivial to get it to use a PID-based approach. Note: we still disable the shutdown port during ITs because we use other methods to stop the container, and the random port selection can cause clashes with random ports allocated to the test (but not yet bound).

Customers who want to disable this port (or set it to a fixed number rather than have it pick a port at random) can add the `karaf.shutdown.port` property to `etc/custom.properties`.

https://issues.sonatype.org/browse/NEXUS-7653
http://bamboo.s/browse/NX-OSSF373-1 :white_check_mark: 
