### PR TITLE
npm contentUri should always end in slash for publish

### DIFF
--- a/testsuite/modern-testsuite/src/test/java/org/sonatype/nexus/testsuite/npm/publish/PublishIT.java
+++ b/testsuite/modern-testsuite/src/test/java/org/sonatype/nexus/testsuite/npm/publish/PublishIT.java
@@ -66,9 +66,12 @@ public class PublishIT
     final File projectDir = util.createTempDir();
     copyPackageJson(packageName, "0.0.1", privateRegistry.contentUri(), projectDir);
     final File npmrc = testData().resolveFile(".npmrc");
+
     final String cmd = String
         .format("npm --registry %s --cache %s --userconfig %s publish %s",
-            privateRegistry.contentUri(),
+            // appending slash to workaround bug in npm cli versions 2.1.7 to 2.1.16
+            // https://github.com/npm/npm/issues/6982
+            privateRegistry.contentUri() + "/",
             localDirectory.getAbsolutePath(),
             npmrc.getAbsolutePath(),
             projectDir.getAbsolutePath());


### PR DESCRIPTION
In order for npm cli version 2.1.7 or higher to be happy, registry url passed to it must end in slash on _publish_.

I'm not sure if this is an npm cli regression or not, so I filed: https://github.com/npm/npm/issues/6982

This pull has one way to make our client act like an npm cli during publish.

Alternately, we can just append a slash in the [PublishIT](https://github.com/sonatype/nexus-oss/blob/nexus-2.11.x-npm-contenturi-slash/testsuite/modern-testsuite/src/test/java/org/sonatype/nexus/testsuite/npm/publish/PublishIT.java#L71-71).

Ending in slash works for all npm cli versions.

We should probably wait to see what the NPM folks say about this.
