### PR TITLE
NEXUS-7901 groovy upgrade

### DIFF
--- a/buildsupport/groovy/pom.xml
+++ b/buildsupport/groovy/pom.xml
@@ -16,9 +16,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <properties>
-    <groovy.version>2.3.7</groovy.version>
-  </properties>
 
   <parent>
     <groupId>org.sonatype.nexus.buildsupport</groupId>
@@ -30,6 +27,10 @@
   <name>${project.groupId}:${project.artifactId}</name>
   <packaging>pom</packaging>
 
+  <properties>
+    <groovy.version>2.3.7</groovy.version>
+  </properties>
+  
   <dependencyManagement>
     <dependencies>
 

--- a/buildsupport/groovy/pom.xml
+++ b/buildsupport/groovy/pom.xml
@@ -16,6 +16,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <groovy.version>2.3.7</groovy.version>
+  </properties>
 
   <parent>
     <groupId>org.sonatype.nexus.buildsupport</groupId>
@@ -33,13 +36,13 @@
       <dependency>
         <groupId>org.codehaus.groovy</groupId>
         <artifactId>groovy-all</artifactId>
-        <version>2.1.5</version>
+        <version>${groovy.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.codehaus.groovy</groupId>
         <artifactId>groovy</artifactId>
-        <version>2.1.5</version>
+        <version>${groovy.version}</version>
       </dependency>
 
       <!--

--- a/plugins/capabilities/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/capability/internal/ui/CapabilityComponent.groovy
+++ b/plugins/capabilities/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/capability/internal/ui/CapabilityComponent.groovy
@@ -199,7 +199,7 @@ extends DirectComponentSupport
     capabilityRegistry.disable(capabilityIdentity(id))
   }
 
