### PR TITLE
NXCM1719UpdateSiteProxyIT: use localOnly when walking cached proxy content

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/internal/LocalContentDiscovererImpl.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/internal/LocalContentDiscovererImpl.java
@@ -77,7 +77,7 @@ public class LocalContentDiscovererImpl
         new DiscoveryResult<MavenRepository>(mavenRepository);
     // NEXUS-6485: Since this fix, prefixes will do include empty directories due to "depth" optimization
     final WalkerContext context =
-        new DefaultWalkerContext(mavenRepository, new ResourceStoreRequest("/"),
+        new DefaultWalkerContext(mavenRepository, new ResourceStoreRequest("/", true, false),
             new DepthLimitedStoreWalkerFilter(config.getLocalScrapeDepth()),
             true);
     final PrefixCollectorProcessor prefixCollectorProcessor = new PrefixCollectorProcessor();

--- a/plugins/osgi/nexus-obr-plugin/src/main/java/org/sonatype/nexus/obr/util/ObrUtils.java
+++ b/plugins/osgi/nexus-obr-plugin/src/main/java/org/sonatype/nexus/obr/util/ObrUtils.java
@@ -264,7 +264,7 @@ public final class ObrUtils
         }
       };
 
-      final ResourceStoreRequest request = new ResourceStoreRequest("/");
+      final ResourceStoreRequest request = new ResourceStoreRequest("/", true, false);
       final DefaultWalkerContext ctx = new DefaultWalkerContext(target, request, new ObrWalkerFilter());
       ctx.getProcessors().add(obrProcessor);
       walker.walk(ctx);

--- a/plugins/p2/nexus-p2-repository-plugin/src/main/java/org/sonatype/nexus/plugins/p2/repository/updatesite/UpdateSiteProxyRepositoryImpl.java
+++ b/plugins/p2/nexus-p2-repository-plugin/src/main/java/org/sonatype/nexus/plugins/p2/repository/updatesite/UpdateSiteProxyRepositoryImpl.java
@@ -203,7 +203,7 @@ public class UpdateSiteProxyRepositoryImpl
       mirrorFeature(site, feature, mirrored);
     }
 
-    final ResourceStoreRequest root = new ResourceStoreRequest(RepositoryItemUid.PATH_ROOT);
+    final ResourceStoreRequest root = new ResourceStoreRequest(RepositoryItemUid.PATH_ROOT, true, false);
 
     final DefaultWalkerContext ctx = new DefaultWalkerContext(this, root, filter);
     ctx.getContext().put("mirrored", mirrored);

--- a/plugins/yum/nexus-yum-repository-plugin/src/main/java/org/sonatype/nexus/yum/internal/EventsRouter.java
+++ b/plugins/yum/nexus-yum-repository-plugin/src/main/java/org/sonatype/nexus/yum/internal/EventsRouter.java
@@ -152,7 +152,7 @@ public class EventsRouter
         log.debug("Removing obsolete metadata files... ({}:{} cached)", repository.getId(), item.getPath());
         RepoMD repoMD = new RepoMD(((StorageFileItem) item).getInputStream());
         final Collection<String> locations = repoMD.getLocations();
-        ResourceStoreRequest request = new ResourceStoreRequest("/" + Yum.PATH_OF_REPODATA);
+        ResourceStoreRequest request = new ResourceStoreRequest("/" + Yum.PATH_OF_REPODATA, true, false);
         request.getRequestContext().put(AccessManager.REQUEST_AUTHORIZED, Boolean.TRUE);
         DefaultWalkerContext context = new DefaultWalkerContext(repository, request);
         context.getProcessors().add(new AbstractFileWalkerProcessor()


### PR DESCRIPTION
Explicitly use the localOnly form of ResourceStoreRequest when walking the local content of proxy repositories.

NXCM1719UpdateSiteProxyIT is currently failing because after mirroring the remote content it walks the proxy repository with a `ResourceStoreRequest` that does not have `localOnly` set to `true` (as it was built using the single-argument constructor). This triggers additional unnecessary remote fetching which ends up clearing the previously cached content, failing the IT.

I also fixed a couple of other places that looked like they could be called/used by proxy repositories and were using the single-argument `ResourceStoreRequest` constructor. But strictly speaking only the `UpdateSiteProxyRepositoryImpl` change is required to fix the failing IT.
