### PR TITLE
NEXUS-7802: Revisit logging, Take 2

### DIFF
--- a/components/nexus-scheduling/src/main/java/org/sonatype/nexus/scheduling/TaskConfiguration.java
+++ b/components/nexus-scheduling/src/main/java/org/sonatype/nexus/scheduling/TaskConfiguration.java
@@ -16,6 +16,8 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.sonatype.sisu.goodies.common.SimpleFormat;
+
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -155,6 +157,15 @@ public final class TaskConfiguration
               && entry.getValue() instanceof String,
           "Invalid entry in map: %s", configuration);
     }
+  }
+
+  /**
+   * Returns assembled string to be used for logging and other (non-UI) purposes. Never returns {@code null} or
+   * empty strung, result should be used as-is, as it contents might change in future.
+   */
+  public String getTaskLogName() {
+    final String name = Strings.isNullOrEmpty(getName()) ? getTypeName() : getName();
+    return SimpleFormat.format("'%s' [%s]", name, getTypeId());
   }
 
   /**

--- a/components/nexus-scheduling/src/main/java/org/sonatype/nexus/scheduling/TaskRemovedException.java
+++ b/components/nexus-scheduling/src/main/java/org/sonatype/nexus/scheduling/TaskRemovedException.java
@@ -22,11 +22,11 @@ public class TaskRemovedException
 {
   public TaskRemovedException(String taskId)
   {
-    super(String.format("NX task '%s' does not exists", taskId));
+    super(String.format("Task '%s' does not exists", taskId));
   }
 
   public TaskRemovedException(String taskId, Throwable cause)
   {
-    super(String.format("NX task '%s' does not exists", taskId), cause);
+    super(String.format("Task '%s' does not exists", taskId), cause);
   }
 }

--- a/components/nexus-scheduling/src/main/java/org/sonatype/nexus/scheduling/internal/DefaultTaskScheduler.java
+++ b/components/nexus-scheduling/src/main/java/org/sonatype/nexus/scheduling/internal/DefaultTaskScheduler.java
@@ -128,14 +128,21 @@ public class DefaultTaskScheduler
       taskConfiguration.setCreated(now);
     }
     taskConfiguration.setUpdated(now);
-    return getScheduler().scheduleTask(taskConfiguration, schedule);
+    final TaskInfo<T> taskInfo = getScheduler().scheduleTask(taskConfiguration, schedule);
+    log.info("Task {} scheduled: {}", taskInfo.getConfiguration().getTaskLogName(), taskInfo.getSchedule().getType());
+    return taskInfo;
   }
 
   @Override
   public <T> TaskInfo<T> rescheduleTask(final String id, final Schedule schedule) {
     checkNotNull(id);
     checkNotNull(schedule);
-    return getScheduler().rescheduleTask(id, schedule);
+    final TaskInfo<T> taskInfo =  getScheduler().rescheduleTask(id, schedule);
+    if (taskInfo != null) {
+      log.info("Task {} rescheduled: {}", taskInfo.getConfiguration().getTaskLogName(),
+          taskInfo.getSchedule().getType());
+    }
+    return taskInfo;
   }
 
   /**
@@ -146,7 +153,7 @@ public class DefaultTaskScheduler
   {
     log.debug("Creating task configuration for task descriptor: {}", taskDescriptor.getId());
     final TaskConfiguration taskConfiguration = new TaskConfiguration();
-    taskConfiguration.setId(generateId(taskDescriptor.getType().getName(), taskConfiguration));
+    taskConfiguration.setId(generateId());
     taskConfiguration.setTypeId(taskDescriptor.getId());
     taskConfiguration.setTypeName(taskDescriptor.getName());
     taskConfiguration.setName(taskDescriptor.getName());
@@ -157,10 +164,9 @@ public class DefaultTaskScheduler
   /**
    * Creates a unique ID for the task.
    */
-  private String generateId(final String taskFQCName,
-                            final TaskConfiguration taskConfiguration)
+  private String generateId()
   {
-    // TODO: call into quartz for this? Must not clash with existing persisted job IDs!
+    // TODO: revisit some possible alternative?
     return UUID.randomUUID().toString();
   }
 

--- a/plugins/basic/nexus-quartz-plugin/src/main/java/org/sonatype/nexus/quartz/internal/QuartzSupportImpl.java
+++ b/plugins/basic/nexus-quartz-plugin/src/main/java/org/sonatype/nexus/quartz/internal/QuartzSupportImpl.java
@@ -348,7 +348,7 @@ public class QuartzSupportImpl
       return scheduler.interrupt(jobKey);
     }
     catch (UnableToInterruptJobException e) {
-      log.info("Unable to interrupt job with key {}", jobKey, e);
+      log.debug("Unable to interrupt job with key {}", jobKey, e);
     }
     return false;
   }

