### PR TITLE
Disable messages panel and toggle

### DIFF
--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/Main.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/Main.js
@@ -49,16 +49,16 @@ Ext.define('NX.view.Main', {
       border: true
     },
 
-    {
-      xtype: 'nx-message-panel',
-      region: 'east',
-      border: true,
-      resizable: true,
-      resizeHandles: 'w',
-
-      // default to hidden, header button toggles
-      hidden: true
-    },
+    //{
+    //  xtype: 'nx-message-panel',
+    //  region: 'east',
+    //  border: true,
+    //  resizable: true,
+    //  resizeHandles: 'w',
+    //
+    //  // default to hidden, header button toggles
+    //  hidden: true
+    //},
 
     {
       xtype: 'nx-footer',
@@ -96,7 +96,7 @@ Ext.define('NX.view.Main', {
       ' ',
       { xtype: 'nx-header-quicksearch', hidden: true },
       '->',
-      { xtype: 'nx-header-messages', ui: 'header' },
+      //{ xtype: 'nx-header-messages', ui: 'header' },
       { xtype: 'nx-header-refresh', ui: 'header' },
       { xtype: 'nx-header-signin', ui: 'header' },
       { xtype: 'nx-header-user-mode', ui: 'header', hidden: true },

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Header.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Header.js
@@ -89,12 +89,12 @@ Ext.define('NX.view.dev.styles.Header', {
             inputAttrTpl: "data-qtip='Quick component keyword search'" // field tooltip
           },
           '->',
-          {
-            xtype: 'button',
-            ui: 'header',
-            glyph: 'xf0f3@FontAwesome',
-            tooltip: 'Toggle messages display'
-          },
+          //{
+          //  xtype: 'button',
+          //  ui: 'header',
+          //  glyph: 'xf0f3@FontAwesome',
+          //  tooltip: 'Toggle messages display'
+          //},
           {
             xtype: 'button',
             ui: 'header',


### PR DESCRIPTION
Disables the messages toggle in header toolbar and side-panel.  Questionable value and current design causes some contention, so lets turn it off until we can design/impl something proper here.

FTR messages still show up, but no longer can see history in the UI... except in the ?debug mode.

Related to:
- https://issues.sonatype.org/browse/NEXUS-7643
- https://issues.sonatype.org/browse/NEXUS-6804
- https://issues.sonatype.org/browse/NEXUS-7321
- https://issues.sonatype.org/browse/NEXUS-7347
