### PR TITLE
Turn OrientDB graph bundle into a fragment of orientdb-core.

### DIFF
--- a/assemblies/nexus-base-edition/src/main/feature/feature.xml
+++ b/assemblies/nexus-base-edition/src/main/feature/feature.xml
@@ -30,7 +30,7 @@
     -->
     <bundle>wrap:${mvn:shiro-guice}$overwrite=merge&amp;Import-Package=*</bundle>
     <bundle>wrap:${mvn:xstream}$overwrite=merge&amp;-exportcontents=*&amp;DynamicImport-Package=*</bundle>
-    <bundle>wrap:${mvn:orientdb-graphdb}$overwrite=merge&amp;Import-Package=com.tinkerpop.*;resolution:=optional,*</bundle>
+    <bundle>wrap:${mvn:orientdb-graphdb}$overwrite=merge&amp;Fragment-Host=com.orientechnologies.orientdb-core&amp;Import-Package=com.tinkerpop.*;resolution:=optional,*</bundle>
     <!--
     Install nexus-specific shell commands
     -->


### PR DESCRIPTION
This will merge their classpaths at runtime and allow graph
functions to be seen by the ServiceRegistry code in core.

(this is easier than re-working the OrientDB registry code.)

http://bamboo.s/browse/NX-OSSF499-1 :white_check_mark: 