### PR TITLE
nexus-2.11.x [NEXUS-7903] fix content-range algorithm

### DIFF
--- a/plugins/basic/nexus-content-plugin/src/main/java/org/sonatype/nexus/content/internal/ContentServlet.java
+++ b/plugins/basic/nexus-content-plugin/src/main/java/org/sonatype/nexus/content/internal/ContentServlet.java
@@ -522,7 +522,7 @@ public class ContentServlet
           response.setHeader("Content-Range", "bytes */" + file.getLength());
           return;
         }
-        final long bodySize = range.upperEndpoint() - range.lowerEndpoint();
+        final long bodySize = 1 + range.upperEndpoint() - range.lowerEndpoint();
         response.setStatus(SC_PARTIAL_CONTENT);
         response.setHeader("Content-Length", String.valueOf(bodySize));
         response.setHeader("Content-Range",
@@ -639,7 +639,7 @@ public class ContentServlet
           }
           else if (rangeValue.endsWith("-")) {
             return Collections.singletonList(Range.closed(
-                Long.parseLong(rangeValue.substring(0, rangeValue.length() - 1)), contentLength));
+                Long.parseLong(rangeValue.substring(0, rangeValue.length() - 1)), contentLength - 1));
           }
           else if (rangeValue.contains("-")) {
             final String[] parts = rangeValue.split("-");
@@ -671,6 +671,6 @@ public class ContentServlet
    * Returns {@code true} if the {@link Range} is applicable to file (file full closed range encloses passed in range).
    */
   protected boolean isRequestedRangeSatisfiable(final StorageFileItem file, final Range<Long> range) {
-    return Range.closed(0L, file.getLength()).encloses(range);
+    return Range.closed(0L, file.getLength() - 1).encloses(range);
   }
 }

--- a/testsuite/modern-testsuite/src/test/java/org/sonatype/nexus/testsuite/content/range/ContentRangeIT.java
+++ b/testsuite/modern-testsuite/src/test/java/org/sonatype/nexus/testsuite/content/range/ContentRangeIT.java
@@ -56,7 +56,7 @@ public class ContentRangeIT
   public void validRangesBeginning() throws IOException {
     final ByteArrayOutputStream bos = new ByteArrayOutputStream();
     // get 1st word
-    content().downloadRange(location, bos, Range.closed(0L, 10L));
+    content().downloadRange(location, bos, Range.closed(0L, 9L));
     final String data = new String(bos.toByteArray(), CHARSET);
     assertThat(data, equalTo("0123456789"));
   }
@@ -65,7 +65,7 @@ public class ContentRangeIT
   public void validRangesBeginningShiftedNine() throws IOException {
     final ByteArrayOutputStream bos = new ByteArrayOutputStream();
     // get 1st word
-    content().downloadRange(location, bos, Range.closed(1L, 10L));
+    content().downloadRange(location, bos, Range.closed(1L, 9L));
     final String data = new String(bos.toByteArray(), CHARSET);
     assertThat(data, equalTo("123456789"));
   }
@@ -74,7 +74,7 @@ public class ContentRangeIT
   public void validRangesBeginningShiftedTen() throws IOException {
     final ByteArrayOutputStream bos = new ByteArrayOutputStream();
     // get 1st word
-    content().downloadRange(location, bos, Range.closed(1L, 11L));
+    content().downloadRange(location, bos, Range.closed(1L, 10L));
     final String data = new String(bos.toByteArray(), CHARSET);
     assertThat(data, equalTo("1234567890"));
   }
@@ -83,16 +83,25 @@ public class ContentRangeIT
   public void validRangesMiddle() throws IOException {
     final ByteArrayOutputStream bos = new ByteArrayOutputStream();
     // get middle
-    content().downloadRange(location, bos, Range.closed(45L, 55L));
+    content().downloadRange(location, bos, Range.closed(45L, 54L));
     final String data = new String(bos.toByteArray(), CHARSET);
     assertThat(data, equalTo("5678901234"));
+  }
+
+  @Test
+  public void validRangesMiddleOneByte() throws IOException {
+    final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    // get middle
+    content().downloadRange(location, bos, Range.closed(48L, 48L));
+    final String data = new String(bos.toByteArray(), CHARSET);
+    assertThat(data, equalTo("8"));
   }
 
   @Test
   public void validRangesEnd() throws IOException {
     final ByteArrayOutputStream bos = new ByteArrayOutputStream();
     // get last word
-    content().downloadRange(location, bos, Range.closed(90L, 100L));
+    content().downloadRange(location, bos, Range.closed(90L, 99L));
     final String data = new String(bos.toByteArray(), CHARSET);
     assertThat(data, equalTo("0123456789"));
   }
@@ -100,7 +109,7 @@ public class ContentRangeIT
   @Test
   public void validRangesSameAsActualContent() throws IOException {
     final ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    content().downloadRange(location, bos, Range.closed(0L, 100L));
+    content().downloadRange(location, bos, Range.closed(0L, 99L));
     final String data = new String(bos.toByteArray(), CHARSET);
     assertThat(data, equalTo(TEST_DATA));
   }
@@ -108,7 +117,7 @@ public class ContentRangeIT
   @Test
   public void invalidRangesNegativeIsIgnoredAndFullFileReturned() throws IOException {
     final ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    content().downloadRange(location, bos, Range.closed(-100L, 100L));
+    content().downloadRange(location, bos, Range.closed(-1L, 99L));
     final String data = new String(bos.toByteArray(), CHARSET);
     assertThat(data, equalTo(TEST_DATA));
   }


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-7903
http://bamboo.s/browse/NX-OSSF483-2 :white_check_mark: 

* a range request of 0-0 should return one byte
* implicit range boundary should be length-1
* the satisfiable range should be [0..length-1]

Please check carefully against http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.16