### PR TITLE
Fix target privilege XO

### DIFF
--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/PrivilegeComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/PrivilegeComponent.groovy
@@ -160,17 +160,19 @@ extends DirectComponentSupport
         privilege.repositoryTargetName = targetRegistry.getRepositoryTarget(value)?.name
       }
       else if (key == 'repositoryId' || key == 'repositoryGroupId') {
-        privilege.repositoryId = value
-        if (value && value != '*' && !value.allWhitespace) {
-          try {
-            privilege.repositoryName = repositoryRegistry.getRepository(value).name
+        if (!privilege.repositoryId) { // check not already mapped
+          privilege.repositoryId = value
+          if (value && value != '*' && !value.allWhitespace) {
+            try {
+              privilege.repositoryName = repositoryRegistry.getRepository(value).name
+            }
+            catch (NoSuchRepositoryException e) {
+              privilege.repositoryName = value
+            }
           }
-          catch (NoSuchRepositoryException e) {
-            privilege.repositoryName = value
+          else {
+            privilege.repositoryName = 'All repositories'
           }
-        }
-        else {
-          privilege.repositoryName = 'All repositories'
         }
       }
     }


### PR DESCRIPTION
Target privileges have both 'repositoryId' and 'repositoryGroupId' as fields,
but only one will have a non-null value. Both fields map to the same property
in the XO object, so make sure we don't overwrite the non-null value with the
null value when preparing the target privilege for transfer.

This fixes the SecurityIT functional test which fails with Java8 due to differences
in the ordering of fields when mapping the internal object to the transfer object.

Diff ignoring whitespace: https://github.com/sonatype/nexus-oss/pull/948/files?w=1

http://bamboo.s/browse/NX-OSSF477-1 :white_check_mark: 