### PR TITLE
Handle concurrent updates while hashing passwords

### DIFF
--- a/components/nexus-security-realms/src/main/java/org/sonatype/security/realms/AuthenticatingRealmImpl.java
+++ b/components/nexus-security-realms/src/main/java/org/sonatype/security/realms/AuthenticatingRealmImpl.java
@@ -120,19 +120,19 @@ public class AuthenticatingRealmImpl
   private void reHashPassword(final CUser user, final String password) {
     String hashedPassword = passwordService.encryptPassword(password);
     try {
-      boolean concurrentlyUpdated;
+      boolean updated = false;
       do {
-        concurrentlyUpdated = false;
         CUser toUpdate = configuration.readUser(user.getId());
         toUpdate.setPassword(hashedPassword);
         try {
           configuration.updateUser(user);
+          updated = true;
         }
         catch (ConcurrentModificationException e) {
-          concurrentlyUpdated = true;
+          logger.debug("Could not re-hash user {} password as user was concurrently being updated. Retrying...");
         }
       }
-      while (concurrentlyUpdated);
+      while (!updated);
       user.setPassword(hashedPassword);
     }
     catch (Exception e) {


### PR DESCRIPTION
There could be situations when same user is authenticated at the same and needs password rehashing or that a user is updated (by some admin) while he is authenticated and needs rehashing. In that case, before we added MVCC to security, password rehashing was overwriting changes with possible old data.
The most probably case to happen was for anonymous password due to concurrent access to UI (as can be seen bellow).

The fix will re-read the user & re-update in case of such a concurrent update.
Related I also pre-hashed default users passwords to avoid an unnecessary update: https://github.com/sonatype/nexus-oss/commit/a25cedd1ba4ab61f431d6005f3146ca2500c59b4

```
2014-12-04 18:35:21,826-0800 ERROR [pool-9-thread-1] *UNKNOWN org.sonatype.security.realms.AuthenticatingRealmImpl - Unable to update hash for user anonymous
java.util.ConcurrentModificationException: User anonymous updated in the meantime
    at org.sonatype.nexus.security.source.OrientSecurityModelConfigurationSource$OrientSecurityModelConfiguration.updateUser(OrientSecurityModelConfigurationSource.java:283) [org.sonatype.nexus.core:3.0.0.SNAPSHOT]
    at org.sonatype.security.realms.tools.DefaultConfigurationManager.updateUser(DefaultConfigurationManager.java:373) [org.sonatype.nexus.core:3.0.0.SNAPSHOT]
    at org.sonatype.security.realms.tools.DefaultConfigurationManager.updateUser(DefaultConfigurationManager.java:360) [org.sonatype.nexus.core:3.0.0.SNAPSHOT]
    at org.sonatype.security.realms.tools.DefaultConfigurationManager.updateUser(DefaultConfigurationManager.java:353) [org.sonatype.nexus.core:3.0.0.SNAPSHOT]
    at org.sonatype.security.realms.AuthenticatingRealmImpl.reHashPassword(AuthenticatingRealmImpl.java:124) [org.sonatype.nexus.core:3.0.0.SNAPSHOT]
    at org.sonatype.security.realms.AuthenticatingRealmImpl.doGetAuthenticationInfo(AuthenticatingRealmImpl.java:98) [org.sonatype.nexus.core:3.0.0.SNAPSHOT]
    at org.apache.shiro.realm.AuthenticatingRealm.getAuthenticationInfo(AuthenticatingRealm.java:568) [org.apache.shiro.core:1.2.3]
    at org.sonatype.security.authentication.FirstSuccessfulModularRealmAuthenticator.doMultiRealmAuthentication(FirstSuccessfulModularRealmAuthenticator.java:55) [org.sonatype.nexus.core:3.0.0.SNAPSHOT]
    at org.apache.shiro.authc.pam.ModularRealmAuthenticator.doAuthenticate(ModularRealmAuthenticator.java:269) [org.apache.shiro.core:1.2.3]
    at org.apache.shiro.authc.AbstractAuthenticator.authenticate(AbstractAuthenticator.java:198) [org.apache.shiro.core:1.2.3]
    at org.apache.shiro.mgt.AuthenticatingSecurityManager.authenticate(AuthenticatingSecurityManager.java:106) [org.apache.shiro.core:1.2.3]
    at org.apache.shiro.mgt.DefaultSecurityManager.login(DefaultSecurityManager.java:270) [org.apache.shiro.core:1.2.3]
    at org.apache.shiro.nexus.NexusWebSecurityManager.login(NexusWebSecurityManager.java:52) [org.sonatype.nexus.core:3.0.0.SNAPSHOT]
    at org.apache.shiro.subject.support.DelegatingSubject.login(DelegatingSubject.java:256) [org.apache.shiro.core:1.2.3]
    at org.sonatype.security.DefaultSecuritySystem.login(DefaultSecuritySystem.java:141) [org.sonatype.nexus.core:3.0.0.SNAPSHOT]
```
