### PR TITLE
NEXUS-7911: fix javax.el discovery

### DIFF
--- a/assemblies/nexus-base-edition/src/main/feature/feature.xml
+++ b/assemblies/nexus-base-edition/src/main/feature/feature.xml
@@ -17,7 +17,8 @@
     <!--
     Wrappers that require use of fragments
     -->
-    <bundle>wrap:${mvn:hibernate-validator}$overwrite=merge&amp;Fragment-Host=javax.validation.api</bundle>
+    <bundle>wrap:${mvn:javax.el}$overwrite=merge&amp;Fragment-Host=org.hibernate.validator</bundle>
+    <bundle>wrap:${mvn:validation-api}$overwrite=merge&amp;Fragment-Host=org.hibernate.validator</bundle>
     <bundle>wrap:${mvn:httpcore}$Bundle-SymbolicName=httpcore</bundle>
     <bundle>wrap:${mvn:httpclient}$Bundle-SymbolicName=httpclient&amp;Fragment-Host=httpcore</bundle>
     <bundle>wrap:${mvn:maven-model}$Bundle-SymbolicName=maven-model</bundle>

--- a/components/nexus-extender/src/main/java/org/sonatype/nexus/extender/modules/ValidationInterceptor.java
+++ b/components/nexus-extender/src/main/java/org/sonatype/nexus/extender/modules/ValidationInterceptor.java
@@ -25,6 +25,7 @@ import org.sonatype.nexus.validation.Validate;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+import org.hibernate.validator.HibernateValidator;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -44,7 +45,7 @@ public class ValidationInterceptor
 
     final ClassLoader tccl = Thread.currentThread().getContextClassLoader();
     try {
-      Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+      Thread.currentThread().setContextClassLoader(HibernateValidator.class.getClassLoader());
       final Validate validate = mi.getMethod().getAnnotation(Validate.class);
 
       validateParameters(mi.getThis(), mi.getMethod(), mi.getArguments(), validate.groups());

--- a/pom.xml
+++ b/pom.xml
@@ -693,7 +693,8 @@
               <!--
               Need special wrapping/fragments
               -->
-              <id>hibernate-validator</id>
+              <id>javax.el</id>
+              <id>validation-api</id>
               <id>httpcore</id>
               <id>httpclient</id>
               <id>maven-model</id>


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-7911
http://bamboo.s/browse/NX-OSSF486-1 :white_check_mark: 

The javax.el factory assumes its implementation will be visible from the TCCL:

 * Made javax.el implementation bundle a fragment of hibernate-validator
 * Switched validation-api to be fragment of hibernate-validator instead of vice-versa
 * Used hibernate-validator as the TCCL during validation interception

This makes sure that the service loader lookup in validation-api can see the
hibernate-validator implementation (as they're still merged in the same space)
but also that the javax.el implementation can now be seen from the same TCCL.