--- a/plugins/basic/nexus-quartz-plugin/src/main/java/org/sonatype/nexus/quartz/internal/nexus/NexusTaskJobListener.java
+++ b/plugins/basic/nexus-quartz-plugin/src/main/java/org/sonatype/nexus/quartz/internal/nexus/NexusTaskJobListener.java
@@ -116,7 +116,7 @@ public class NexusTaskJobListener<T>
 
   @Override
   public void jobToBeExecuted(final JobExecutionContext context) {
-    log.trace("Job {} jobToBeExecuted", jobKey.getName());
+    log.trace("Job {} : {} jobToBeExecuted", jobKey.getName(), nexusTaskInfo.getConfiguration().getTaskLogName());
     // get current trigger, which in this method SHOULD be job's trigger.
     // Still, in some circumstances (that I cannot imagine right now, except to have concurrency bug)
     // the NX Task's Trigger might be missing. Still, we don't want to throw in this listener
@@ -126,8 +126,10 @@ public class NexusTaskJobListener<T>
 
     NexusTaskFuture<T> future = nexusTaskInfo.getNexusTaskFuture();
     if (future == null) {
-      log.trace("Job {} has no future, creating it", jobKey.getName());
-      future = new NexusTaskFuture<>(quartzSupport, jobKey, context.getFireTime(),
+      log.trace("Job {} : {} has no future, creating it", jobKey.getName(),
+          nexusTaskInfo.getConfiguration().getTaskLogName());
+      future = new NexusTaskFuture<>(quartzSupport, jobKey, nexusTaskInfo.getConfiguration().getTaskLogName(),
+          context.getFireTime(),
           nexusScheduleConverter.toSchedule(context.getTrigger()));
       // set the future on taskinfo
       nexusTaskInfo.setNexusTaskState(
@@ -147,7 +149,7 @@ public class NexusTaskJobListener<T>
 
   @Override
   public void jobWasExecuted(final JobExecutionContext context, final JobExecutionException jobException) {
-    log.trace("Job {} jobWasExecuted", jobKey.getName());
+    log.trace("Job {} : {} jobWasExecuted", jobKey.getName(), nexusTaskInfo.getConfiguration().getTaskLogName());
     final NexusTaskFuture<T> future = (NexusTaskFuture<T>) context.get(NexusTaskFuture.FUTURE_KEY);
     // on Executed, the taskInfo might be removed or even replaced, so use the one we started with
     // DO NOT TOUCH the listener's instance
@@ -169,7 +171,8 @@ public class NexusTaskJobListener<T>
         endState,
         future.getStartedAt(),
         System.currentTimeMillis() - future.getStartedAt().getTime());
-    log.trace("Job {} lastRunState={}", jobKey.getName(), endState);
+    log.trace("Job {} : {} lastRunState={}", jobKey.getName(), nexusTaskInfo.getConfiguration().getTaskLogName(),
+        endState);
 
     Trigger currentTrigger = getCurrentTrigger(context);
 

--- a/plugins/basic/nexus-quartz-plugin/src/main/java/org/sonatype/nexus/quartz/internal/nexus/NexusTaskJobSupport.java
+++ b/plugins/basic/nexus-quartz-plugin/src/main/java/org/sonatype/nexus/quartz/internal/nexus/NexusTaskJobSupport.java
@@ -127,26 +127,26 @@ public class NexusTaskJobSupport<T>
         }
       }
       catch (TaskInterruptedException e) {
-        log.debug("NX Task {}:{} canceled:", taskConfiguration.getTypeId(), taskConfiguration.getId(), e);
+        log.debug("Task {} : {} canceled:", taskConfiguration.getId(), taskConfiguration.getTaskLogName(), e);
         if (!nexusTaskInfo.getNexusTaskFuture().isCancelled()) {
           nexusTaskInfo.getNexusTaskFuture().doCancel();
           eventBus.post(new TaskEventCanceled<>(nexusTaskInfo));
         }
       }
       catch (InterruptedException e) {
-        log.debug("NX Task {}:{} interrupted:", taskConfiguration.getTypeId(), taskConfiguration.getId(), e);
+        log.debug("Task {} : {} interrupted:", taskConfiguration.getId(), taskConfiguration.getTaskLogName(), e);
         // this is non-cancelable task being interrupted, do the paperwork in this case
         // same as would be done for cancelable tasks in case of #interrupt()
         nexusTaskInfo.getNexusTaskFuture().doCancel();
         eventBus.post(new TaskEventCanceled<>(nexusTaskInfo));
       }
       catch (Exception e) {
-        log.warn("Task execution failure: {}:{}", taskConfiguration.getTypeId(), taskConfiguration.getId(), e);
+        log.warn("Task {} : {} execution failure", taskConfiguration.getId(), taskConfiguration.getTaskLogName(), e);
         ex = e;
       }
     }
     catch (Exception e) {
-      log.warn("Task instantiation failure: {}", context.getJobDetail().getKey(), e);
+      log.warn("Task {} instantiation failure", context.getJobDetail().getKey(), e);
       ex = e;
     }
     if (ex != null) {
@@ -199,6 +199,7 @@ public class NexusTaskJobSupport<T>
         return;
       }
       else {
+        log.info("Task {} not cancelable", nexusTask.taskConfiguration().getTaskLogName());
         throw new UnableToInterruptJobException("Task " + nexusTask + " not Cancellable");
       }
     }


### PR DESCRIPTION
Logging revisited. Introduced "logging name" of task based
on it's configuration to make it more user friendly than
UUID (actually two UUIDs, one for NX Task and one for QZ Job!)
Also, simplified logging (ie. using "Task" instead of "NX Task", etc).

UUID should NOT appear in logs if loggers at INFO level. Still, at DEBUG
and TRACE they ARE logged, to be able to identify them in case of DB dump
analysis.

Also, removed one unused method from QuartzTaskExecutorSPI.

Issue
https://issues.sonatype.org/browse/NEXUS-7802

CI
http://bamboo.s/browse/NX-OSSF476