### PR TITLE
fix for RoutingWithProxyRepositoryIT

### DIFF
--- a/testsuite/modern-testsuite/src/test/java/org/sonatype/nexus/testsuite/routing/RoutingWithProxyRepositoryIT.java
+++ b/testsuite/modern-testsuite/src/test/java/org/sonatype/nexus/testsuite/routing/RoutingWithProxyRepositoryIT.java
@@ -72,6 +72,9 @@ public class RoutingWithProxyRepositoryIT
   public void proxyLoosesWLIfDisabled()
       throws Exception
   {
+    // wait for central
+    routingTest().waitForAllRoutingUpdateJobToStop();
+
     assertThat(exists(PREFIX_FILE_LOCATION), is(true));
     assertThat(noscrape(PREFIX_FILE_LOCATION), is(false));
     {
@@ -98,6 +101,9 @@ public class RoutingWithProxyRepositoryIT
   public void proxyWLDeletableAndRecreateManually()
       throws Exception
   {
+    // wait for central
+    routingTest().waitForAllRoutingUpdateJobToStop();
+
     // we did no any waiting, e just booted nexus, so it must be present
     assertThat(exists(PREFIX_FILE_LOCATION), is(true));
     assertThat(noscrape(PREFIX_FILE_LOCATION), is(false));


### PR DESCRIPTION
As it is about Central, but central prefix
is processed during boot, and the outcome is left
to chance of concurrency (at my machine, it was 1:3
of executions)

CI
http://bamboo.s/browse/NX-OSSF416
