### PR TITLE
[2.11.x] Support RUT Auth on /content URL's

### DIFF
--- a/plugins/basic/nexus-content-plugin/src/main/java/org/sonatype/nexus/content/internal/ContentAuthenticationFilter.java
+++ b/plugins/basic/nexus-content-plugin/src/main/java/org/sonatype/nexus/content/internal/ContentAuthenticationFilter.java
@@ -20,8 +20,10 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
 import org.sonatype.nexus.content.ContentRestrictionConstituent;
+import org.sonatype.nexus.security.filter.authc.AuthenticationTokenFactory;
 import org.sonatype.nexus.security.filter.authc.NexusHttpAuthenticationFilter;
 
+import com.google.common.base.Throwables;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.web.filter.authc.AuthenticationFilter;
@@ -38,9 +40,14 @@ public class ContentAuthenticationFilter
 {
   private final List<ContentRestrictionConstituent> constituents;
 
+  private List<AuthenticationTokenFactory> factories;
+
   @Inject
-  public ContentAuthenticationFilter(final @Nullable List<ContentRestrictionConstituent> constituents) {
+  public ContentAuthenticationFilter(final @Nullable List<ContentRestrictionConstituent> constituents,
+                                     final @Nullable List<AuthenticationTokenFactory> factories)
+  {
     this.constituents = constituents;
+    this.factories = factories;
     setApplicationName("Sonatype Nexus Repository Manager");
   }
 
@@ -71,7 +78,57 @@ public class ContentAuthenticationFilter
       return new ContentRestrictedToken(basis, request);
     }
     else {
+      AuthenticationToken token = createAuthenticationToken(request, response);
+      if (token != null) {
+        return token;
+      }
       return super.createToken(request, response);
     }
+  }
+
+  @Override
+  protected boolean isAccessAllowed(final ServletRequest request, final ServletResponse response,
+                                    final Object mappedValue)
+  {
+    if (!isRestricted(request) && isLoginAttempt(request, response)) {
+      try {
+        return executeLogin(request, response) && super.isAccessAllowed(request, response, mappedValue);
+      }
+      catch (Exception e) {
+        throw Throwables.propagate(e);
+      }
+    }
+    return super.isAccessAllowed(request, response, mappedValue);
+  }
+
+  @Override
+  protected boolean isLoginAttempt(ServletRequest request, ServletResponse response) {
+    if (isRestricted(request)) {
+      return super.isLoginAttempt(request, response);
+    }
+    AuthenticationToken token = createAuthenticationToken(request, response);
+    return token != null || super.isLoginAttempt(request, response);
+  }
+
+  private AuthenticationToken createAuthenticationToken(ServletRequest request, ServletResponse response) {
+    if (factories != null) {
+      for (AuthenticationTokenFactory factory : factories) {
+        try {
+          AuthenticationToken token = factory.createToken(request, response);
+          if (token != null) {
+            getLogger().debug("Token '{}' created by {}", token, factory);
+            return token;
+          }
+        }
+        catch (Exception e) {
+          getLogger().warn(
+              "Factory {} failed to create an authentication token {}/{}",
+              factory, e.getClass().getName(), e.getMessage(),
+              getLogger().isDebugEnabled() ? e : null
+          );
+        }
+      }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-7889
http://bamboo.s/browse/NX-OSSF490

Applied same logic as in NexusAuthenticationFilter in order to support RUT Auth. 
If content is protected (user token enabled and protects content), RUT auth is skipped (will work as before).

Manually ran user token UT/ITs and they all pass.