-  private static CapabilityXO asCapability(final CapabilityReference reference) {
+  static CapabilityXO asCapability(final CapabilityReference reference) {
     CapabilityDescriptor descriptor = reference.context().descriptor()
     Capability capability = reference.capability()
 

--- a/plugins/capabilities/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/capability/internal/ui/CapabilityComponent.groovy
+++ b/plugins/capabilities/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/capability/internal/ui/CapabilityComponent.groovy
@@ -14,6 +14,7 @@ package org.sonatype.nexus.capability.internal.ui
 
 import com.softwarementors.extjs.djn.config.annotations.DirectAction
 import com.softwarementors.extjs.djn.config.annotations.DirectMethod
+import groovy.transform.PackageScope
 import org.apache.shiro.authz.annotation.RequiresAuthentication
 import org.apache.shiro.authz.annotation.RequiresPermissions
 import org.hibernate.validator.constraints.NotEmpty
@@ -199,6 +200,7 @@ extends DirectComponentSupport
     capabilityRegistry.disable(capabilityIdentity(id))
   }
 
+  @PackageScope
   static CapabilityXO asCapability(final CapabilityReference reference) {
     CapabilityDescriptor descriptor = reference.context().descriptor()
     Capability capability = reference.capability()

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/GeneralSettingsComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/GeneralSettingsComponent.groovy
@@ -75,7 +75,7 @@ extends DirectComponentSupport
     return read()
   }
 
-  private static validate(final GeneralSettingsXO generalSettingsXO) {
+  static validate(final GeneralSettingsXO generalSettingsXO) {
     def validations = new ValidationResponse()
     if (!StringUtils.isBlank(generalSettingsXO.baseUrl)) {
       try {

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/GeneralSettingsComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/GeneralSettingsComponent.groovy
@@ -14,6 +14,7 @@ package org.sonatype.nexus.coreui
 
 import com.softwarementors.extjs.djn.config.annotations.DirectAction
 import com.softwarementors.extjs.djn.config.annotations.DirectMethod
+import groovy.transform.PackageScope
 import org.apache.commons.lang.StringUtils
 import org.apache.shiro.authz.annotation.RequiresAuthentication
 import org.apache.shiro.authz.annotation.RequiresPermissions
@@ -75,6 +76,7 @@ extends DirectComponentSupport
     return read()
   }
 
+  @PackageScope
   static validate(final GeneralSettingsXO generalSettingsXO) {
     def validations = new ValidationResponse()
     if (!StringUtils.isBlank(generalSettingsXO.baseUrl)) {

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/HttpSettingsComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/HttpSettingsComponent.groovy
@@ -14,6 +14,7 @@ package org.sonatype.nexus.coreui
 
 import com.softwarementors.extjs.djn.config.annotations.DirectAction
 import com.softwarementors.extjs.djn.config.annotations.DirectMethod
+import groovy.transform.PackageScope
 import org.apache.commons.lang.StringUtils
 import org.apache.shiro.authz.annotation.RequiresAuthentication
 import org.apache.shiro.authz.annotation.RequiresPermissions
@@ -123,6 +124,7 @@ extends DirectComponentSupport
     return read()
   }
 
+  @PackageScope
   static fromRemoteHttpProxySettings(final RemoteHttpProxySettings settings) {
     def enabled = false, hostname = null, port = null, username = null, ntlmHost = null, ntlmDomain = null
     if (settings) {
@@ -146,6 +148,7 @@ extends DirectComponentSupport
     return [enabled, hostname, port, username, ntlmHost, ntlmDomain]
   }
 
+  @PackageScope
   static toRemoteHttpProxySettings(final Boolean enabled,
                                            final String hostname,
                                            final Integer port,
@@ -173,6 +176,7 @@ extends DirectComponentSupport
     return null
   }
 
+  @PackageScope
   static String getPassword(Password password, RemoteAuthenticationSettings settings) {
     if (password?.valid) {
       return password.value

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/HttpSettingsComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/HttpSettingsComponent.groovy
@@ -123,7 +123,7 @@ extends DirectComponentSupport
     return read()
   }
 
-  private static fromRemoteHttpProxySettings(final RemoteHttpProxySettings settings) {
+  static fromRemoteHttpProxySettings(final RemoteHttpProxySettings settings) {
     def enabled = false, hostname = null, port = null, username = null, ntlmHost = null, ntlmDomain = null
     if (settings) {
       enabled = settings.enabled
@@ -146,7 +146,7 @@ extends DirectComponentSupport
     return [enabled, hostname, port, username, ntlmHost, ntlmDomain]
   }
 
-  private static toRemoteHttpProxySettings(final Boolean enabled,
+  static toRemoteHttpProxySettings(final Boolean enabled,
                                            final String hostname,
                                            final Integer port,
                                            final Boolean auth,
@@ -173,7 +173,7 @@ extends DirectComponentSupport
     return null
   }
 
-  def static String getPassword(Password password, RemoteAuthenticationSettings settings) {
+  static String getPassword(Password password, RemoteAuthenticationSettings settings) {
     if (password?.valid) {
       return password.value
     }

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/MavenUploadComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/MavenUploadComponent.groovy
@@ -105,6 +105,7 @@ extends DirectComponentSupport
     }
   }
 
+  @PackageScope
   static ArtifactStoreRequest createRequest(final FileItem file,
                                                     final MavenRepository mavenRepository,
                                                     final UploadContext uploadContext,
@@ -140,7 +141,7 @@ extends DirectComponentSupport
 
   @PackageScope
   static UploadContext createUploadContext(final Map<String, String> params,
-                                                   final Map<String, FileItem> files)
+      final Map<String, FileItem> files)
   {
     UploadContext context = new UploadContext(
         pomAvailable: false,

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/MavenUploadComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/MavenUploadComponent.groovy
@@ -104,7 +104,7 @@ extends DirectComponentSupport
     }
   }
 
-  private static ArtifactStoreRequest createRequest(final FileItem file,
+  static ArtifactStoreRequest createRequest(final FileItem file,
                                                     final MavenRepository mavenRepository,
                                                     final UploadContext uploadContext,
                                                     final RequestContext requestContext,
@@ -137,7 +137,7 @@ extends DirectComponentSupport
     return result
   }
 
-  private static UploadContext createUploadContext(final Map<String, String> params,
+  static UploadContext createUploadContext(final Map<String, String> params,
                                                    final Map<String, FileItem> files)
   {
     UploadContext context = new UploadContext(
@@ -188,7 +188,7 @@ extends DirectComponentSupport
     return context
   }
 
-  private static RequestContext createRequestContext(final HttpServletRequest request) {
+  static RequestContext createRequestContext(final HttpServletRequest request) {
     RequestContext context = new RequestContext(
         userId: SecurityUtils.subject?.principal as String,
         userAgent: request.getHeader('user-agent'),
@@ -234,7 +234,7 @@ extends DirectComponentSupport
     }
   }
 
-  private static isPom(final FileItem file, final Map<String, String> params) {
+  static isPom(final FileItem file, final Map<String, String> params) {
     def extension = params["${file.fieldName}.extension"]
     def classifier = params["${file.fieldName}.classifier"]
     return extension == 'pom' && StringUtils.isEmpty(classifier)

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/MavenUploadComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/MavenUploadComponent.groovy
@@ -15,6 +15,7 @@ package org.sonatype.nexus.coreui
 import com.softwarementors.extjs.djn.config.annotations.DirectAction
 import com.softwarementors.extjs.djn.config.annotations.DirectFormPostMethod
 import com.softwarementors.extjs.djn.servlet.ssm.WebContextManager
+import groovy.transform.PackageScope
 import org.apache.commons.fileupload.FileItem
 import org.apache.commons.lang.StringUtils
 import org.apache.maven.model.Model
@@ -137,6 +138,7 @@ extends DirectComponentSupport
     return result
   }
 
+  @PackageScope
   static UploadContext createUploadContext(final Map<String, String> params,
                                                    final Map<String, FileItem> files)
   {
@@ -188,6 +190,7 @@ extends DirectComponentSupport
     return context
   }
 
+  @PackageScope
   static RequestContext createRequestContext(final HttpServletRequest request) {
     RequestContext context = new RequestContext(
         userId: SecurityUtils.subject?.principal as String,
@@ -213,6 +216,7 @@ extends DirectComponentSupport
     return context
   }
 
+  @PackageScope
   static void validateRepositoryPolicy(final MavenRepository mavenRepository, final String version) {
     def validations = new ValidationResponse()
     if (Gav.isSnapshot(version)) {
@@ -234,6 +238,7 @@ extends DirectComponentSupport
     }
   }
 
+  @PackageScope
   static isPom(final FileItem file, final Map<String, String> params) {
     def extension = params["${file.fieldName}.extension"]
     def classifier = params["${file.fieldName}.classifier"]

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/PrivilegeComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/PrivilegeComponent.groovy
@@ -14,7 +14,7 @@ package org.sonatype.nexus.coreui
 
 import com.softwarementors.extjs.djn.config.annotations.DirectAction
 import com.softwarementors.extjs.djn.config.annotations.DirectMethod
-import groovy.transform.CompileStatic
+import groovy.transform.PackageScope
 import org.apache.shiro.authz.annotation.RequiresAuthentication
 import org.apache.shiro.authz.annotation.RequiresPermissions
 import org.hibernate.validator.constraints.NotEmpty
@@ -53,7 +53,6 @@ import javax.validation.groups.Default
 @Named
 @Singleton
 @DirectAction(action = 'coreui_Privilege')
-@CompileStatic
 class PrivilegeComponent
 extends DirectComponentSupport
 {
@@ -144,7 +143,8 @@ extends DirectComponentSupport
     authorizationManager.deletePrivilege(id)
   }
 
-  def PrivilegeXO asPrivilegeXO(Privilege input) {
+  @PackageScope
+  PrivilegeXO asPrivilegeXO(Privilege input) {
     def privilege = new PrivilegeXO(
         id: input.id,
         version: input.version,

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/RepositoryComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/RepositoryComponent.groovy
@@ -938,7 +938,7 @@ extends DirectComponentSupport
     return null
   }
 
-  private static Predicate<Repository> hasAnyOfContentClasses(final String[] contentClasses) {
+  static Predicate<Repository> hasAnyOfContentClasses(final String[] contentClasses) {
     if (contentClasses) {
       List<Predicate<Repository>> predicates = []
       contentClasses.each { String contentClass ->
@@ -961,7 +961,7 @@ extends DirectComponentSupport
     return null
   }
 
-  private static Predicate<Repository> hasNoneOfContentClasses(final String[] contentClasses) {
+  static Predicate<Repository> hasNoneOfContentClasses(final String[] contentClasses) {
     if (contentClasses) {
       List<Predicate<Repository>> predicates = []
       contentClasses.each { String contentClass ->

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/RepositoryComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/RepositoryComponent.groovy
@@ -12,6 +12,7 @@
  */
 package org.sonatype.nexus.coreui
 
+import groovy.transform.PackageScope
 import org.sonatype.nexus.scheduling.TaskScheduler
 import org.sonatype.nexus.scheduling.TaskConfiguration
 
@@ -99,6 +100,8 @@ extends DirectComponentSupport
 
   private static final TRUST_STORE_TYPE = 'repository'
 
+  private static final Pattern BRACKETS_PATTERN = Pattern.compile("(.*)( \\(.*\\))")
+
   @Inject
   @Named("protected")
   RepositoryRegistry protectedRepositoryRegistry
@@ -135,7 +138,7 @@ extends DirectComponentSupport
   @Inject
   Validator validator
 
-  def typesToClass = [
+  Map typesToClass = [
       'proxy': ProxyRepository.class,
       'hosted': HostedRepository.class,
       'shadow': ShadowRepository.class,
@@ -431,7 +434,8 @@ extends DirectComponentSupport
     }
   }
 
-  def RepositoryXO create(RepositoryXO repositoryXO, Closure... createClosures) {
+  @PackageScope
+  RepositoryXO create(RepositoryXO repositoryXO, Closure... createClosures) {
     def template = templateManager.templates.getTemplateById(repositoryXO.template) as RepositoryTemplate
     CRepository configuration = template.configurableRepository.getCurrentConfiguration(true)
     createClosures.each { createClosure ->
@@ -441,7 +445,8 @@ extends DirectComponentSupport
     return asRepositoryXO(created, readTemplates(null))
   }
 
-  def <T extends Repository> RepositoryXO update(RepositoryXO repositoryXO, Class<T> repoType, Closure... updateClosures) {
+  @PackageScope
+  <T extends Repository> RepositoryXO update(RepositoryXO repositoryXO, Class<T> repoType, Closure... updateClosures) {
     if (repositoryXO.id) {
       T updated = protectedRepositoryRegistry.getRepositoryWithFacet(repositoryXO.id, repoType)
       updateClosures.each { updateClosure ->
@@ -453,7 +458,8 @@ extends DirectComponentSupport
     throw new IllegalArgumentException('Missing id for repository to be updated')
   }
 
-  def static doCreate = { CRepository repo, RepositoryXO repositoryXO ->
+  @PackageScope
+  static Closure doCreate = { CRepository repo, RepositoryXO repositoryXO ->
     repo.with {
       id = repositoryXO.id
       name = repositoryXO.name
@@ -473,7 +479,8 @@ extends DirectComponentSupport
     }
   }
 
-  def static doUpdate = { Repository repo, RepositoryXO repositoryXO ->
+  @PackageScope
+  static Closure doUpdate = { Repository repo, RepositoryXO repositoryXO ->
     repo.with {
       name = repositoryXO.name
       browseable = repositoryXO.browseable
@@ -487,34 +494,41 @@ extends DirectComponentSupport
     }
   }
 
-  def static doCreateGroup = { CRepository repo, RepositoryGroupXO repositoryXO ->
+  @PackageScope
+  static Closure doCreateGroup = { CRepository repo, RepositoryGroupXO repositoryXO ->
     M2GroupRepositoryConfiguration exConf = new M2GroupRepositoryConfiguration(
         repo.externalConfiguration as Xpp3Dom
     )
     exConf.memberRepositoryIds = repositoryXO.memberRepositoryIds
   }
 
-  def static doUpdateGroup = { GroupRepository repo, RepositoryGroupXO repositoryXO ->
+  @PackageScope
+  static Closure doUpdateGroup = { GroupRepository repo, RepositoryGroupXO repositoryXO ->
     repo.memberRepositoryIds = repositoryXO.memberRepositoryIds
   }
 
-  def static doCreateHosted = { CRepository repo, RepositoryHostedXO repositoryXO ->
+  @PackageScope
+  static Closure doCreateHosted = { CRepository repo, RepositoryHostedXO repositoryXO ->
     repo.writePolicy = repositoryXO.writePolicy
   }
 
-  def static doUpdateHosted = { HostedRepository repo, RepositoryHostedXO repositoryXO ->
+  @PackageScope
+  static Closure doUpdateHosted = { HostedRepository repo, RepositoryHostedXO repositoryXO ->
     repo.writePolicy = repositoryXO.writePolicy
   }
 
-  def static doCreateHostedMaven = { CRepository repo, RepositoryHostedMavenXO repositoryXO ->
+  @PackageScope
+  static Closure doCreateHostedMaven = { CRepository repo, RepositoryHostedMavenXO repositoryXO ->
     repo.indexable = repositoryXO.indexable
   }
 
-  def static doUpdateHostedMaven = { MavenHostedRepository repo, RepositoryHostedMavenXO repositoryXO ->
+  @PackageScope
+  static Closure doUpdateHostedMaven = { MavenHostedRepository repo, RepositoryHostedMavenXO repositoryXO ->
     repo.indexable = repositoryXO.indexable
   }
 
-  def doCreateProxy = { CRepository repo, RepositoryProxyXO repositoryXO ->
+  @PackageScope
+  static Closure doCreateProxy = { CRepository repo, RepositoryProxyXO repositoryXO ->
     M2RepositoryConfiguration exConf = new M2RepositoryConfiguration(
         repo.externalConfiguration as Xpp3Dom
     )
@@ -551,7 +565,8 @@ extends DirectComponentSupport
     }
   }
 
-  def doUpdateProxy = { ProxyRepository repo, RepositoryProxyXO repositoryXO ->
+  @PackageScope
+  static Closure doUpdateProxy = { ProxyRepository repo, RepositoryProxyXO repositoryXO ->
     if (repositoryXO.authEnabled) {
       validator.validate(repositoryXO, RepositoryProxyXO.Authentication)
     }
@@ -603,7 +618,8 @@ extends DirectComponentSupport
     }
   }
 
-  def static doCreateProxyMaven = { CRepository repo, RepositoryProxyMavenXO repositoryXO ->
+  @PackageScope
+  static Closure doCreateProxyMaven = { CRepository repo, RepositoryProxyMavenXO repositoryXO ->
     M2RepositoryConfiguration exConf = new M2RepositoryConfiguration(
         repo.externalConfiguration as Xpp3Dom
     )
@@ -613,14 +629,16 @@ extends DirectComponentSupport
     if (repositoryXO.metadataMaxAge != null) exConf.metadataMaxAge = repositoryXO.metadataMaxAge
   }
 
-  def static doUpdateProxyMaven = { MavenProxyRepository repo, RepositoryProxyMavenXO repositoryXO ->
+  @PackageScope
+  static Closure doUpdateProxyMaven = { MavenProxyRepository repo, RepositoryProxyMavenXO repositoryXO ->
     repo.downloadRemoteIndexes = repositoryXO.downloadRemoteIndexes
     if (repositoryXO.checksumPolicy != null) repo.checksumPolicy = repositoryXO.checksumPolicy
     if (repositoryXO.artifactMaxAge != null) repo.artifactMaxAge = repositoryXO.artifactMaxAge
     if (repositoryXO.metadataMaxAge != null) repo.metadataMaxAge = repositoryXO.metadataMaxAge
   }
 
-  def static doCreateVirtual = { CRepository repo, RepositoryVirtualXO repositoryXO ->
+  @PackageScope
+  static Closure doCreateVirtual = { CRepository repo, RepositoryVirtualXO repositoryXO ->
     // HACK: we should not use a Maven2->Maven1 config
     M2LayoutedM1ShadowRepositoryConfiguration exConf = new M2LayoutedM1ShadowRepositoryConfiguration(
         repo.externalConfiguration as Xpp3Dom
@@ -629,12 +647,14 @@ extends DirectComponentSupport
     exConf.synchronizeAtStartup = repositoryXO.synchronizeAtStartup
   }
 
-  def doUpdateVirtual = { ShadowRepository repo, RepositoryVirtualXO repositoryXO ->
+  @PackageScope
+  static Closure doUpdateVirtual = { ShadowRepository repo, RepositoryVirtualXO repositoryXO ->
     repo.synchronizeAtStartup = repositoryXO.synchronizeAtStartup
     repo.masterRepository = protectedRepositoryRegistry.getRepository(repositoryXO.shadowOf)
   }
 
-  def asRepositoryXO(Repository repo, List<RepositoryTemplateXO> templates) {
+  @PackageScope
+  static RepositoryXO asRepositoryXO(Repository repo, List<RepositoryTemplateXO> templates) {
     def RepositoryXO xo = null
     repo.adaptToFacet(MavenHostedRepository.class)?.with {
       xo = doGetMavenHosted(it, xo)
@@ -657,7 +677,8 @@ extends DirectComponentSupport
     return doGet(repo, xo, templates)
   }
 
-  def static doGetMavenHosted(MavenHostedRepository repo, RepositoryXO xo) {
+  @PackageScope
+  static RepositoryXO doGetMavenHosted(MavenHostedRepository repo, RepositoryXO xo) {
     if (!xo) xo = new RepositoryHostedMavenXO()
     if (xo instanceof RepositoryHostedMavenXO) {
       xo.with {
@@ -668,7 +689,8 @@ extends DirectComponentSupport
     return xo
   }
 
-  def static doGetHosted(HostedRepository repo, RepositoryXO xo) {
+  @PackageScope
+  static RepositoryXO doGetHosted(HostedRepository repo, RepositoryXO xo) {
     if (!xo) xo = new RepositoryHostedXO()
     if (xo instanceof RepositoryHostedXO) {
       xo.with {
@@ -678,7 +700,8 @@ extends DirectComponentSupport
     return xo
   }
 
-  def static doGetMavenProxy(MavenProxyRepository repo, RepositoryXO xo) {
+  @PackageScope
+  static RepositoryXO doGetMavenProxy(MavenProxyRepository repo, RepositoryXO xo) {
     if (!xo) xo = new RepositoryProxyMavenXO()
     if (xo instanceof RepositoryProxyMavenXO) {
       xo.with {
@@ -692,7 +715,8 @@ extends DirectComponentSupport
     return xo
   }
 
-  def doGetProxy(ProxyRepository repo, RepositoryXO xo) {
+  @PackageScope
+  static RepositoryXO doGetProxy(ProxyRepository repo, RepositoryXO xo) {
     if (!xo) xo = new RepositoryProxyXO()
     if (xo instanceof RepositoryProxyXO) {
       xo.with {
@@ -732,7 +756,8 @@ extends DirectComponentSupport
     return xo
   }
 
-  def static doGetGroup(GroupRepository repo, RepositoryXO xo) {
+  @PackageScope
+  static RepositoryXO doGetGroup(GroupRepository repo, RepositoryXO xo) {
     if (!xo) xo = new RepositoryGroupXO()
     if (xo instanceof RepositoryGroupXO) {
       xo.with {
@@ -742,7 +767,8 @@ extends DirectComponentSupport
     return xo
   }
 
-  def static doGetVirtual(ShadowRepository repo, RepositoryXO xo) {
+  @PackageScope
+  static RepositoryXO doGetVirtual(ShadowRepository repo, RepositoryXO xo) {
     if (!xo) xo = new RepositoryVirtualXO()
     if (xo instanceof RepositoryVirtualXO) {
       xo.with {
@@ -753,7 +779,8 @@ extends DirectComponentSupport
     return xo
   }
 
-  def doGet(Repository repo, RepositoryXO xo, List<RepositoryTemplateXO> templates) {
+  @PackageScope
+  static RepositoryXO doGet(Repository repo, RepositoryXO xo, List<RepositoryTemplateXO> templates) {
     if (!xo) xo = new RepositoryXO()
     if (xo instanceof RepositoryXO) {
       xo.with {
@@ -781,7 +808,8 @@ extends DirectComponentSupport
     return xo
   }
 
-  def static typeOf(Repository repository) {
+  @PackageScope
+  static String typeOf(Repository repository) {
     def kind = repository.repositoryKind
     if (kind.isFacetAvailable(ProxyRepository.class)) {
       return 'proxy'
@@ -797,10 +825,9 @@ extends DirectComponentSupport
     }
     return null
   }
-
-  private static final Pattern BRACKETS_PATTERN = Pattern.compile("(.*)( \\(.*\\))")
-
-  def static String nameOfProvider(List<RepositoryTemplateXO> templates, type, provider) {
+  
+  @PackageScope
+  static String nameOfProvider(List<RepositoryTemplateXO> templates, type, provider) {
     def template = templates.find { template -> template.type == type && template.provider == provider }
     def name = template?.providerName
     if (name) {
@@ -812,7 +839,8 @@ extends DirectComponentSupport
     return name
   }
 
-  def static String getPassword(Password password, RemoteAuthenticationSettings settings) {
+  @PackageScope
+  static String getPassword(Password password, RemoteAuthenticationSettings settings) {
     if (password?.valid) {
       return password.value
     }
@@ -822,6 +850,7 @@ extends DirectComponentSupport
     return null
   }
 
+  @PackageScope
   List<Repository> filter(final @Nullable StoreLoadParameters parameters) {
     List<Repository> repositories = protectedRepositoryRegistry.repositories
     boolean includeUserManaged = true
@@ -873,6 +902,7 @@ extends DirectComponentSupport
     return repositories
   }
 
+  @PackageScope
   Predicate<Repository> hasAnyOfFacets(@Nullable final String[] facets) {
     if (facets) {
       List<Predicate<Repository>> predicates = []
@@ -905,6 +935,7 @@ extends DirectComponentSupport
     return null
   }
 
+  @PackageScope
   Predicate<Repository> hasNoneOfFacets(@Nullable final String[] facets) {
     if (facets) {
       List<Predicate<Repository>> predicates = []
@@ -938,6 +969,7 @@ extends DirectComponentSupport
     return null
   }
 
+  @PackageScope
   static Predicate<Repository> hasAnyOfContentClasses(final String[] contentClasses) {
     if (contentClasses) {
       List<Predicate<Repository>> predicates = []
@@ -961,6 +993,7 @@ extends DirectComponentSupport
     return null
   }
 
+  @PackageScope
   static Predicate<Repository> hasNoneOfContentClasses(final String[] contentClasses) {
     if (contentClasses) {
       List<Predicate<Repository>> predicates = []

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/RepositoryTargetComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/RepositoryTargetComponent.groovy
@@ -130,7 +130,7 @@ extends DirectComponentSupport
     nexusConfiguration.saveConfiguration()
   }
 
-  private static RepositoryTargetXO asRepositoryTarget(Target input) {
+   static RepositoryTargetXO asRepositoryTarget(Target input) {
     return new RepositoryTargetXO(
         id: input.id,
         name: input.name,

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/RepositoryTargetComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/RepositoryTargetComponent.groovy
@@ -14,6 +14,7 @@ package org.sonatype.nexus.coreui
 
 import com.softwarementors.extjs.djn.config.annotations.DirectAction
 import com.softwarementors.extjs.djn.config.annotations.DirectMethod
+import groovy.transform.PackageScope
 import org.apache.shiro.authz.annotation.RequiresAuthentication
 import org.apache.shiro.authz.annotation.RequiresPermissions
 import org.hibernate.validator.constraints.NotEmpty
@@ -130,7 +131,8 @@ extends DirectComponentSupport
     nexusConfiguration.saveConfiguration()
   }
 
-   static RepositoryTargetXO asRepositoryTarget(Target input) {
+  @PackageScope
+  static RepositoryTargetXO asRepositoryTarget(Target input) {
     return new RepositoryTargetXO(
         id: input.id,
         name: input.name,
@@ -139,7 +141,8 @@ extends DirectComponentSupport
     )
   }
 
-  private void validate(final RepositoryTargetXO target) {
+  @PackageScope
+  void validate(final RepositoryTargetXO target) {
     def validations = new ValidationResponse()
 
     def contentClass = repositoryTypeRegistry.contentClasses[target.format]

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/RoleComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/RoleComponent.groovy
@@ -170,7 +170,7 @@ extends DirectComponentSupport
     securitySystem.getAuthorizationManager(DEFAULT_SOURCE).deleteRole(id)
   }
 
-  private static RoleXO asRoleXO(Role input) {
+  static RoleXO asRoleXO(Role input) {
     return new RoleXO(
         id: input.roleId,
         version: input.version,

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/RoleComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/RoleComponent.groovy
@@ -14,6 +14,7 @@ package org.sonatype.nexus.coreui
 
 import com.softwarementors.extjs.djn.config.annotations.DirectAction
 import com.softwarementors.extjs.djn.config.annotations.DirectMethod
+import groovy.transform.PackageScope
 import org.apache.shiro.authz.annotation.RequiresAuthentication
 import org.apache.shiro.authz.annotation.RequiresPermissions
 import org.hibernate.validator.constraints.NotEmpty
@@ -170,6 +171,7 @@ extends DirectComponentSupport
     securitySystem.getAuthorizationManager(DEFAULT_SOURCE).deleteRole(id)
   }
 
+  @PackageScope
   static RoleXO asRoleXO(Role input) {
     return new RoleXO(
         id: input.roleId,

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/SmtpSettingsComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/SmtpSettingsComponent.groovy
@@ -14,6 +14,7 @@ package org.sonatype.nexus.coreui
 
 import com.softwarementors.extjs.djn.config.annotations.DirectAction
 import com.softwarementors.extjs.djn.config.annotations.DirectMethod
+import groovy.transform.PackageScope
 import org.apache.shiro.authz.annotation.RequiresAuthentication
 import org.apache.shiro.authz.annotation.RequiresPermissions
 import org.hibernate.validator.constraints.Email
@@ -141,6 +142,7 @@ extends DirectComponentSupport
     }
   }
 
+  @PackageScope
   static SmtpSettingsXO.ConnectionType getConnectionType(final NexusEmailer emailer) {
     if (emailer.SMTPSslEnabled) {
       return SmtpSettingsXO.ConnectionType.SSL
@@ -151,6 +153,7 @@ extends DirectComponentSupport
     return SmtpSettingsXO.ConnectionType.PLAIN
   }
 
+  @PackageScope
   static String parseReason(final EmailerException e) {
     // first let's go to the top in exception chain
     Throwable top = e

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/SmtpSettingsComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/SmtpSettingsComponent.groovy
@@ -141,7 +141,7 @@ extends DirectComponentSupport
     }
   }
 
-  private static SmtpSettingsXO.ConnectionType getConnectionType(final NexusEmailer emailer) {
+  static SmtpSettingsXO.ConnectionType getConnectionType(final NexusEmailer emailer) {
     if (emailer.SMTPSslEnabled) {
       return SmtpSettingsXO.ConnectionType.SSL
     }
@@ -151,7 +151,7 @@ extends DirectComponentSupport
     return SmtpSettingsXO.ConnectionType.PLAIN
   }
 
-  private static String parseReason(final EmailerException e) {
+  static String parseReason(final EmailerException e) {
     // first let's go to the top in exception chain
     Throwable top = e
     while (top.getCause() != null) {

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/TaskComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/TaskComponent.groovy
@@ -403,7 +403,7 @@ class TaskComponent
     return new Manual()
   }
 
-  private static void validateState(final TaskInfo<?> task) {
+  static void validateState(final TaskInfo<?> task) {
     State state = task.currentState.state;
     if (State.RUNNING == state) {
       throw new Exception('Task can\'t be edited while it is being executed or it is in line to be executed');

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/TaskComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/TaskComponent.groovy
@@ -12,6 +12,8 @@
  */
 package org.sonatype.nexus.coreui
 
+import groovy.transform.PackageScope
+
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -212,6 +214,7 @@ class TaskComponent
     nexusScheduler.getTaskById(id)?.currentState?.future?.cancel(false)
   }
 
+  @PackageScope
   static String getStatusDescription(final CurrentState<?> currentState) {
     switch (currentState.state) {
       case State.WAITING:
@@ -232,6 +235,7 @@ class TaskComponent
     }
   }
 
+  @PackageScope
   static String getSchedule(final Schedule schedule) {
     if (schedule instanceof Manual) {
       return 'manual'
@@ -262,15 +266,16 @@ class TaskComponent
     }
   }
 
+  @PackageScope
   static Date getNextRun(final TaskInfo<?> task) {
     return task.currentState.nextRun;
   }
 
+  @PackageScope
   static String getLastRunResult(final TaskInfo<?> task) {
     String lastRunResult = null
 
     if (task.lastRunState != null) {
-      lastRunResult = null;
       switch (task.lastRunState.endState) {
         case EndState.OK:
           lastRunResult = "Ok";
@@ -308,6 +313,7 @@ class TaskComponent
     return lastRunResult
   }
 
+  @PackageScope
   TaskXO asTaskXO(final TaskInfo<?> task) {
     def result = new TaskXO(
         id: task.id,
@@ -353,6 +359,7 @@ class TaskComponent
     result
   }
 
+  @PackageScope
   static Schedule asSchedule(final TaskXO taskXO) {
     if (taskXO.schedule == 'advanced') {
       try {
@@ -403,6 +410,7 @@ class TaskComponent
     return new Manual()
   }
 
+  @PackageScope
   static void validateState(final TaskInfo<?> task) {
     State state = task.currentState.state;
     if (State.RUNNING == state) {

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/UserComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/UserComponent.groovy
@@ -15,6 +15,7 @@ package org.sonatype.nexus.coreui
 import com.google.inject.Key
 import com.softwarementors.extjs.djn.config.annotations.DirectAction
 import com.softwarementors.extjs.djn.config.annotations.DirectMethod
+import groovy.transform.PackageScope
 import org.apache.shiro.authz.annotation.RequiresAuthentication
 import org.apache.shiro.authz.annotation.RequiresPermissions
 import org.apache.shiro.authz.annotation.RequiresUser
@@ -293,7 +294,8 @@ extends DirectComponentSupport
     securitySystem.deleteUser(id, source)
   }
 
-  static asUserXO(final User user) {
+  @PackageScope
+  static UserXO asUserXO(final User user) {
     UserXO userXO = new UserXO(
         userId: user.userId,
         version: user.version,
@@ -328,6 +330,7 @@ extends DirectComponentSupport
     return subject.principal == userId
   }
 
+  @PackageScope
   static String validateEmail(final String email) {
     if (email) {
       try {

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/UserComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/UserComponent.groovy
@@ -293,7 +293,7 @@ extends DirectComponentSupport
     securitySystem.deleteUser(id, source)
   }
 
-  private static asUserXO(final User user) {
+  static asUserXO(final User user) {
     UserXO userXO = new UserXO(
         userId: user.userId,
         version: user.version,
@@ -328,7 +328,7 @@ extends DirectComponentSupport
     return subject.principal == userId
   }
 
-  private static String validateEmail(final String email) {
+  static String validateEmail(final String email) {
     if (email) {
       try {
         new Address(email)

--- a/plugins/security/nexus-ldap-plugin/src/main/java/org/sonatype/security/realms/ldap/internal/ui/LdapServerComponent.groovy
+++ b/plugins/security/nexus-ldap-plugin/src/main/java/org/sonatype/security/realms/ldap/internal/ui/LdapServerComponent.groovy
@@ -14,6 +14,7 @@ package org.sonatype.security.realms.ldap.internal.ui
 
 import com.softwarementors.extjs.djn.config.annotations.DirectAction
 import com.softwarementors.extjs.djn.config.annotations.DirectMethod
+import groovy.transform.PackageScope
 import org.sonatype.security.realms.ldap.internal.ssl.SSLLdapContextFactory
 import org.sonatype.security.realms.ldap.api.dto.LdapTrustStoreKey
 import com.sonatype.nexus.ssl.plugin.TrustStore
@@ -238,6 +239,7 @@ extends DirectComponentSupport
     }
   }
 
+  @PackageScope
   LdapServerXO asLdapServerXO(final CLdapServerConfiguration ldapServer) {
     CConnectionInfo connectionInfo = ldapServer.connectionInfo
     CUserAndGroupAuthConfiguration userAndGroupConfig = ldapServer.userAndGroupConfig
@@ -286,6 +288,7 @@ extends DirectComponentSupport
     )
   }
 
+  @PackageScope
   static String asLdapServerUrl(final CConnectionInfo connectionInfo) {
     return new LdapURL(
         connectionInfo.getProtocol(),
@@ -295,6 +298,7 @@ extends DirectComponentSupport
     ).toString()
   }
 
+  @PackageScope
   static LdapSchemaTemplateXO asLdapSchemaTemplateXO(final LdapSchemaTemplate template) {
     CUserAndGroupAuthConfiguration userAndGroupConfig = template.userAndGroupAuthConfig
     return new LdapSchemaTemplateXO(
@@ -321,6 +325,7 @@ extends DirectComponentSupport
     )
   }
 
+  @PackageScope
   static CLdapServerConfiguration asCLdapServerConfiguration(final LdapServerXO ldapServerXO, final String authPassword) {
     return new CLdapServerConfiguration(
         id: ldapServerXO.id,
@@ -366,6 +371,7 @@ extends DirectComponentSupport
     )
   }
 
+  @PackageScope
   LdapServerConnectionXO validate(final LdapServerConnectionXO ldapServerConnectionXO) {
     if (ldapServerConnectionXO.authScheme != 'none') {
       validator.validate(ldapServerConnectionXO, LdapServerConnectionXO.AuthScheme)
@@ -373,6 +379,7 @@ extends DirectComponentSupport
     return ldapServerConnectionXO
   }
 
+  @PackageScope
   LdapServerXO validate(final LdapServerXO ldapServerXO) {
     validate(ldapServerXO as LdapServerConnectionXO)
     if (ldapServerXO.backupMirrorEnabled) {
@@ -401,6 +408,7 @@ extends DirectComponentSupport
     return ldapContextFactory
   }
 
+  @PackageScope
   static String buildReason(final String userMessage, Throwable t) {
     String message = "${userMessage}: ${t.message}"
 

--- a/plugins/security/nexus-ldap-plugin/src/main/java/org/sonatype/security/realms/ldap/internal/ui/LdapServerComponent.groovy
+++ b/plugins/security/nexus-ldap-plugin/src/main/java/org/sonatype/security/realms/ldap/internal/ui/LdapServerComponent.groovy
@@ -286,7 +286,7 @@ extends DirectComponentSupport
     )
   }
 
-  private static String asLdapServerUrl(final CConnectionInfo connectionInfo) {
+  static String asLdapServerUrl(final CConnectionInfo connectionInfo) {
     return new LdapURL(
         connectionInfo.getProtocol(),
         connectionInfo.getHost(),
@@ -295,7 +295,7 @@ extends DirectComponentSupport
     ).toString()
   }
 
-  private static LdapSchemaTemplateXO asLdapSchemaTemplateXO(final LdapSchemaTemplate template) {
+  static LdapSchemaTemplateXO asLdapSchemaTemplateXO(final LdapSchemaTemplate template) {
     CUserAndGroupAuthConfiguration userAndGroupConfig = template.userAndGroupAuthConfig
     return new LdapSchemaTemplateXO(
         name: template.name,
@@ -321,7 +321,7 @@ extends DirectComponentSupport
     )
   }
 
-  private static CLdapServerConfiguration asCLdapServerConfiguration(final LdapServerXO ldapServerXO, final String authPassword) {
+  static CLdapServerConfiguration asCLdapServerConfiguration(final LdapServerXO ldapServerXO, final String authPassword) {
     return new CLdapServerConfiguration(
         id: ldapServerXO.id,
         name: ldapServerXO.name,
@@ -401,7 +401,7 @@ extends DirectComponentSupport
     return ldapContextFactory
   }
 
-  private static String buildReason(final String userMessage, Throwable t) {
+  static String buildReason(final String userMessage, Throwable t) {
     String message = "${userMessage}: ${t.message}"
 
     while (t != t.cause && t.cause) {

--- a/pom.xml
+++ b/pom.xml
@@ -433,12 +433,12 @@
             <dependency>
               <groupId>org.codehaus.groovy</groupId>
               <artifactId>groovy-eclipse-compiler</artifactId>
-              <version>2.8.0-01</version>
+              <version>2.9.1-01</version>
             </dependency>
             <dependency>
               <groupId>org.codehaus.groovy</groupId>
               <artifactId>groovy-eclipse-batch</artifactId>
-              <version>2.1.5-03</version>
+              <version>2.3.7-01</version>
             </dependency>
           </dependencies>
           <configuration>


### PR DESCRIPTION
Upgrade groovy to newer version as only groovy 2.8+ is actually workable in Java8, although earlier versions may/may not work depending on what you're tyring to do (among other reasons to upgrade).
Challenges:
- resolution of visible fields/methods has changed, leading to problems where Guice intercepted methods with Closures calling private methods can no longer find them

Options:
- @CompileStatic code does not appear to suffer from the lookup problem, but forces us to abandon some of the Groovier syntax and dynamic typing features. Also, it too seems to have some strange buggy behaviour, like the GDK method lookup failure explicitly mentioned later
- remote private modifier from affected methods and apply @PackageScope to keep the visibility as tight as possible

@PackageScope option gets my :+1: , looking forward to votes from the rest of the team on a path forward.



