### PR TITLE
Upgrade OrientDB to 2.0-rc2

### DIFF
--- a/assemblies/nexus-base-edition/src/main/feature/feature.xml
+++ b/assemblies/nexus-base-edition/src/main/feature/feature.xml
@@ -29,7 +29,6 @@
     -->
     <bundle>wrap:${mvn:shiro-guice}$overwrite=merge&amp;Import-Package=*</bundle>
     <bundle>wrap:${mvn:xstream}$overwrite=merge&amp;-exportcontents=*&amp;DynamicImport-Package=*</bundle>
-    <bundle>wrap:${mvn:orientdb-graphdb}$overwrite=merge&amp;Import-Package=com.tinkerpop.*;resolution:=optional,*</bundle>
     <!--
     Install nexus-specific shell commands
     -->

--- a/buildsupport/db/pom.xml
+++ b/buildsupport/db/pom.xml
@@ -28,7 +28,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <orientdb.version>2.0-rc1</orientdb.version>
+    <orientdb.version>2.0-rc2</orientdb.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -710,7 +710,6 @@
               <id>httpclient</id>
               <id>maven-model</id>
               <id>maven-model-builder</id>
-              <id>orientdb-graphdb</id>
               <id>xmlpull</id>
               <id>xpp3_min</id>
               <id>shiro-guice</id>


### PR DESCRIPTION
http://bamboo.s/browse/NX-OSSF484-1

2.0-rc2 includes fixes to OSGi metadata in orient-graphdb meaning we can drop our local workaround.