### PR TITLE
NEXUS-7303: enable basic JSR-250 lifecycle support

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/NxApplication.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/NxApplication.java
@@ -41,6 +41,7 @@ import org.sonatype.sisu.goodies.lifecycle.LifecycleSupport;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
+import org.eclipse.sisu.bean.BeanManager;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -70,6 +71,8 @@ public class NxApplication
 
   private final OrientBootstrap orientBootstrap;
 
+  private final BeanManager beanManager;
+
   @Inject
   public NxApplication(final EventBus eventBus,
                        final NexusConfiguration nexusConfiguration,
@@ -78,7 +81,8 @@ public class NxApplication
                        final NexusScheduler nexusScheduler,
                        final RepositoryRegistry repositoryRegistry,
                        final EventSubscriberHost eventSubscriberHost,
-                       final OrientBootstrap orientBootstrap)
+                       final OrientBootstrap orientBootstrap,
+                       final BeanManager beanManager)
   {
     this.eventBus = checkNotNull(eventBus);
     this.applicationStatusSource = checkNotNull(applicationStatusSource);
@@ -88,6 +92,7 @@ public class NxApplication
     this.repositoryRegistry = checkNotNull(repositoryRegistry);
     this.eventSubscriberHost = checkNotNull(eventSubscriberHost);
     this.orientBootstrap = checkNotNull(orientBootstrap);
+    this.beanManager = checkNotNull(beanManager);
 
     logInitialized();
   }
@@ -204,6 +209,9 @@ public class NxApplication
 
     // HACK: Must stop database services manually
     orientBootstrap.stop();
+
+    // dispose of JSR-250
+    beanManager.unmanage();
 
     applicationStatusSource.getSystemStatus().setState(SystemState.STOPPED);
     log.info("Stopped {}", getNexusNameForLogs());

--- a/components/nexus-extender/src/main/java/org/sonatype/nexus/extender/modules/NexusBundleModule.java
+++ b/components/nexus-extender/src/main/java/org/sonatype/nexus/extender/modules/NexusBundleModule.java
@@ -22,6 +22,7 @@ import com.google.common.base.Strings;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import org.apache.shiro.guice.aop.ShiroAopModule;
+import org.eclipse.sisu.bean.LifecycleModule;
 import org.eclipse.sisu.inject.MutableBeanLocator;
 import org.eclipse.sisu.launch.BundleModule;
 import org.eclipse.sisu.plexus.PlexusSpaceModule;
@@ -54,6 +55,8 @@ public class NexusBundleModule
 
   private final List<AbstractInterceptorModule> interceptorModules;
 
+  private final LifecycleModule lifecycleModule = new LifecycleModule();
+
   private final String imports;
 
   private final boolean hasPlexus;
@@ -76,6 +79,7 @@ public class NexusBundleModule
     maybeAddValidation(modules);
     maybeAddWebResources(modules);
     maybeAddInterceptors(modules);
+    maybeAddLifecycle(modules);
     modules.addAll(super.modules());
     modules.add(rankingModule);
 
@@ -130,6 +134,12 @@ public class NexusBundleModule
       if (aim.appliesTo(space)) {
         modules.add(aim);
       }
+    }
+  }
+
+  private void maybeAddLifecycle(List<Module> modules) {
+    if (imports.contains("javax.annotation")) {
+      modules.add(lifecycleModule);
     }
   }
 }


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-7303

Use `@PostConstruct` and `@PreDestroy` to mark lifecycle methods. You still need to inject or depend on the component at least transitively so it will be created in the first place (alternatively you could mark it as eager) but once created it will be managed according to JSR-250.

Note: shutdown is currently centralized in `NxApplication` with components being disposed of in reverse order of their creation. This will be changed in a subsequent PR so that stopping a bundle will lead to disposal of its components. Interleaving JSR-250 with the Lifecycle API from the goodies library is also being investigated.
