### PR TITLE
Fix for DefaultSnapshotRemoverIT

### DIFF
--- a/components/nexus-core/src/test/java/org/sonatype/nexus/AbstractMavenRepoContentTests.java
+++ b/components/nexus-core/src/test/java/org/sonatype/nexus/AbstractMavenRepoContentTests.java
@@ -172,7 +172,7 @@ public abstract class AbstractMavenRepoContentTests
         try {
           String path = file.getAbsolutePath().substring(from.getAbsolutePath().length());
 
-          FileUtils.copyFile(file, new File(to, path));
+          FileUtils.copyFile(file, new File(to, path), false);
         }
         catch (IOException e) {
           throw new IllegalStateException("Cannot copy dirtree.", e);


### PR DESCRIPTION
The IT depends on file timestamp of checked out sources. This is
why it never fails on CI, as there is always freshly checked out.

On dev machine on the other hand, if the git repo was checked out
2+ ago, this IT will start failing.

fix is to not preserve timestamps on fillInRepo().

CI
http://bamboo.s/browse/NX-OSSF415
