### PR TITLE
Priv property injection

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/security/RepositoryPropertyDescriptor.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/security/RepositoryPropertyDescriptor.java
@@ -12,13 +12,8 @@
  */
 package org.sonatype.nexus.security;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
-
 import org.sonatype.security.realms.privileges.PrivilegePropertyDescriptor;
 
-@Singleton
-@Named("RepositoryPropertyDescriptor")
 public class RepositoryPropertyDescriptor
     implements PrivilegePropertyDescriptor
 {

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/security/RepositoryViewPrivilegeDescriptor.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/security/RepositoryViewPrivilegeDescriptor.java
@@ -12,10 +12,8 @@
  */
 package org.sonatype.nexus.security;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
@@ -27,9 +25,8 @@ import org.sonatype.security.realms.privileges.PrivilegeDescriptor;
 import org.sonatype.security.realms.privileges.PrivilegePropertyDescriptor;
 import org.sonatype.security.realms.validator.SecurityValidationContext;
 
+import com.google.common.collect.Lists;
 import org.codehaus.plexus.util.StringUtils;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 @Singleton
 @Named("RepositoryViewPrivilegeDescriptor")
@@ -39,15 +36,6 @@ public class RepositoryViewPrivilegeDescriptor
 {
   public static final String TYPE = "repository";
 
-  private final PrivilegePropertyDescriptor repoProperty;
-
-  @Inject
-  public RepositoryViewPrivilegeDescriptor(
-      @Named("RepositoryPropertyDescriptor") PrivilegePropertyDescriptor repoProperty)
-  {
-    this.repoProperty = checkNotNull(repoProperty);
-  }
-
   @Override
   public String getName() {
     return "Repository View";
@@ -55,11 +43,9 @@ public class RepositoryViewPrivilegeDescriptor
 
   @Override
   public List<PrivilegePropertyDescriptor> getPropertyDescriptors() {
-    List<PrivilegePropertyDescriptor> propertyDescriptors = new ArrayList<PrivilegePropertyDescriptor>();
-
-    propertyDescriptors.add(repoProperty);
-
-    return propertyDescriptors;
+    List<PrivilegePropertyDescriptor> descriptors = Lists.newArrayList();
+    descriptors.add(new RepositoryPropertyDescriptor());
+    return descriptors;
   }
 
   @Override

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/security/targets/TargetPrivilegeDescriptor.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/security/targets/TargetPrivilegeDescriptor.java
@@ -10,12 +10,11 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
+
 package org.sonatype.nexus.security.targets;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
@@ -28,9 +27,8 @@ import org.sonatype.security.realms.privileges.PrivilegePropertyDescriptor;
 import org.sonatype.security.realms.privileges.application.ApplicationPrivilegeMethodPropertyDescriptor;
 import org.sonatype.security.realms.validator.SecurityValidationContext;
 
+import com.google.common.collect.Lists;
 import org.codehaus.plexus.util.StringUtils;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 @Singleton
 @Named("TargetPrivilegeDescriptor")
@@ -40,27 +38,6 @@ public class TargetPrivilegeDescriptor
 {
   public static final String TYPE = "target";
 
-  private final PrivilegePropertyDescriptor methodProperty;
-
-  private final PrivilegePropertyDescriptor targetProperty;
-
-  private final PrivilegePropertyDescriptor repositoryProperty;
-
-  private final PrivilegePropertyDescriptor groupProperty;
-
-  @Inject
-  public TargetPrivilegeDescriptor(
-      final @Named("ApplicationPrivilegeMethodPropertyDescriptor") PrivilegePropertyDescriptor methodProperty,
-      final @Named("TargetPrivilegeRepositoryTargetPropertyDescriptor") PrivilegePropertyDescriptor targetProperty,
-      final @Named("TargetPrivilegeRepositoryPropertyDescriptor") PrivilegePropertyDescriptor repositoryProperty,
-      final @Named("TargetPrivilegeGroupPropertyDescriptor") PrivilegePropertyDescriptor groupProperty)
-  {
-    this.methodProperty = checkNotNull(methodProperty);
-    this.targetProperty = checkNotNull(targetProperty);
-    this.repositoryProperty = checkNotNull(repositoryProperty);
-    this.groupProperty = checkNotNull(groupProperty);
-  }
-
   @Override
   public String getName() {
     return "Repository Target";
@@ -68,14 +45,11 @@ public class TargetPrivilegeDescriptor
 
   @Override
   public List<PrivilegePropertyDescriptor> getPropertyDescriptors() {
-    List<PrivilegePropertyDescriptor> propertyDescriptors = new ArrayList<PrivilegePropertyDescriptor>();
-
-    propertyDescriptors.add(methodProperty);
-    propertyDescriptors.add(targetProperty);
-    propertyDescriptors.add(repositoryProperty);
-    propertyDescriptors.add(groupProperty);
-
-    return propertyDescriptors;
+    return Lists.newArrayList(
+        new ApplicationPrivilegeMethodPropertyDescriptor(),
+        new TargetPrivilegeRepositoryTargetPropertyDescriptor(),
+        new TargetPrivilegeRepositoryPropertyDescriptor(),
+        new TargetPrivilegeGroupPropertyDescriptor());
   }
 
   @Override
@@ -197,7 +171,6 @@ public class TargetPrivilegeDescriptor
             "Invalid method selected.");
         response.addValidationError(message);
       }
-
     }
 
     return response;

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/security/targets/TargetPrivilegeGroupPropertyDescriptor.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/security/targets/TargetPrivilegeGroupPropertyDescriptor.java
@@ -12,13 +12,8 @@
  */
 package org.sonatype.nexus.security.targets;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
-
 import org.sonatype.security.realms.privileges.PrivilegePropertyDescriptor;
 
-@Singleton
-@Named("TargetPrivilegeGroupPropertyDescriptor")
 public class TargetPrivilegeGroupPropertyDescriptor
     implements PrivilegePropertyDescriptor
 {

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/security/targets/TargetPrivilegeRepositoryPropertyDescriptor.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/security/targets/TargetPrivilegeRepositoryPropertyDescriptor.java
@@ -12,13 +12,8 @@
  */
 package org.sonatype.nexus.security.targets;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
-
 import org.sonatype.security.realms.privileges.PrivilegePropertyDescriptor;
 
-@Singleton
-@Named("TargetPrivilegeRepositoryPropertyDescriptor")
 public class TargetPrivilegeRepositoryPropertyDescriptor
     implements PrivilegePropertyDescriptor
 {

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/security/targets/TargetPrivilegeRepositoryTargetPropertyDescriptor.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/security/targets/TargetPrivilegeRepositoryTargetPropertyDescriptor.java
@@ -12,13 +12,8 @@
  */
 package org.sonatype.nexus.security.targets;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
-
 import org.sonatype.security.realms.privileges.PrivilegePropertyDescriptor;
 
-@Singleton
-@Named("TargetPrivilegeRepositoryTargetPropertyDescriptor")
 public class TargetPrivilegeRepositoryTargetPropertyDescriptor
     implements PrivilegePropertyDescriptor
 {

--- a/components/nexus-security/src/main/java/org/sonatype/security/DefaultSecuritySystem.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/DefaultSecuritySystem.java
@@ -109,15 +109,15 @@ public class DefaultSecuritySystem
   private volatile boolean started;
 
   @Inject
-  public DefaultSecuritySystem(List<SecurityEmailer> securityEmailers,
-                               EventBus eventBus,
-                               PasswordGenerator passwordGenerator,
-                               Map<String, AuthorizationManager> authorizationManagers,
-                               Map<String, Realm> realmMap,
-                               SecurityConfigurationManager securityConfiguration,
-                               RealmSecurityManager securityManager,
-                               CacheManager cacheManager,
-                               Map<String, UserManager> userManagers)
+  public DefaultSecuritySystem(final List<SecurityEmailer> securityEmailers,
+                               final EventBus eventBus,
+                               final PasswordGenerator passwordGenerator,
+                               final Map<String, AuthorizationManager> authorizationManagers,
+                               final Map<String, Realm> realmMap,
+                               final SecurityConfigurationManager securityConfiguration,
+                               final RealmSecurityManager securityManager,
+                               final CacheManager cacheManager,
+                               final Map<String, UserManager> userManagers)
   {
     this.securityEmailers = securityEmailers;
     this.eventBus = eventBus;

--- a/components/nexus-security/src/main/java/org/sonatype/security/DefaultSecuritySystem.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/DefaultSecuritySystem.java
@@ -134,9 +134,7 @@ public class DefaultSecuritySystem
     started = false;
   }
 
-  public Subject login(AuthenticationToken token)
-      throws AuthenticationException
-  {
+  public Subject login(AuthenticationToken token) throws AuthenticationException {
     try {
       Subject subject = this.getSubject();
       subject.login(token);
@@ -147,9 +145,7 @@ public class DefaultSecuritySystem
     }
   }
 
-  public AuthenticationInfo authenticate(AuthenticationToken token)
-      throws AuthenticationException
-  {
+  public AuthenticationInfo authenticate(AuthenticationToken token) throws AuthenticationException {
     try {
       return this.getSecurityManager().authenticate(token);
     }
@@ -189,9 +185,7 @@ public class DefaultSecuritySystem
     return this.getSecurityManager().isPermitted(principal, permissions.toArray(new String[permissions.size()]));
   }
 
-  public void checkPermission(PrincipalCollection principal, String permission)
-      throws AuthorizationException
-  {
+  public void checkPermission(PrincipalCollection principal, String permission) throws AuthorizationException {
     try {
       this.getSecurityManager().checkPermission(principal, permission);
     }
@@ -201,9 +195,7 @@ public class DefaultSecuritySystem
 
   }
 
-  public void checkPermission(PrincipalCollection principal, List<String> permissions)
-      throws AuthorizationException
-  {
+  public void checkPermission(PrincipalCollection principal, List<String> permissions) throws AuthorizationException {
     try {
       this.getSecurityManager().checkPermissions(principal, permissions.toArray(new String[permissions.size()]));
     }
@@ -226,13 +218,13 @@ public class DefaultSecuritySystem
         realms.add(this.realmMap.get(realmId));
       }
       else {
-        this.logger.debug("Failed to look up realm as a component, trying reflection");
+        logger.debug("Failed to look up realm as a component, trying reflection");
         // If that fails, will simply use reflection to load
         try {
           realms.add((Realm) getClass().getClassLoader().loadClass(realmId).newInstance());
         }
         catch (Exception e) {
-          this.logger.error("Unable to lookup security realms", e);
+          logger.error("Unable to lookup security realms", e);
         }
       }
     }
@@ -252,9 +244,7 @@ public class DefaultSecuritySystem
     return roles;
   }
 
-  public Set<Role> listRoles(String sourceId)
-      throws NoSuchAuthorizationManagerException
-  {
+  public Set<Role> listRoles(String sourceId) throws NoSuchAuthorizationManagerException {
     if (ALL_ROLES_KEY.equalsIgnoreCase(sourceId)) {
       return this.listRoles();
     }
@@ -280,15 +270,11 @@ public class DefaultSecuritySystem
   // * user management
   // *********************
 
-  public User addUser(User user)
-      throws NoSuchUserManagerException, InvalidConfigurationException
-  {
+  public User addUser(User user) throws NoSuchUserManagerException, InvalidConfigurationException {
     return this.addUser(user, this.generatePassword());
   }
 
-  public User addUser(User user, String password)
-      throws NoSuchUserManagerException, InvalidConfigurationException
-  {
+  public User addUser(User user, String password) throws NoSuchUserManagerException, InvalidConfigurationException {
     // if the password is null, generate one
     if (password == null) {
       password = this.generatePassword();
@@ -318,7 +304,7 @@ public class DefaultSecuritySystem
                   user.getRoles()));
         }
         catch (UserNotFoundException e) {
-          this.logger.debug("User '" + user.getUserId() + "' is not managed by the usermanager: "
+          logger.debug("User '" + user.getUserId() + "' is not managed by the usermanager: "
               + tmpUserManager.getSource());
         }
       }
@@ -364,7 +350,7 @@ public class DefaultSecuritySystem
                   user.getRoles()));
         }
         catch (UserNotFoundException e) {
-          this.logger.debug("User '" + user.getUserId() + "' is not managed by the usermanager: "
+          logger.debug("User '" + user.getUserId() + "' is not managed by the usermanager: "
               + tmpUserManager.getSource());
         }
       }
@@ -384,14 +370,12 @@ public class DefaultSecuritySystem
       this.deleteUser(userId, user.getSource());
     }
     catch (NoSuchUserManagerException e) {
-      this.logger.error("User manager returned user, but could not be found: " + e.getMessage(), e);
+      logger.error("User manager returned user, but could not be found: " + e.getMessage(), e);
       throw new IllegalStateException("User manager returned user, but could not be found: " + e.getMessage(), e);
     }
   }
 
-  public void deleteUser(String userId, String source)
-      throws UserNotFoundException, NoSuchUserManagerException
-  {
+  public void deleteUser(String userId, String source) throws UserNotFoundException, NoSuchUserManagerException {
     checkNotNull(userId, "User ID may not be null");
 
     Subject subject = getSubject();
@@ -419,7 +403,7 @@ public class DefaultSecuritySystem
   }
 
   public Set<RoleIdentifier> getUsersRoles(String userId, String source)
-      throws UserNotFoundException, NoSuchUserManagerException
+    throws UserNotFoundException, NoSuchUserManagerException
   {
     User user = this.getUser(userId, source);
     return user.getRoles();
@@ -444,7 +428,7 @@ public class DefaultSecuritySystem
                   roleIdentifiers));
         }
         catch (UserNotFoundException e) {
-          this.logger.debug("User '" + userId + "' is not managed by the usermanager: "
+          logger.debug("User '" + userId + "' is not managed by the usermanager: "
               + tmpUserManager.getSource());
         }
       }
@@ -529,7 +513,7 @@ public class DefaultSecuritySystem
         users.addAll(getUserManager(criteria.getSource()).searchUsers(criteria));
       }
       catch (NoSuchUserManagerException e) {
-        this.logger.warn("UserManager: " + criteria.getSource() + " was not found.", e);
+        logger.warn("UserManager: " + criteria.getSource() + " was not found.", e);
       }
     }
 
@@ -581,7 +565,6 @@ public class DefaultSecuritySystem
     orderedLocators.addAll(unOrderdLocators);
 
     return orderedLocators;
-
   }
 
   private void addOtherRolesToUser(User user) {
@@ -600,7 +583,7 @@ public class DefaultSecuritySystem
           }
         }
         catch (UserNotFoundException e) {
-          this.logger.debug("User '" + user.getUserId() + "' is not managed by the usermanager: "
+          logger.debug("User '" + user.getUserId() + "' is not managed by the usermanager: "
               + tmpUserManager.getSource());
         }
       }
@@ -637,7 +620,7 @@ public class DefaultSecuritySystem
       }
     }
     catch (org.apache.shiro.authc.AuthenticationException e) {
-      this.logger.debug("User failed to change password reason: " + e.getMessage(), e);
+      logger.debug("User failed to change password reason: " + e.getMessage(), e);
       throw new InvalidCredentialsException();
     }
 
@@ -656,7 +639,7 @@ public class DefaultSecuritySystem
     }
     catch (NoSuchUserManagerException e) {
       // this should NEVER happen
-      this.logger.warn("User '" + userId + "' with source: '" + user.getSource()
+      logger.warn("User '" + userId + "' with source: '" + user.getSource()
           + "' but could not find the UserManager for that source.");
     }
 
@@ -664,9 +647,7 @@ public class DefaultSecuritySystem
     eventBus.post(new UserPrincipalsExpired(userId, user.getSource()));
   }
 
-  public void forgotPassword(String userId, String email)
-      throws UserNotFoundException, InvalidConfigurationException
-  {
+  public void forgotPassword(String userId, String email) throws UserNotFoundException, InvalidConfigurationException {
     UserSearchCriteria criteria = new UserSearchCriteria();
     criteria.setEmail(email);
     criteria.setUserId(userId);
@@ -690,9 +671,7 @@ public class DefaultSecuritySystem
     resetPassword(userId);
   }
 
-  public void forgotUsername(String email)
-      throws UserNotFoundException
-  {
+  public void forgotUsername(String email) throws UserNotFoundException {
     UserSearchCriteria criteria = new UserSearchCriteria();
     criteria.setEmail(email);
 
@@ -717,9 +696,7 @@ public class DefaultSecuritySystem
 
   }
 
-  public void resetPassword(String userId)
-      throws UserNotFoundException, InvalidConfigurationException
-  {
+  public void resetPassword(String userId) throws UserNotFoundException, InvalidConfigurationException {
     String newClearTextPassword = this.generatePassword();
 
     User user = this.getUser(userId);
@@ -731,7 +708,6 @@ public class DefaultSecuritySystem
 
     // send email
     this.getSecurityEmailer().sendResetPassword(user.getEmailAddress(), newClearTextPassword);
-
   }
 
   private String generatePassword() {
@@ -745,7 +721,7 @@ public class DefaultSecuritySystem
         this.securityEmailer = i.next();
       }
       else {
-        this.logger.error("Failed to find a SecurityEmailer");
+        logger.error("Failed to find a SecurityEmailer");
         this.securityEmailer = new NullSecurityEmailer();
       }
     }
@@ -756,9 +732,7 @@ public class DefaultSecuritySystem
     return new ArrayList<String>(this.securityConfiguration.getRealms());
   }
 
-  public void setRealms(List<String> realms)
-      throws InvalidConfigurationException
-  {
+  public void setRealms(List<String> realms) throws InvalidConfigurationException {
     this.securityConfiguration.setRealms(realms);
     this.securityConfiguration.save();
 
@@ -771,9 +745,7 @@ public class DefaultSecuritySystem
     this.securityConfiguration.save();
   }
 
-  public void setAnonymousUsername(String anonymousUsername)
-      throws InvalidConfigurationException
-  {
+  public void setAnonymousUsername(String anonymousUsername) throws InvalidConfigurationException {
     User user = null;
     try {
       user = getUser(securityConfiguration.getAnonymousUsername());
@@ -793,9 +765,7 @@ public class DefaultSecuritySystem
     return this.securityConfiguration.getAnonymousPassword();
   }
 
-  public void setAnonymousPassword(String anonymousPassword)
-      throws InvalidConfigurationException
-  {
+  public void setAnonymousPassword(String anonymousPassword) throws InvalidConfigurationException {
     User user = null;
     try {
       user = getUser(securityConfiguration.getAnonymousUsername());

--- a/components/nexus-security/src/main/java/org/sonatype/security/SecuritySystem.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/SecuritySystem.java
@@ -37,14 +37,12 @@ import org.apache.shiro.subject.Subject;
 
 /**
  * This is a facade around all things security ( authentication, authorization, user management, and configuration ).
- * It
- * is meant to be the single point of access.
+ * It is meant to be the single point of access.
  *
  * @author Brian Demers
  */
 public interface SecuritySystem
 {
-
   /**
    * Starts the SecuritySystem. Before this method is called the state is unknown.
    */
@@ -65,16 +63,14 @@ public interface SecuritySystem
    * @return the Subject representing the logged in user.
    * @throws AuthenticationException if the user can not be authenticated
    */
-  public Subject login(AuthenticationToken token)
-      throws AuthenticationException;
+  Subject login(AuthenticationToken token) throws AuthenticationException;
 
   /**
    * Authenticates a user and does NOT log them in. If successful returns a AuthenticationInfo.
    *
    * @return the AuthenticationInfo for this request.
    */
-  public AuthenticationInfo authenticate(AuthenticationToken token)
-      throws AuthenticationException;
+  AuthenticationInfo authenticate(AuthenticationToken token) throws AuthenticationException;
 
   // /**
   // * This method sets the current thread to use the <code>principal</code> passed in.
@@ -83,17 +79,17 @@ public interface SecuritySystem
   // * @param principal The account to login in as.
   // * @return The subject that was created as a result of the principal.
   // */
-  // public Subject runAs( PrincipalCollection principal );
+  // Subject runAs( PrincipalCollection principal );
 
   /**
    * Finds the current logged in Subject.
    */
-  public Subject getSubject();
+  Subject getSubject();
 
   /**
    * Logs the subject out.
    */
-  public void logout(Subject subject);
+  void logout(Subject subject);
 
   // *********************
   // * authorization
@@ -104,7 +100,7 @@ public interface SecuritySystem
    *
    * @return true only if the principal has the permission.
    */
-  public boolean isPermitted(PrincipalCollection principal, String permission);
+  boolean isPermitted(PrincipalCollection principal, String permission);
 
   /**
    * Checks if principal has a list of permission.
@@ -112,27 +108,25 @@ public interface SecuritySystem
    * @param permissions list of permission to check.
    * @return A boolean array, the results in the array match the order of the permission
    */
-  public boolean[] isPermitted(PrincipalCollection principal, List<String> permissions);
+  boolean[] isPermitted(PrincipalCollection principal, List<String> permissions);
 
   /**
    * Checks if principal has a permission, throws an AuthorizationException otherwise.
    */
-  public void checkPermission(PrincipalCollection principal, String permission)
-      throws AuthorizationException;
+  void checkPermission(PrincipalCollection principal, String permission) throws AuthorizationException;
 
   /**
    * Checks if principal has a list of permissions, throws an AuthorizationException unless the principal has all
    * permissions.
    */
-  public void checkPermission(PrincipalCollection principal, List<String> permissions)
-      throws AuthorizationException;
+  void checkPermission(PrincipalCollection principal, List<String> permissions) throws AuthorizationException;
 
   /**
    * Checks if a principal has a role.
    *
    * @return true if the principal has this role.
    */
-  public boolean hasRole(PrincipalCollection principals, String role);
+  boolean hasRole(PrincipalCollection principals, String role);
 
   // ******************************
   // * Role permission management
@@ -144,7 +138,7 @@ public interface SecuritySystem
    *
    * @return All the roles defined in the system.
    */
-  public Set<Role> listRoles();
+  Set<Role> listRoles();
 
   /**
    * NOTE: this method could be slow if there is a large list of roles coming from an external source (such as a
@@ -153,8 +147,7 @@ public interface SecuritySystem
    * @param sourceId The identifier of an {@link AuthorizationManager}.
    * @return All the roles defined by an {@link AuthorizationManager}.
    */
-  public Set<Role> listRoles(String sourceId)
-      throws NoSuchAuthorizationManagerException;
+  Set<Role> listRoles(String sourceId) throws NoSuchAuthorizationManagerException;
 
   // *********************
   // * user management
@@ -167,8 +160,7 @@ public interface SecuritySystem
    * @param user User to be created.
    * @return The User that was just created.
    */
-  User addUser(User user)
-      throws NoSuchUserManagerException, InvalidConfigurationException;
+  User addUser(User user) throws NoSuchUserManagerException, InvalidConfigurationException;
 
   /**
    * Adds a new User to the system.<BR/>
@@ -178,14 +170,13 @@ public interface SecuritySystem
    * @param password The users initial password.
    * @return The User that was just created.
    */
-  User addUser(User user, String password)
-      throws NoSuchUserManagerException, InvalidConfigurationException;
+  User addUser(User user, String password) throws NoSuchUserManagerException, InvalidConfigurationException;
 
   /**
    * Get a User by id and source.
    *
    * @param userId   Id of the user to return.
-   * @param soruceId the Id of the source to get the user from.
+   * @param sourceId the Id of the source to get the user from.
    * @return The user
    */
   User getUser(String userId, String sourceId)
@@ -198,8 +189,7 @@ public interface SecuritySystem
    * @param userId Id of the user to return.
    * @return The user
    */
-  User getUser(String userId)
-      throws UserNotFoundException;
+  User getUser(String userId) throws UserNotFoundException;
 
   /**
    * Updates a new User to the system.<BR/>
@@ -208,8 +198,7 @@ public interface SecuritySystem
    * @param user User to be updated.
    * @return The User that was just updated.
    */
-  User updateUser(User user)
-      throws UserNotFoundException, NoSuchUserManagerException, InvalidConfigurationException;
+  User updateUser(User user) throws UserNotFoundException, NoSuchUserManagerException, InvalidConfigurationException;
 
   /**
    * Remove a user based on the Id.
@@ -218,8 +207,7 @@ public interface SecuritySystem
    * @Deprecated use deleteUser( String userId, String source )
    */
   @Deprecated
-  void deleteUser(String userId)
-      throws UserNotFoundException;
+  void deleteUser(String userId) throws UserNotFoundException;
 
   /**
    * Removes a user based on the userId and sourceId.
@@ -227,11 +215,10 @@ public interface SecuritySystem
    * @param userId   The id of the user to be removed.
    * @param sourceId The sourceId of the user to be removed.
    */
-  void deleteUser(String userId, String sourceId)
-      throws UserNotFoundException, NoSuchUserManagerException;
+  void deleteUser(String userId, String sourceId) throws UserNotFoundException, NoSuchUserManagerException;
 
   /**
-   * Returns a list of {@link RoleIdentifiers} which represents all the roles a given user has.
+   * Returns a list of {@link RoleIdentifier} which represents all the roles a given user has.
    *
    * @param userId   The Id of the user.
    * @param sourceId The source Id of the user.
@@ -261,7 +248,7 @@ public interface SecuritySystem
   /**
    * Searches for Users by criteria.
    */
-  public Set<User> searchUsers(UserSearchCriteria criteria);
+  Set<User> searchUsers(UserSearchCriteria criteria);
 
   // *********************
   // * forget / change password
@@ -273,24 +260,21 @@ public interface SecuritySystem
    * @param userId the user Id of the user
    * @param email  email address of the user
    */
-  void forgotPassword(String userId, String email)
-      throws UserNotFoundException, InvalidConfigurationException;
+  void forgotPassword(String userId, String email) throws UserNotFoundException, InvalidConfigurationException;
 
   /**
    * Sends an email to a user to recover his/her password.
    *
    * @param email The email address of the user.
    */
-  void forgotUsername(String email)
-      throws UserNotFoundException;
+  void forgotUsername(String email) throws UserNotFoundException;
 
   /**
    * Generate a new user password and will email it to the user.
    *
    * @param userId the user Id of the user
    */
-  void resetPassword(String userId)
-      throws UserNotFoundException, InvalidConfigurationException;
+  void resetPassword(String userId) throws UserNotFoundException, InvalidConfigurationException;
 
   /**
    * Updates a users password.
@@ -309,8 +293,7 @@ public interface SecuritySystem
    * @param userId      The id of the user.
    * @param newPassword The user's new password.
    */
-  void changePassword(String userId, String newPassword)
-      throws UserNotFoundException, InvalidConfigurationException;
+  void changePassword(String userId, String newPassword) throws UserNotFoundException, InvalidConfigurationException;
 
   // *********************
   // * Authorization Management
@@ -321,10 +304,9 @@ public interface SecuritySystem
    *
    * @return A set of all the privileges in the system.
    */
-  public Set<Privilege> listPrivileges();
+  Set<Privilege> listPrivileges();
 
-  public AuthorizationManager getAuthorizationManager(String source)
-      throws NoSuchAuthorizationManagerException;
+  AuthorizationManager getAuthorizationManager(String source) throws NoSuchAuthorizationManagerException;
 
   // //
   // Application configuration, TODO: I don't think all of these need to be exposed, but they currently are
@@ -340,8 +322,7 @@ public interface SecuritySystem
   /**
    * Set the currently configured realms.
    */
-  void setRealms(List<String> realms)
-      throws InvalidConfigurationException;
+  void setRealms(List<String> realms) throws InvalidConfigurationException;
 
   /**
    * Return true if anonymous access is enabled.
@@ -376,12 +357,10 @@ public interface SecuritySystem
   /**
    * Sets the anonymous user password.
    */
-  void setAnonymousPassword(String anonymousPassword)
-      throws InvalidConfigurationException;
+  void setAnonymousPassword(String anonymousPassword) throws InvalidConfigurationException;
 
   /**
    * Returns the configured shiro SecurityManager
    */
-  public RealmSecurityManager getSecurityManager();
-
+  RealmSecurityManager getSecurityManager();
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/SecuritySystem.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/SecuritySystem.java
@@ -346,8 +346,7 @@ public interface SecuritySystem
    * Sets the name of the anonymous users. Could be something other then 'anonymous', for example Active Directory
    * uses 'Guest' TODO: consider removing this method.
    */
-  void setAnonymousUsername(String anonymousUsername)
-      throws InvalidConfigurationException;
+  void setAnonymousUsername(String anonymousUsername) throws InvalidConfigurationException;
 
   /**
    * Gets the anonymous user password.

--- a/components/nexus-security/src/main/java/org/sonatype/security/authentication/AuthenticationException.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/authentication/AuthenticationException.java
@@ -14,13 +14,10 @@ package org.sonatype.security.authentication;
 
 /**
  * Thrown when a Subject or Principal could not be authenticated.
- *
- * @author Brian Demers
  */
 public class AuthenticationException
     extends Exception
 {
-
   private static final long serialVersionUID = 5307046352518675119L;
 
   public AuthenticationException() {
@@ -37,5 +34,4 @@ public class AuthenticationException
   public AuthenticationException(String message, Throwable cause) {
     super(message, cause);
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/authentication/FirstSuccessfulModularRealmAuthenticator.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/authentication/FirstSuccessfulModularRealmAuthenticator.java
@@ -22,64 +22,47 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This Authenticator will only try to authenticate with each realm. The first successful AuthenticationInfo found will
- * be returned and other realms will not be queried. <BR/>
- * <BR/>
- * This makes for the performance short comings when using the {@link ModularRealmAuthenticator} and
- * {@link FirstSuccessfulAuthenticationStrategy} where all the realms will be queried, but only the first success is
- * returned.
+ * This Authenticator will only try to authenticate with each realm.
  *
- * @author Brian Demers
+ * The first successful AuthenticationInfo found will be returned and other realms will not be queried.
+ *
  * @see ModularRealmAuthenticator
- * @see FirstSuccessfulAuthenticationStrategy
  */
 public class FirstSuccessfulModularRealmAuthenticator
     extends ModularRealmAuthenticator
 {
-  private static final Logger logger = LoggerFactory.getLogger(FirstSuccessfulModularRealmAuthenticator.class);
+  private static final Logger log = LoggerFactory.getLogger(FirstSuccessfulModularRealmAuthenticator.class);
 
   @Override
-  protected AuthenticationInfo doMultiRealmAuthentication(Collection<Realm> realms, AuthenticationToken token) {
-    logger.trace("Iterating through [" + realms.size() + "] realms for PAM authentication");
+  protected AuthenticationInfo doMultiRealmAuthentication(final Collection<Realm> realms,
+                                                          final AuthenticationToken token)
+  {
+    log.trace("Iterating through [{}] realms for PAM authentication", realms.size());
 
     for (Realm realm : realms) {
       // check if the realm supports this token
       if (realm.supports(token)) {
-        if (logger.isTraceEnabled()) {
-          logger.trace("Attempting to authenticate token [" + token + "] " + "using realm of type [" + realm
-              + "]");
-        }
+        log.trace("Attempting to authenticate token [{}] using realm of type [{}]", token, realm);
 
         try {
-          // try to login
           AuthenticationInfo info = realm.getAuthenticationInfo(token);
-          // just make sure are ducks are in a row
-          // return the first successful login.
           if (info != null) {
             return info;
           }
-          else if (logger.isTraceEnabled()) {
-            logger.trace("Realm [" + realm + "] returned null when authenticating token " + "[" + token
-                + "]");
-          }
+
+          log.trace("Realm [{}] returned null when authenticating token [{}]", realm, token);
         }
         catch (Throwable t) {
-          if (logger.isTraceEnabled()) {
-            String msg =
-                "Realm [" + realm + "] threw an exception during a multi-realm authentication attempt:";
-            logger.trace(msg, t);
-          }
+          log.trace("Realm [{}] threw an exception during a multi-realm authentication attempt", realm, t);
         }
       }
       else {
-        if (logger.isTraceEnabled()) {
-          logger.trace("Realm of type [" + realm + "] does not support token " + "[" + token
-              + "].  Skipping realm.");
-        }
+        log.trace("Realm of type [{}] does not support token [{}]; skipping realm", realm, token);
       }
     }
+
     throw new org.apache.shiro.authc.AuthenticationException("Authentication token of type [" + token.getClass()
-        + "] " + "could not be authenticated by any configured realms.  Please ensure that at least one realm can "
+        + "] could not be authenticated by any configured realms.  Please ensure that at least one realm can "
         + "authenticate these tokens.");
   }
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/authorization/AbstractReadOnlyAuthorizationManager.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/authorization/AbstractReadOnlyAuthorizationManager.java
@@ -17,60 +17,43 @@ import org.sonatype.configuration.validation.InvalidConfigurationException;
 /**
  * An abstract AuthorizationManager, that just throws exceptions for all the write methods. Any call to theses methods
  * should be checked by the <code>supportsWrite()</code> method, so this should never be called.
- *
- * @author Brian Demers
  */
 public abstract class AbstractReadOnlyAuthorizationManager
     implements AuthorizationManager
 {
-
   public boolean supportsWrite() {
     return false;
   }
 
-  public Privilege addPrivilege(Privilege privilege)
-      throws InvalidConfigurationException
-  {
-    this.throwException();
+  public Privilege addPrivilege(Privilege privilege) throws InvalidConfigurationException {
+    throwException();
     return null;
   }
 
-  public Role addRole(Role role)
-      throws InvalidConfigurationException
-  {
-    this.throwException();
+  public Role addRole(Role role) throws InvalidConfigurationException {
+    throwException();
     return null;
   }
 
-  public void deletePrivilege(String privilegeId)
-      throws NoSuchPrivilegeException
-  {
-    this.throwException();
+  public void deletePrivilege(String privilegeId) throws NoSuchPrivilegeException {
+    throwException();
   }
 
-  public void deleteRole(String roleId)
-      throws NoSuchRoleException
-  {
-    this.throwException();
+  public void deleteRole(String roleId) throws NoSuchRoleException {
+    throwException();
   }
 
-  public Privilege updatePrivilege(Privilege privilege)
-      throws NoSuchPrivilegeException, InvalidConfigurationException
-  {
-    this.throwException();
+  public Privilege updatePrivilege(Privilege privilege) throws NoSuchPrivilegeException, InvalidConfigurationException {
+    throwException();
     return null;
   }
 
-  public Role updateRole(Role role)
-      throws NoSuchRoleException, InvalidConfigurationException
-  {
-    this.throwException();
+  public Role updateRole(Role role) throws NoSuchRoleException, InvalidConfigurationException {
+    throwException();
     return null;
   }
 
   private void throwException() {
-    throw new IllegalStateException("AuthorizationManager: '" + this.getSource()
-        + "' does not support write operations.");
+    throw new IllegalStateException("AuthorizationManager: '" + getSource() + "' does not support write operations.");
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/authorization/AuthorizationException.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/authorization/AuthorizationException.java
@@ -20,7 +20,6 @@ package org.sonatype.security.authorization;
 public class AuthorizationException
     extends Exception
 {
-
   private static final long serialVersionUID = -2410686526069723485L;
 
   public AuthorizationException() {
@@ -37,5 +36,4 @@ public class AuthorizationException
   public AuthorizationException(String message, Throwable cause) {
     super(message, cause);
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/authorization/AuthorizationManager.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/authorization/AuthorizationManager.java
@@ -17,84 +17,70 @@ import java.util.Set;
 import org.sonatype.configuration.validation.InvalidConfigurationException;
 
 /**
- * A DAO for Roles and Privileges comming from a given source.
- *
- * @author Brian Demers
+ * Authorization manager.
  */
 public interface AuthorizationManager
 {
   /**
    * The Id if this AuthorizationManager;
    */
-  public String getSource();
+  String getSource();
 
   /**
    * If this AuthorizationManager is writable.
    */
   boolean supportsWrite();
 
-  // **************
-  // ROLE CRUDS
-  // **************
-
   /**
    * Returns the all Roles from this AuthorizationManager. NOTE: this call could be slow when coming from an external
    * source (i.e. a database) TODO: Consider removing this method.
    */
-  public Set<Role> listRoles();
+  Set<Role> listRoles();
 
   /**
    * Returns a Role base on an Id.
    */
-  public Role getRole(String roleId)
-      throws NoSuchRoleException;
+  Role getRole(String roleId) throws NoSuchRoleException;
 
   /**
    * Adds a role to this AuthorizationManager.
    */
-  public Role addRole(Role role)
-      throws InvalidConfigurationException;
+  Role addRole(Role role) throws InvalidConfigurationException;
 
   /**
    * Updates a role in this AuthorizationManager.
    */
-  public Role updateRole(Role role)
-      throws NoSuchRoleException, InvalidConfigurationException;
+  Role updateRole(Role role) throws NoSuchRoleException, InvalidConfigurationException;
 
   /**
    * Removes a role in this AuthorizationManager.
    */
-  public void deleteRole(String roleId)
-      throws NoSuchRoleException;
+  void deleteRole(String roleId) throws NoSuchRoleException;
 
   // Privilege CRUDS
 
   /**
    * Returns the all Privileges from this AuthorizationManager.
    */
-  public Set<Privilege> listPrivileges();
+  Set<Privilege> listPrivileges();
 
   /**
    * Returns a Privilege base on an Id.
    */
-  public Privilege getPrivilege(String privilegeId)
-      throws NoSuchPrivilegeException;
+  Privilege getPrivilege(String privilegeId) throws NoSuchPrivilegeException;
 
   /**
    * Adds a Privilege to this AuthorizationManager.
    */
-  public Privilege addPrivilege(Privilege privilege)
-      throws InvalidConfigurationException;
+  Privilege addPrivilege(Privilege privilege) throws InvalidConfigurationException;
 
   /**
    * Updates a Privilege in this AuthorizationManager.
    */
-  public Privilege updatePrivilege(Privilege privilege)
-      throws NoSuchPrivilegeException, InvalidConfigurationException;
+  Privilege updatePrivilege(Privilege privilege) throws NoSuchPrivilegeException, InvalidConfigurationException;
 
   /**
    * Removes a Privilege in this AuthorizationManager.
    */
-  public void deletePrivilege(String privilegeId)
-      throws NoSuchPrivilegeException;
+  void deletePrivilege(String privilegeId) throws NoSuchPrivilegeException;
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/authorization/AuthorizationManagerImpl.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/authorization/AuthorizationManagerImpl.java
@@ -50,9 +50,9 @@ public class AuthorizationManagerImpl
   private final EventBus eventBus;
 
   @Inject
-  public AuthorizationManagerImpl(ConfigurationManager configuration,
-                                  PrivilegeInheritanceManager privInheritance,
-                                  EventBus eventBus)
+  public AuthorizationManagerImpl(final ConfigurationManager configuration,
+                                  final PrivilegeInheritanceManager privInheritance,
+                                  final EventBus eventBus)
   {
     this.configuration = configuration;
     this.privInheritance = privInheritance;
@@ -148,15 +148,11 @@ public class AuthorizationManagerImpl
     return roles;
   }
 
-  public Role getRole(String roleId)
-      throws NoSuchRoleException
-  {
+  public Role getRole(String roleId) throws NoSuchRoleException {
     return this.toRole(this.configuration.readRole(roleId));
   }
 
-  public Role addRole(Role role)
-      throws InvalidConfigurationException
-  {
+  public Role addRole(Role role) throws InvalidConfigurationException {
     // the roleId of the secRole might change, so we need to keep the reference
     final CRole secRole = this.toRole(role);
 
@@ -168,9 +164,7 @@ public class AuthorizationManagerImpl
     return this.toRole(secRole);
   }
 
-  public Role updateRole(Role role)
-      throws NoSuchRoleException, InvalidConfigurationException
-  {
+  public Role updateRole(Role role) throws NoSuchRoleException, InvalidConfigurationException {
     final CRole secRole = this.toRole(role);
 
     configuration.updateRole(secRole);
@@ -181,9 +175,7 @@ public class AuthorizationManagerImpl
     return this.toRole(secRole);
   }
 
-  public void deleteRole(final String roleId)
-      throws NoSuchRoleException
-  {
+  public void deleteRole(final String roleId) throws NoSuchRoleException {
     configuration.deleteRole(roleId);
 
     // notify any listeners that the config changed
@@ -205,15 +197,11 @@ public class AuthorizationManagerImpl
     return privileges;
   }
 
-  public Privilege getPrivilege(String privilegeId)
-      throws NoSuchPrivilegeException
-  {
+  public Privilege getPrivilege(String privilegeId) throws NoSuchPrivilegeException {
     return this.toPrivilege(this.configuration.readPrivilege(privilegeId));
   }
 
-  public Privilege addPrivilege(Privilege privilege)
-      throws InvalidConfigurationException
-  {
+  public Privilege addPrivilege(Privilege privilege) throws InvalidConfigurationException {
     final CPrivilege secPriv = this.toPrivilege(privilege);
     // create implies read, so we need to add logic for that
     addInheritedPrivileges(secPriv);
@@ -226,9 +214,7 @@ public class AuthorizationManagerImpl
     return this.toPrivilege(secPriv);
   }
 
-  public Privilege updatePrivilege(Privilege privilege)
-      throws NoSuchPrivilegeException, InvalidConfigurationException
-  {
+  public Privilege updatePrivilege(Privilege privilege) throws NoSuchPrivilegeException, InvalidConfigurationException {
     final CPrivilege secPriv = this.toPrivilege(privilege);
 
     configuration.updatePrivilege(secPriv);
@@ -239,9 +225,7 @@ public class AuthorizationManagerImpl
     return this.toPrivilege(secPriv);
   }
 
-  public void deletePrivilege(final String privilegeId)
-      throws NoSuchPrivilegeException
-  {
+  public void deletePrivilege(final String privilegeId) throws NoSuchPrivilegeException {
     configuration.deletePrivilege(privilegeId);
 
     // notify any listeners that the config changed
@@ -276,5 +260,4 @@ public class AuthorizationManagerImpl
   private void fireAuthorizationChangedEvent() {
     this.eventBus.post(new AuthorizationConfigurationChanged());
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/authorization/ExceptionCatchingModularRealmAuthorizer.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/authorization/ExceptionCatchingModularRealmAuthorizer.java
@@ -47,8 +47,8 @@ public class ExceptionCatchingModularRealmAuthorizer
   }
 
   @Inject
-  public ExceptionCatchingModularRealmAuthorizer(Collection<Realm> realms,
-      Provider<RolePermissionResolver> rolePermissionResolverProvider)
+  public ExceptionCatchingModularRealmAuthorizer(final Collection<Realm> realms, 
+                                                 final Provider<RolePermissionResolver> rolePermissionResolverProvider)
   {
     this.rolePermissionResolverProvider = rolePermissionResolverProvider;
     setRealms(realms);
@@ -61,10 +61,8 @@ public class ExceptionCatchingModularRealmAuthorizer
 
   // Authorization
   @Override
-  public void checkPermission(PrincipalCollection subjectPrincipal, String permission)
-      throws AuthorizationException
-  {
-    if (!this.isPermitted(subjectPrincipal, permission)) {
+  public void checkPermission(PrincipalCollection subjectPrincipal, String permission) throws AuthorizationException {
+    if (!isPermitted(subjectPrincipal, permission)) {
       throw new AuthorizationException("User is not permitted: " + permission);
     }
   }
@@ -73,7 +71,7 @@ public class ExceptionCatchingModularRealmAuthorizer
   public void checkPermission(PrincipalCollection subjectPrincipal, Permission permission)
       throws AuthorizationException
   {
-    if (!this.isPermitted(subjectPrincipal, permission)) {
+    if (!isPermitted(subjectPrincipal, permission)) {
       throw new AuthorizationException("User is not permitted: " + permission);
     }
   }
@@ -97,10 +95,8 @@ public class ExceptionCatchingModularRealmAuthorizer
   }
 
   @Override
-  public void checkRole(PrincipalCollection subjectPrincipal, String roleIdentifier)
-      throws AuthorizationException
-  {
-    if (!this.hasRole(subjectPrincipal, roleIdentifier)) {
+  public void checkRole(PrincipalCollection subjectPrincipal, String roleIdentifier) throws AuthorizationException {
+    if (!hasRole(subjectPrincipal, roleIdentifier)) {
       throw new AuthorizationException("User is not permitted role: " + roleIdentifier);
     }
   }
@@ -109,7 +105,7 @@ public class ExceptionCatchingModularRealmAuthorizer
   public void checkRoles(PrincipalCollection subjectPrincipal, Collection<String> roleIdentifiers)
       throws AuthorizationException
   {
-    if (!this.hasAllRoles(subjectPrincipal, roleIdentifiers)) {
+    if (!hasAllRoles(subjectPrincipal, roleIdentifiers)) {
       throw new AuthorizationException("User is not permitted role: " + roleIdentifiers);
     }
   }
@@ -127,7 +123,7 @@ public class ExceptionCatchingModularRealmAuthorizer
 
   @Override
   public boolean hasRole(PrincipalCollection subjectPrincipal, String roleIdentifier) {
-    for (Realm realm : this.getRealms()) {
+    for (Realm realm : getRealms()) {
       if (!(realm instanceof Authorizer)) {
         continue; // ignore non-authorizing realms
       }
@@ -152,7 +148,7 @@ public class ExceptionCatchingModularRealmAuthorizer
   public boolean[] hasRoles(PrincipalCollection subjectPrincipal, List<String> roleIdentifiers) {
     boolean[] combinedResult = new boolean[roleIdentifiers.size()];
 
-    for (Realm realm : this.getRealms()) {
+    for (Realm realm : getRealms()) {
       if (!(realm instanceof Authorizer)) {
         continue; // ignore non-authorizing realms
       }
@@ -177,21 +173,21 @@ public class ExceptionCatchingModularRealmAuthorizer
 
   @Override
   public boolean isPermitted(PrincipalCollection subjectPrincipal, String permission) {
-    for (Realm realm : this.getRealms()) {
+    for (Realm realm : getRealms()) {
       if (!(realm instanceof Authorizer)) {
         continue; // ignore non-authorizing realms
       }
       try {
         if (((Authorizer) realm).isPermitted(subjectPrincipal, permission)) {
           if (logger.isTraceEnabled()) {
-            this.logger.trace("Realm: " + realm.getName() + " user: " + subjectPrincipal.iterator().next()
+            logger.trace("Realm: " + realm.getName() + " user: " + subjectPrincipal.iterator().next()
                 + " has permission: " + permission);
           }
           return true;
         }
         else {
           if (logger.isTraceEnabled()) {
-            this.logger.trace("Realm: " + realm.getName() + " user: " + subjectPrincipal.iterator().next()
+            logger.trace("Realm: " + realm.getName() + " user: " + subjectPrincipal.iterator().next()
                 + " does NOT have permission: " + permission);
           }
         }
@@ -210,7 +206,7 @@ public class ExceptionCatchingModularRealmAuthorizer
 
   @Override
   public boolean isPermitted(PrincipalCollection subjectPrincipal, Permission permission) {
-    for (Realm realm : this.getRealms()) {
+    for (Realm realm : getRealms()) {
       if (!(realm instanceof Authorizer)) {
         continue; // ignore non-authorizing realms
       }
@@ -234,7 +230,7 @@ public class ExceptionCatchingModularRealmAuthorizer
   public boolean[] isPermitted(PrincipalCollection subjectPrincipal, String... permissions) {
     boolean[] combinedResult = new boolean[permissions.length];
 
-    for (Realm realm : this.getRealms()) {
+    for (Realm realm : getRealms()) {
       if (!(realm instanceof Authorizer)) {
         continue; // ignore non-authorizing realms
       }
@@ -260,7 +256,7 @@ public class ExceptionCatchingModularRealmAuthorizer
   public boolean[] isPermitted(PrincipalCollection subjectPrincipal, List<Permission> permissions) {
     boolean[] combinedResult = new boolean[permissions.size()];
 
-    for (Realm realm : this.getRealms()) {
+    for (Realm realm : getRealms()) {
       if (!(realm instanceof Authorizer)) {
         continue; // ignore non-authorizing realms
       }
@@ -305,8 +301,6 @@ public class ExceptionCatchingModularRealmAuthorizer
   }
 
   private void logAndIgnore(Realm realm, Exception e) {
-    if (logger.isTraceEnabled()) {
-      logger.trace("Realm: '" + realm.getName() + "', caused: " + e.getMessage(), e);
-    }
+    logger.trace("Realm '{}' failure", realm.getName(), e);
   }
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/authorization/NoSuchAuthorizationManagerException.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/authorization/NoSuchAuthorizationManagerException.java
@@ -14,13 +14,10 @@ package org.sonatype.security.authorization;
 
 /**
  * Thrown when an AuthorizationManager could not be found.
- *
- * @author Brian Demers
  */
 public class NoSuchAuthorizationManagerException
     extends Exception
 {
-
   private static final long serialVersionUID = -9130834235862218360L;
 
   public NoSuchAuthorizationManagerException() {
@@ -37,5 +34,4 @@ public class NoSuchAuthorizationManagerException
   public NoSuchAuthorizationManagerException(Throwable cause) {
     super(cause);
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/authorization/NoSuchPrivilegeException.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/authorization/NoSuchPrivilegeException.java
@@ -14,8 +14,6 @@ package org.sonatype.security.authorization;
 
 /**
  * Thrown when a Privilege could not be found.
- *
- * @author Brian Demers
  */
 public class NoSuchPrivilegeException
     extends Exception
@@ -36,5 +34,4 @@ public class NoSuchPrivilegeException
   public NoSuchPrivilegeException(Throwable cause) {
     super(cause);
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/authorization/NoSuchRoleException.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/authorization/NoSuchRoleException.java
@@ -14,8 +14,6 @@ package org.sonatype.security.authorization;
 
 /**
  * Thrown when a Role could not be found.
- *
- * @author Brian Demers
  */
 public class NoSuchRoleException
     extends Exception
@@ -36,5 +34,4 @@ public class NoSuchRoleException
   public NoSuchRoleException(Throwable cause) {
     super(cause);
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/authorization/PermissionFactory.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/authorization/PermissionFactory.java
@@ -15,14 +15,12 @@ package org.sonatype.security.authorization;
 import org.apache.shiro.authz.Permission;
 
 /**
- * A permission factory that creates Permission instances. It may apply other stuff, like caching instances for
- * example,
+ * A permission factory that creates Permission instances.
+ *
+ * It may apply other stuff, like caching instances for example,
  * based on permission string representation. This is just a concept to be able to hide caching of it. Which
  * implementation you use, depends on your app very much, but usually you'd want the one producing the most widely used
  * permission in Shiro: the {@link WildcardPermissionFactory}.
- *
- * @author cstamas
- * @since sonatype-security 2.8
  */
 public interface PermissionFactory
 {

--- a/components/nexus-security/src/main/java/org/sonatype/security/authorization/Privilege.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/authorization/Privilege.java
@@ -16,13 +16,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A simple bean that represents a privilge.
- *
- * @author Brian Demers
+ * A simple bean that represents a privilege.
  */
 public class Privilege
 {
-
   /**
    * Field id
    */
@@ -53,10 +50,13 @@ public class Privilege
   private String version;
 
   public Privilege() {
-
   }
 
-  public Privilege(String id, String name, String description, String type, Map<String, String> properties,
+  public Privilege(String id,
+                   String name,
+                   String description,
+                   String type,
+                   Map<String, String> properties,
                    boolean readOnly)
   {
     this.id = id;

--- a/components/nexus-security/src/main/java/org/sonatype/security/authorization/PrivilegeInheritanceManager.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/authorization/PrivilegeInheritanceManager.java
@@ -16,13 +16,11 @@ import java.util.List;
 
 /**
  * Allows for an method to inherit from another. For example: 'delete' imply that a user has access to 'read'.
- *
- * @author Brian Demers
  */
 public interface PrivilegeInheritanceManager
 {
   /**
-   * Retrive a list of methods that are inherited by the requested method
+   * Retrieve a list of methods that are inherited by the requested method
    */
   List<String> getInheritedMethods(String method);
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/authorization/Role.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/authorization/Role.java
@@ -41,10 +41,14 @@ public class Role
   private String version;
 
   public Role() {
-
   }
 
-  public Role(String roleId, String name, String description, String source, boolean readOnly, Set<String> roles,
+  public Role(String roleId,
+              String name,
+              String description,
+              String source,
+              boolean readOnly,
+              Set<String> roles,
               Set<String> privileges)
   {
     this.roleId = roleId;
@@ -246,5 +250,4 @@ public class Role
     }
     return true;
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/authorization/WildcardPermissionFactory.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/authorization/WildcardPermissionFactory.java
@@ -23,9 +23,6 @@ import org.apache.shiro.authz.permission.WildcardPermission;
  * A permission factory that creates instances of Shiro's {@link WildcardPermission} by directly invoking it's
  * constructor with passed in string representation of the permission. This is the default factory, as the
  * {@link WildcardPermission} is the default permission implementation used all over Security.
- *
- * @author cstamas
- * @since sonatype-security 2.8
  */
 @Named("wildcard")
 @Singleton

--- a/components/nexus-security/src/main/java/org/sonatype/security/email/NullSecurityEmailer.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/email/NullSecurityEmailer.java
@@ -34,5 +34,4 @@ public class NullSecurityEmailer
   public void sendResetPassword(String email, String password) {
     log.error("No SecurityEmailer, user will not be notified.");
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/events/AuthenticationEvent.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/events/AuthenticationEvent.java
@@ -19,7 +19,6 @@ package org.sonatype.security.events;
  */
 public class AuthenticationEvent
 {
-
   private final String userId;
 
   private final boolean successful;
@@ -44,5 +43,4 @@ public class AuthenticationEvent
         ", successful=" + successful +
         '}';
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/events/AuthorizationConfigurationChanged.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/events/AuthorizationConfigurationChanged.java
@@ -14,10 +14,8 @@ package org.sonatype.security.events;
 
 /**
  * An event fired when the authorization configuration has changed.
- *
- * @author Brian Demers
  */
 public class AuthorizationConfigurationChanged
 {
-
+  // empty
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/events/SecurityConfigurationChanged.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/events/SecurityConfigurationChanged.java
@@ -14,10 +14,8 @@ package org.sonatype.security.events;
 
 /**
  * An event fired when the security configuration has changed.
- *
- * @author Brian Demers
  */
 public class SecurityConfigurationChanged
 {
-
+  // empty
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/events/UserPrincipalsExpired.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/events/UserPrincipalsExpired.java
@@ -14,12 +14,9 @@ package org.sonatype.security.events;
 
 /**
  * An event fired when a user is removed from the system, so cached principals can be expired.
- *
- * @since sonatype-security 2.8
  */
 public class UserPrincipalsExpired
 {
-
   private final String userId;
 
   private final String source;
@@ -49,5 +46,4 @@ public class UserPrincipalsExpired
   public String getSource() {
     return source;
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/realms/AuthenticatingRealmImpl.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/realms/AuthenticatingRealmImpl.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Default {@link AuthenticatingRealm}.
+ *
  * This realm ONLY handles authentication.
  */
 @Singleton
@@ -62,8 +63,8 @@ public class AuthenticatingRealmImpl
   private final int MAX_LEGACY_PASSWORD_LENGTH = 40;
 
   @Inject
-  public AuthenticatingRealmImpl(ConfigurationManager configuration,
-                                 PasswordService passwordService)
+  public AuthenticatingRealmImpl(final ConfigurationManager configuration,
+                                 final PasswordService passwordService)
   {
     this.configuration = configuration;
     this.passwordService = passwordService;
@@ -76,9 +77,7 @@ public class AuthenticatingRealmImpl
   }
 
   @Override
-  protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken token)
-      throws AuthenticationException
-  {
+  protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken token) throws AuthenticationException {
     UsernamePasswordToken upToken = (UsernamePasswordToken) token;
 
     CUser user;
@@ -106,12 +105,12 @@ public class AuthenticatingRealmImpl
       throw new DisabledAccountException("User '" + upToken.getUsername() + "' is disabled.");
     }
     else {
-      throw new AccountException("User '" + upToken.getUsername() + "' is in illegal status '"
-          + user.getStatus() + "'.");
+      throw new AccountException(
+          "User '" + upToken.getUsername() + "' is in illegal status '" + user.getStatus() + "'.");
     }
   }
 
-  /*
+  /**
    * Re-hash user password, and persist changes.
    *
    * @param user to update
@@ -140,13 +139,11 @@ public class AuthenticatingRealmImpl
     }
   }
 
-  /*
-   * Checks to see if the credentials in token match the credentials stored on
-   * user
+  /**
+   * Checks to see if the credentials in token match the credentials stored on user
    *
-   * @param token the username/password token containing the credentials to
-   * verify
-   * @param the user object containing the stored credentials
+   * @param token the username/password token containing the credentials to verify
+   * @param user object containing the stored credentials
    * @return true if credentials match, false otherwise
    */
   private boolean isValidCredentials(UsernamePasswordToken token, CUser user) {
@@ -163,7 +160,7 @@ public class AuthenticatingRealmImpl
     return credentialsValid;
   }
 
-  /*
+  /**
    * Checks to see if the specified user is a legacy user
    * A legacy user has an unsalted password
    *
@@ -175,11 +172,10 @@ public class AuthenticatingRealmImpl
     return user.getPassword().length() <= this.MAX_LEGACY_PASSWORD_LENGTH;
   }
 
-  /*
+  /**
    * Creates an authentication info object
    * using the credentials of the provided user
    *
-   * @param user
    * @return authentication info object based on user credentials
    */
   private AuthenticationInfo createAuthenticationInfo(CUser user) {

--- a/components/nexus-security/src/main/java/org/sonatype/security/realms/AuthorizingRealmImpl.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/realms/AuthorizingRealmImpl.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Default {@link AuthorizingRealm}.
+ *
  * This realm ONLY handles authorization.
  */
 @Singleton
@@ -65,8 +66,9 @@ public class AuthorizingRealmImpl
   private final SecuritySystem securitySystem;
 
   @Inject
-  public AuthorizingRealmImpl(UserManager userManager, SecuritySystem securitySystem,
-                              Map<String, UserManager> userManagerMap)
+  public AuthorizingRealmImpl(final UserManager userManager,
+                              final SecuritySystem securitySystem,
+                              final Map<String, UserManager> userManagerMap)
   {
     this.userManager = userManager;
     this.securitySystem = securitySystem;
@@ -83,9 +85,7 @@ public class AuthorizingRealmImpl
   }
 
   @Override
-  protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken token)
-      throws AuthenticationException
-  {
+  protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken token) throws AuthenticationException {
     return null;
   }
 
@@ -130,10 +130,7 @@ public class AuthorizingRealmImpl
           }
         }
         catch (UserNotFoundException e) {
-          if (this.logger.isTraceEnabled()) {
-            this.logger.trace("Failed to find role mappings for user: " + username + " realm: "
-                + realmName);
-          }
+          logger.trace("Failed to find role mappings for user: {} realm: {}", username, realmName);
         }
       }
     }
@@ -156,9 +153,7 @@ public class AuthorizingRealmImpl
           + " not manged by Nexus realm.");
     }
 
-    SimpleAuthorizationInfo info = new SimpleAuthorizationInfo(roles);
-
-    return info;
+    return new SimpleAuthorizationInfo(roles);
   }
 
   private void cleanUpRealmList(Set<String> realmNames) {

--- a/components/nexus-security/src/main/java/org/sonatype/security/realms/RolePermissionResolverImpl.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/realms/RolePermissionResolverImpl.java
@@ -60,10 +60,10 @@ public class RolePermissionResolverImpl
   private final Map<String, Collection<Permission>> permissionsCache;
 
   @Inject
-  public RolePermissionResolverImpl(ConfigurationManager configuration,
-                                    List<PrivilegeDescriptor> privilegeDescriptors,
-                                    @Named("caching") PermissionFactory permissionFactory,
-                                    EventBus eventBus)
+  public RolePermissionResolverImpl(final ConfigurationManager configuration,
+                                    final List<PrivilegeDescriptor> privilegeDescriptors,
+                                    final @Named("caching") PermissionFactory permissionFactory,
+                                    final EventBus eventBus)
   {
     this.configuration = configuration;
     this.privilegeDescriptors = privilegeDescriptors;

--- a/components/nexus-security/src/main/java/org/sonatype/security/realms/privileges/AbstractPrivilegeDescriptor.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/realms/privileges/AbstractPrivilegeDescriptor.java
@@ -27,8 +27,12 @@ import org.codehaus.plexus.util.StringUtils;
 public abstract class AbstractPrivilegeDescriptor
     implements PrivilegeDescriptor
 {
-  @Inject
   private ConfigurationIdGenerator idGenerator;
+
+  @Inject
+  public void installDependencies(final ConfigurationIdGenerator idGenerator) {
+    this.idGenerator = idGenerator;
+  }
 
   public ValidationResponse validatePrivilege(CPrivilege privilege, SecurityValidationContext ctx, boolean update) {
     ValidationResponse response = new ValidationResponse();
@@ -38,41 +42,33 @@ public abstract class AbstractPrivilegeDescriptor
     }
 
     SecurityValidationContext context = (SecurityValidationContext) response.getContext();
-
     List<String> existingIds = context.getExistingPrivilegeIds();
 
     if (existingIds == null) {
       context.addExistingPrivilegeIds();
-
       existingIds = context.getExistingPrivilegeIds();
     }
 
-    if (!update
-        && (StringUtils.isEmpty(privilege.getId()) || "0".equals(privilege.getId()) ||
-        (existingIds.contains(privilege.getId())))) {
+    if (!update && (StringUtils.isEmpty(privilege.getId()) || "0".equals(privilege.getId()) || (existingIds.contains(privilege.getId())))) {
       String newId = idGenerator.generateId();
 
-      ValidationMessage message =
-          new ValidationMessage("id", "Fixed wrong privilege ID from '" + privilege.getId() + "' to '" + newId
-              + "'");
+      ValidationMessage message = new ValidationMessage("id",
+          "Fixed wrong privilege ID from '" + privilege.getId() + "' to '" + newId + "'");
       response.addValidationWarning(message);
-
       privilege.setId(newId);
-
       response.setModified(true);
     }
 
     if (StringUtils.isEmpty(privilege.getType())) {
-      ValidationMessage message =
-          new ValidationMessage("type", "Cannot have an empty type", "Privilege cannot have an invalid type");
+      ValidationMessage message = new ValidationMessage("type",
+          "Cannot have an empty type", "Privilege cannot have an invalid type");
 
       response.addValidationError(message);
     }
 
     if (StringUtils.isEmpty(privilege.getName())) {
-      ValidationMessage message =
-          new ValidationMessage("name", "Privilege ID '" + privilege.getId() + "' requires a name.",
-              "Name is required.");
+      ValidationMessage message = new ValidationMessage("name",
+          "Privilege ID '" + privilege.getId() + "' requires a name.", "Name is required.");
       response.addValidationError(message);
     }
 

--- a/components/nexus-security/src/main/java/org/sonatype/security/realms/privileges/application/ApplicationPrivilegeDescriptor.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/realms/privileges/application/ApplicationPrivilegeDescriptor.java
@@ -12,11 +12,9 @@
  */
 package org.sonatype.security.realms.privileges.application;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.enterprise.inject.Typed;
-import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
@@ -28,6 +26,7 @@ import org.sonatype.security.realms.privileges.PrivilegeDescriptor;
 import org.sonatype.security.realms.privileges.PrivilegePropertyDescriptor;
 import org.sonatype.security.realms.validator.SecurityValidationContext;
 
+import com.google.common.collect.Lists;
 import org.codehaus.plexus.util.StringUtils;
 
 @Singleton
@@ -39,19 +38,6 @@ public class ApplicationPrivilegeDescriptor
 {
   public static final String TYPE = "method";
 
-  private final PrivilegePropertyDescriptor methodProperty;
-
-  private final PrivilegePropertyDescriptor permissionProperty;
-
-  @Inject
-  public ApplicationPrivilegeDescriptor(
-      @Named("ApplicationPrivilegeMethodPropertyDescriptor") PrivilegePropertyDescriptor methodProperty,
-      @Named("ApplicationPrivilegePermissionPropertyDescriptor") PrivilegePropertyDescriptor permissionProperty)
-  {
-    this.methodProperty = methodProperty;
-    this.permissionProperty = permissionProperty;
-  }
-
   public String getName() {
     return "Application";
   }
@@ -61,12 +47,10 @@ public class ApplicationPrivilegeDescriptor
   }
 
   public List<PrivilegePropertyDescriptor> getPropertyDescriptors() {
-    List<PrivilegePropertyDescriptor> propertyDescriptors = new ArrayList<PrivilegePropertyDescriptor>();
-
-    propertyDescriptors.add(methodProperty);
-    propertyDescriptors.add(permissionProperty);
-
-    return propertyDescriptors;
+    return Lists.newArrayList(
+        new ApplicationPrivilegeMethodPropertyDescriptor(),
+        new ApplicationPrivilegePermissionPropertyDescriptor()
+    );
   }
 
   public String buildPermission(CPrivilege privilege) {

--- a/components/nexus-security/src/main/java/org/sonatype/security/realms/privileges/application/ApplicationPrivilegeMethodPropertyDescriptor.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/realms/privileges/application/ApplicationPrivilegeMethodPropertyDescriptor.java
@@ -12,15 +12,8 @@
  */
 package org.sonatype.security.realms.privileges.application;
 
-import javax.enterprise.inject.Typed;
-import javax.inject.Named;
-import javax.inject.Singleton;
-
 import org.sonatype.security.realms.privileges.PrivilegePropertyDescriptor;
 
-@Singleton
-@Typed(PrivilegePropertyDescriptor.class)
-@Named("ApplicationPrivilegeMethodPropertyDescriptor")
 public class ApplicationPrivilegeMethodPropertyDescriptor
     implements PrivilegePropertyDescriptor
 {

--- a/components/nexus-security/src/main/java/org/sonatype/security/realms/privileges/application/ApplicationPrivilegePermissionPropertyDescriptor.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/realms/privileges/application/ApplicationPrivilegePermissionPropertyDescriptor.java
@@ -12,19 +12,14 @@
  */
 package org.sonatype.security.realms.privileges.application;
 
-import javax.enterprise.inject.Typed;
-import javax.inject.Named;
-import javax.inject.Singleton;
-
 import org.sonatype.security.realms.privileges.PrivilegePropertyDescriptor;
 
-@Singleton
-@Typed(PrivilegePropertyDescriptor.class)
-@Named("ApplicationPrivilegePermissionPropertyDescriptor")
 public class ApplicationPrivilegePermissionPropertyDescriptor
     implements PrivilegePropertyDescriptor
 {
   public static final String ID = "permission";
+
+  // FIXME: This is not actually the permission, but the prefix or base of the permission
 
   public String getHelpText() {
     return "The Shiro permission string associated with this privilege";
@@ -41,5 +36,4 @@ public class ApplicationPrivilegePermissionPropertyDescriptor
   public String getType() {
     return "string";
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/realms/tools/ConfigurationManager.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/realms/tools/ConfigurationManager.java
@@ -32,13 +32,10 @@ import org.sonatype.security.usermanagement.UserNotFoundException;
  * cannot be used directly in a thread-safe manner
  *
  * Direct calls to read-based ConfigurationManager methods can be called in a thread-safe manner. However, operations
- * that require multiple read-based calls should be encapsulated into an action and executed via the runRead method
- *
- * @author Brian Demers
+ * that require multiple read-based calls should be encapsulated into an action and executed via the runRead method.
  */
 public interface ConfigurationManager
 {
-
   /**
    * Retrieve all users
    */
@@ -57,102 +54,84 @@ public interface ConfigurationManager
   /**
    * Create a new user.
    */
-  void createUser(CUser user, Set<String> roles)
-      throws InvalidConfigurationException;
+  void createUser(CUser user, Set<String> roles) throws InvalidConfigurationException;
 
   /**
    * Create a new user and sets the password.
    */
-  void createUser(CUser user, String password, Set<String> roles)
-      throws InvalidConfigurationException;
+  void createUser(CUser user, String password, Set<String> roles) throws InvalidConfigurationException;
 
   /**
    * Create a new role
    */
-  void createRole(CRole role)
-      throws InvalidConfigurationException;
+  void createRole(CRole role) throws InvalidConfigurationException;
 
   /**
    * Create a new privilege
    */
-  void createPrivilege(CPrivilege privilege)
-      throws InvalidConfigurationException;
+  void createPrivilege(CPrivilege privilege) throws InvalidConfigurationException;
 
   /**
    * Retrieve an existing user
    */
-  CUser readUser(String id)
-      throws UserNotFoundException;
+  CUser readUser(String id) throws UserNotFoundException;
 
   /**
    * Retrieve an existing role
    */
-  CRole readRole(String id)
-      throws NoSuchRoleException;
+  CRole readRole(String id) throws NoSuchRoleException;
 
   /**
    * Retrieve an existing privilege
    */
-  CPrivilege readPrivilege(String id)
-      throws NoSuchPrivilegeException;
+  CPrivilege readPrivilege(String id) throws NoSuchPrivilegeException;
 
   /**
    * Update an existing user. Roles are unchanged
    *
    * @param user to update
    */
-  public void updateUser(CUser user)
-      throws InvalidConfigurationException, UserNotFoundException;
+  void updateUser(CUser user) throws InvalidConfigurationException, UserNotFoundException;
 
   /**
    * Update an existing user and their roles
    */
-  void updateUser(CUser user, Set<String> roles)
-      throws InvalidConfigurationException, UserNotFoundException;
+  void updateUser(CUser user, Set<String> roles) throws InvalidConfigurationException, UserNotFoundException;
 
   /**
    * Update an existing role
    */
-  void updateRole(CRole role)
-      throws InvalidConfigurationException, NoSuchRoleException;
+  void updateRole(CRole role) throws InvalidConfigurationException, NoSuchRoleException;
 
-  void createUserRoleMapping(CUserRoleMapping userRoleMapping)
-      throws InvalidConfigurationException;
+  void createUserRoleMapping(CUserRoleMapping userRoleMapping) throws InvalidConfigurationException;
 
-  void updateUserRoleMapping(CUserRoleMapping userRoleMapping)
-      throws InvalidConfigurationException, NoSuchRoleMappingException;
+  void updateUserRoleMapping(CUserRoleMapping userRoleMapping) throws InvalidConfigurationException, NoSuchRoleMappingException;
 
-  CUserRoleMapping readUserRoleMapping(String userId, String source)
-      throws NoSuchRoleMappingException;
+  CUserRoleMapping readUserRoleMapping(String userId, String source) throws NoSuchRoleMappingException;
 
   List<CUserRoleMapping> listUserRoleMappings();
 
-  void deleteUserRoleMapping(String userId, String source)
-      throws NoSuchRoleMappingException;
+  void deleteUserRoleMapping(String userId, String source) throws NoSuchRoleMappingException;
 
   /**
    * Update an existing privilege
    */
-  void updatePrivilege(CPrivilege privilege)
-      throws InvalidConfigurationException, NoSuchPrivilegeException;
+  void updatePrivilege(CPrivilege privilege) throws InvalidConfigurationException, NoSuchPrivilegeException;
 
   /**
    * Delete an existing user
    */
-  void deleteUser(String id)
-      throws UserNotFoundException;
+  void deleteUser(String id) throws UserNotFoundException;
 
   /**
    * Delete an existing role
    */
-  void deleteRole(String id)
-      throws NoSuchRoleException;
+  void deleteRole(String id) throws NoSuchRoleException;
 
   /**
    * Delete an existing privilege
    */
-  void deletePrivilege(String id)
-      throws NoSuchPrivilegeException;
+  void deletePrivilege(String id) throws NoSuchPrivilegeException;
 
   void cleanRemovedRole(String roleId);
 

--- a/components/nexus-security/src/main/java/org/sonatype/security/realms/tools/DefaultConfigurationManager.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/realms/tools/DefaultConfigurationManager.java
@@ -78,14 +78,14 @@ public class DefaultConfigurationManager
   private volatile SecurityModelConfiguration mergedConfiguration;
 
   @Inject
-  public DefaultConfigurationManager(SecurityModelConfigurationSource configurationSource,
-                                     List<StaticSecurityResource> staticResources,
-                                     List<DynamicSecurityResource> dynamicResources,
-                                     List<SecurityConfigurationModifier> configurationModifiers,
-                                     SecurityConfigurationCleaner configCleaner,
-                                     SecurityConfigurationValidator validator,
-                                     PasswordService passwordService,
-                                     EventBus eventBus)
+  public DefaultConfigurationManager(final SecurityModelConfigurationSource configurationSource,
+                                     final List<StaticSecurityResource> staticResources,
+                                     final List<DynamicSecurityResource> dynamicResources,
+                                     final List<SecurityConfigurationModifier> configurationModifiers,
+                                     final SecurityConfigurationCleaner configCleaner,
+                                     final SecurityConfigurationValidator validator,
+                                     final PasswordService passwordService,
+                                     final EventBus eventBus)
   {
     this.configurationSource = configurationSource;
     this.dynamicResources = dynamicResources;
@@ -124,9 +124,7 @@ public class DefaultConfigurationManager
   }
 
   @Override
-  public void createPrivilege(CPrivilege privilege)
-      throws InvalidConfigurationException
-  {
+  public void createPrivilege(CPrivilege privilege) throws InvalidConfigurationException {
     createPrivilege(privilege, initializeContext());
   }
 
@@ -149,15 +147,11 @@ public class DefaultConfigurationManager
   }
 
   @Override
-  public void createRole(CRole role)
-      throws InvalidConfigurationException
-  {
+  public void createRole(CRole role) throws InvalidConfigurationException {
     createRole(role, initializeContext());
   }
 
-  private void createRole(CRole role, SecurityValidationContext context)
-      throws InvalidConfigurationException
-  {
+  private void createRole(CRole role, SecurityValidationContext context) throws InvalidConfigurationException {
     if (context == null) {
       context = initializeContext();
     }
@@ -174,16 +168,12 @@ public class DefaultConfigurationManager
   }
 
   @Override
-  public void createUser(CUser user, Set<String> roles)
-      throws InvalidConfigurationException
-  {
+  public void createUser(CUser user, Set<String> roles) throws InvalidConfigurationException {
     createUser(user, null, roles, initializeContext());
   }
 
   @Override
-  public void createUser(CUser user, String password, Set<String> roles)
-      throws InvalidConfigurationException
-  {
+  public void createUser(CUser user, String password, Set<String> roles) throws InvalidConfigurationException {
     createUser(user, password, roles, initializeContext());
   }
 
@@ -211,9 +201,7 @@ public class DefaultConfigurationManager
   }
 
   @Override
-  public void deletePrivilege(String id)
-      throws NoSuchPrivilegeException
-  {
+  public void deletePrivilege(String id) throws NoSuchPrivilegeException {
     boolean found = getDefaultConfiguration().removePrivilege(id);
     if (!found) {
       throw new NoSuchPrivilegeException(id);
@@ -222,9 +210,7 @@ public class DefaultConfigurationManager
   }
 
   @Override
-  public void deleteRole(String id)
-      throws NoSuchRoleException
-  {
+  public void deleteRole(String id) throws NoSuchRoleException {
     boolean found = getDefaultConfiguration().removeRole(id);
     if (!found) {
       throw new NoSuchRoleException(id);
@@ -233,9 +219,7 @@ public class DefaultConfigurationManager
   }
 
   @Override
-  public void deleteUser(String id)
-      throws UserNotFoundException
-  {
+  public void deleteUser(String id) throws UserNotFoundException {
     boolean found = getDefaultConfiguration().removeUser(id);
 
     if (!found) {
@@ -244,9 +228,7 @@ public class DefaultConfigurationManager
   }
 
   @Override
-  public CPrivilege readPrivilege(String id)
-      throws NoSuchPrivilegeException
-  {
+  public CPrivilege readPrivilege(String id) throws NoSuchPrivilegeException {
     CPrivilege privilege = getMergedConfiguration().getPrivilege(id);
     if (privilege != null) {
       return privilege;
@@ -261,9 +243,7 @@ public class DefaultConfigurationManager
   }
 
   @Override
-  public CRole readRole(String id)
-      throws NoSuchRoleException
-  {
+  public CRole readRole(String id) throws NoSuchRoleException {
     CRole role = getMergedConfiguration().getRole(id);
     if (role != null) {
       return role;
@@ -278,9 +258,7 @@ public class DefaultConfigurationManager
   }
 
   @Override
-  public CUser readUser(String id)
-      throws UserNotFoundException
-  {
+  public CUser readUser(String id) throws UserNotFoundException {
     CUser user = getDefaultConfiguration().getUser(id);
 
     if (user != null) {
@@ -290,9 +268,7 @@ public class DefaultConfigurationManager
   }
 
   @Override
-  public void updatePrivilege(CPrivilege privilege)
-      throws InvalidConfigurationException, NoSuchPrivilegeException
-  {
+  public void updatePrivilege(CPrivilege privilege) throws InvalidConfigurationException, NoSuchPrivilegeException {
     updatePrivilege(privilege, initializeContext());
   }
 
@@ -315,9 +291,7 @@ public class DefaultConfigurationManager
   }
 
   @Override
-  public void updateRole(CRole role)
-      throws InvalidConfigurationException, NoSuchRoleException
-  {
+  public void updateRole(CRole role) throws InvalidConfigurationException, NoSuchRoleException {
     updateRole(role, initializeContext());
   }
 
@@ -340,9 +314,7 @@ public class DefaultConfigurationManager
   }
 
   @Override
-  public void updateUser(CUser user)
-      throws InvalidConfigurationException, UserNotFoundException
-  {
+  public void updateUser(CUser user) throws InvalidConfigurationException, UserNotFoundException {
     Set<String> roles = Collections.emptySet();
     try {
       roles = readUserRoleMapping(user.getId(), UserManagerImpl.SOURCE).getRoles();
@@ -354,9 +326,7 @@ public class DefaultConfigurationManager
   }
 
   @Override
-  public void updateUser(CUser user, Set<String> roles)
-      throws InvalidConfigurationException, UserNotFoundException
-  {
+  public void updateUser(CUser user, Set<String> roles) throws InvalidConfigurationException, UserNotFoundException {
     updateUser(user, roles, initializeContext());
   }
 
@@ -379,9 +349,7 @@ public class DefaultConfigurationManager
   }
 
   @Override
-  public void createUserRoleMapping(CUserRoleMapping userRoleMapping)
-      throws InvalidConfigurationException
-  {
+  public void createUserRoleMapping(CUserRoleMapping userRoleMapping) throws InvalidConfigurationException {
     createUserRoleMapping(userRoleMapping, initializeContext());
   }
 
@@ -430,9 +398,7 @@ public class DefaultConfigurationManager
     }
   }
 
-  private CUserRoleMapping readCUserRoleMapping(String userId, String source)
-      throws NoSuchRoleMappingException
-  {
+  private CUserRoleMapping readCUserRoleMapping(String userId, String source) throws NoSuchRoleMappingException {
     CUserRoleMapping mapping = getDefaultConfiguration().getUserRoleMapping(userId, source);
 
     if (mapping != null) {
@@ -444,9 +410,7 @@ public class DefaultConfigurationManager
   }
 
   @Override
-  public CUserRoleMapping readUserRoleMapping(String userId, String source)
-      throws NoSuchRoleMappingException
-  {
+  public CUserRoleMapping readUserRoleMapping(String userId, String source) throws NoSuchRoleMappingException {
     return readCUserRoleMapping(userId, source);
   }
 
@@ -482,9 +446,7 @@ public class DefaultConfigurationManager
   }
 
   @Override
-  public void deleteUserRoleMapping(String userId, String source)
-      throws NoSuchRoleMappingException
-  {
+  public void deleteUserRoleMapping(String userId, String source) throws NoSuchRoleMappingException {
     boolean found = getDefaultConfiguration().removeUserRoleMapping(userId, source);
 
     if (!found) {
@@ -696,5 +658,4 @@ public class DefaultConfigurationManager
 
     return newRole;
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/realms/tools/DefaultSecurityConfigurationCleaner.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/realms/tools/DefaultSecurityConfigurationCleaner.java
@@ -28,8 +28,6 @@ import org.sonatype.sisu.goodies.common.ComponentSupport;
  * Removes dead references to roles and permissions in the security model. When a permission is removed all roles will
  * be updated so the permission reference can removed. When a Role is removed references are removed from other roles
  * and users.
- *
- * @author Brian Demers
  */
 @Singleton
 @Typed(SecurityConfigurationCleaner.class)

--- a/components/nexus-security/src/main/java/org/sonatype/security/realms/tools/DefaultSecurityPasswordService.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/realms/tools/DefaultSecurityPasswordService.java
@@ -30,9 +30,7 @@ import org.apache.shiro.crypto.hash.Hash;
  * details, such as password comparisons, hashing algorithm, hash iterations, salting policy, etc.
  * 
  * This class is just a wrapper around DefaultPasswordService to apply the default password policy,
- * and provide backward compatibility with legacy SHA1 and MD5 based passwords
- * 
- * @since 3.1
+ * and provide backward compatibility with legacy SHA1 and MD5 based passwords.
  */
 @Singleton
 @Typed(PasswordService.class)
@@ -69,10 +67,8 @@ public class DefaultSecurityPasswordService
   }
 
   @Override
-  public String encryptPassword(Object plaintextPassword)
-      throws IllegalArgumentException
-  {
-    return this.passwordService.encryptPassword(plaintextPassword);
+  public String encryptPassword(Object plaintextPassword) {
+    return passwordService.encryptPassword(plaintextPassword);
   }
 
   @Override
@@ -80,27 +76,17 @@ public class DefaultSecurityPasswordService
     //When hash is just a string, it could be a legacy password. Check both
     //current and legacy password services
 
-    if (this.passwordService.passwordsMatch(submittedPlaintext, encrypted)) {
-      return true;
-    }
-
-    if (this.legacyPasswordService.passwordsMatch(submittedPlaintext, encrypted)) {
-      return true;
-    }
-
-    return false;
+    return passwordService.passwordsMatch(submittedPlaintext, encrypted) ||
+        legacyPasswordService.passwordsMatch(submittedPlaintext, encrypted);
   }
 
   @Override
-  public Hash hashPassword(Object plaintext)
-      throws IllegalArgumentException
-  {
-    return this.passwordService.hashPassword(plaintext);
+  public Hash hashPassword(Object plaintext) {
+    return passwordService.hashPassword(plaintext);
   }
 
   @Override
   public boolean passwordsMatch(Object plaintext, Hash savedPasswordHash) {
-    return this.passwordService.passwordsMatch(plaintext, savedPasswordHash);
+    return passwordService.passwordsMatch(plaintext, savedPasswordHash);
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/realms/tools/DynamicSecurityResource.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/realms/tools/DynamicSecurityResource.java
@@ -17,8 +17,6 @@ import org.sonatype.security.model.SecurityModelConfiguration;
 /**
  * A DynamicSecurityResource all for other components/plugins to contributes users/roles/privileges to the security
  * model.
- *
- * @author Brian Demers
  */
 public interface DynamicSecurityResource
 {

--- a/components/nexus-security/src/main/java/org/sonatype/security/realms/tools/LegacyNexusPasswordService.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/realms/tools/LegacyNexusPasswordService.java
@@ -23,8 +23,6 @@ import org.apache.shiro.crypto.hash.format.HexFormat;
 
 /*
  * PasswordService for handling legacy passwords (SHA-1 and MD5)
- * 
- * @since 3.1
  */
 @Singleton
 @Typed(PasswordService.class)
@@ -57,9 +55,7 @@ public class LegacyNexusPasswordService
   }
 
   @Override
-  public String encryptPassword(Object plaintextPassword)
-      throws IllegalArgumentException
-  {
+  public String encryptPassword(Object plaintextPassword) {
     throw new IllegalArgumentException("Not supported");
   }
 
@@ -67,14 +63,7 @@ public class LegacyNexusPasswordService
   public boolean passwordsMatch(Object submittedPlaintext, String encrypted) {
     //Legacy passwords can be hashed with sha-1 or md5, check both
 
-    if (this.sha1PasswordService.passwordsMatch(submittedPlaintext, encrypted)) {
-      return true;
-    }
-
-    if (this.md5PasswordService.passwordsMatch(submittedPlaintext, encrypted)) {
-      return true;
-    }
-
-    return false;
+    return sha1PasswordService.passwordsMatch(submittedPlaintext, encrypted) ||
+        md5PasswordService.passwordsMatch(submittedPlaintext, encrypted);
   }
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/realms/tools/NoSuchRoleMappingException.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/realms/tools/NoSuchRoleMappingException.java
@@ -14,8 +14,6 @@ package org.sonatype.security.realms.tools;
 
 /**
  * Thrown when a Role Mapping cannot be found.
- *
- * @author Brian Demers
  */
 public class NoSuchRoleMappingException
     extends Exception
@@ -36,5 +34,4 @@ public class NoSuchRoleMappingException
   public NoSuchRoleMappingException(Throwable cause) {
     super(cause);
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/realms/tools/SecurityConfigurationModifier.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/realms/tools/SecurityConfigurationModifier.java
@@ -16,7 +16,5 @@ import org.sonatype.security.model.SecurityModelConfiguration;
 
 public interface SecurityConfigurationModifier
 {
-
   boolean apply(SecurityModelConfiguration configuration);
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/realms/tools/StaticSecurityResource.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/realms/tools/StaticSecurityResource.java
@@ -17,8 +17,6 @@ import org.sonatype.security.model.SecurityModelConfiguration;
 /**
  * A StaticSecurityResource all for other components/plugins to contributes users/roles/privileges to the security
  * model.
- *
- * @author Brian Demers
  */
 public interface StaticSecurityResource
 {
@@ -26,5 +24,4 @@ public interface StaticSecurityResource
    * Gets the security configuration.
    */
   SecurityModelConfiguration getConfiguration();
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/realms/validator/DefaultConfigurationIdGenerator.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/realms/validator/DefaultConfigurationIdGenerator.java
@@ -29,5 +29,4 @@ public class DefaultConfigurationIdGenerator
   public String generateId() {
     return Long.toHexString(System.nanoTime() + rand.nextInt(2008));
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/realms/validator/DefaultConfigurationValidator.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/realms/validator/DefaultConfigurationValidator.java
@@ -51,8 +51,8 @@ public class DefaultConfigurationValidator
   private final List<PrivilegeDescriptor> privilegeDescriptors;
 
   @Inject
-  public DefaultConfigurationValidator(List<PrivilegeDescriptor> privilegeDescriptors,
-                                       ConfigurationIdGenerator idGenerator)
+  public DefaultConfigurationValidator(final List<PrivilegeDescriptor> privilegeDescriptors,
+                                       final ConfigurationIdGenerator idGenerator)
   {
     this.privilegeDescriptors = privilegeDescriptors;
     this.idGenerator = idGenerator;

--- a/components/nexus-security/src/main/java/org/sonatype/security/realms/validator/SecurityValidationContext.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/realms/validator/SecurityValidationContext.java
@@ -33,28 +33,28 @@ public class SecurityValidationContext
   private Map<String, String> existingRoleNameMap;
 
   public void addExistingPrivilegeIds() {
-    if (this.existingPrivilegeIds == null) {
-      this.existingPrivilegeIds = new ArrayList<>();
+    if (existingPrivilegeIds == null) {
+      existingPrivilegeIds = new ArrayList<>();
     }
   }
 
   public void addExistingRoleIds() {
-    if (this.existingRoleIds == null) {
-      this.existingRoleIds = new ArrayList<>();
+    if (existingRoleIds == null) {
+      existingRoleIds = new ArrayList<>();
     }
 
-    if (this.roleContainmentMap == null) {
-      this.roleContainmentMap = new HashMap<>();
+    if (roleContainmentMap == null) {
+      roleContainmentMap = new HashMap<>();
     }
 
-    if (this.existingRoleNameMap == null) {
-      this.existingRoleNameMap = new HashMap<>();
+    if (existingRoleNameMap == null) {
+      existingRoleNameMap = new HashMap<>();
     }
   }
 
   public void addExistingUserIds() {
-    if (this.existingUserIds == null) {
-      this.existingUserIds = new ArrayList<>();
+    if (existingUserIds == null) {
+      existingUserIds = new ArrayList<>();
     }
   }
 

--- a/components/nexus-security/src/main/java/org/sonatype/security/realms/validator/SecurityValidationContext.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/realms/validator/SecurityValidationContext.java
@@ -34,27 +34,27 @@ public class SecurityValidationContext
 
   public void addExistingPrivilegeIds() {
     if (this.existingPrivilegeIds == null) {
-      this.existingPrivilegeIds = new ArrayList<String>();
+      this.existingPrivilegeIds = new ArrayList<>();
     }
   }
 
   public void addExistingRoleIds() {
     if (this.existingRoleIds == null) {
-      this.existingRoleIds = new ArrayList<String>();
+      this.existingRoleIds = new ArrayList<>();
     }
 
     if (this.roleContainmentMap == null) {
-      this.roleContainmentMap = new HashMap<String, List<String>>();
+      this.roleContainmentMap = new HashMap<>();
     }
 
     if (this.existingRoleNameMap == null) {
-      this.existingRoleNameMap = new HashMap<String, String>();
+      this.existingRoleNameMap = new HashMap<>();
     }
   }
 
   public void addExistingUserIds() {
     if (this.existingUserIds == null) {
-      this.existingUserIds = new ArrayList<String>();
+      this.existingUserIds = new ArrayList<>();
     }
   }
 
@@ -77,5 +77,4 @@ public class SecurityValidationContext
   public Map<String, String> getExistingRoleNameMap() {
     return existingRoleNameMap;
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/AbstractReadOnlyUserManager.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/AbstractReadOnlyUserManager.java
@@ -15,41 +15,32 @@ package org.sonatype.security.usermanagement;
 import org.sonatype.configuration.validation.InvalidConfigurationException;
 
 /**
- * An abstract UserManager, that just throws exceptions for all the write methods. Any call to theses methods should be
- * checked by the <code>supportsWrite()</code> method, so this should never be called.
+ * An abstract UserManager, that just throws exceptions for all the write methods.
  *
- * @author Brian Demers
+ * Any call to theses methods should be checked by the <code>supportsWrite()</code> method,
+ * so this should never be called.
  */
 public abstract class AbstractReadOnlyUserManager
     extends AbstractUserManager
 {
-
   public boolean supportsWrite() {
     return false;
   }
 
-  public User addUser(User user, String password)
-      throws InvalidConfigurationException
-  {
+  public User addUser(User user, String password) throws InvalidConfigurationException {
     this.throwException();
     return null;
   }
 
-  public void changePassword(String userId, String newPassword)
-      throws UserNotFoundException
-  {
+  public void changePassword(String userId, String newPassword) throws UserNotFoundException {
     this.throwException();
   }
 
-  public void deleteUser(String userId)
-      throws UserNotFoundException
-  {
+  public void deleteUser(String userId) throws UserNotFoundException {
     this.throwException();
   }
 
-  public User updateUser(User user)
-      throws UserNotFoundException, InvalidConfigurationException
-  {
+  public User updateUser(User user) throws UserNotFoundException, InvalidConfigurationException {
     this.throwException();
     return null;
   }
@@ -57,5 +48,4 @@ public abstract class AbstractReadOnlyUserManager
   private void throwException() {
     throw new IllegalStateException("UserManager: '" + this.getSource() + "' does not support write operations.");
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/AbstractUserManager.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/AbstractUserManager.java
@@ -31,7 +31,6 @@ public abstract class AbstractUserManager
     extends ComponentSupport
     implements UserManager
 {
-
   protected Set<User> filterListInMemeory(Set<User> users, UserSearchCriteria criteria) {
     HashSet<User> result = new HashSet<User>();
 
@@ -56,7 +55,9 @@ public abstract class AbstractUserManager
     return matchesCriteria(user.getUserId(), user.getSource(), userRoles, criteria);
   }
 
-  protected boolean matchesCriteria(String userId, String userSource, Collection<String> usersRoles,
+  protected boolean matchesCriteria(String userId,
+                                    String userSource,
+                                    Collection<String> usersRoles,
                                     UserSearchCriteria criteria)
   {
     if (StringUtils.isNotEmpty(criteria.getUserId())
@@ -82,5 +83,4 @@ public abstract class AbstractUserManager
 
     return true;
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/ConfiguredUsersUserManager.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/ConfiguredUsersUserManager.java
@@ -49,8 +49,8 @@ public class ConfiguredUsersUserManager
   public static final String SOURCE = "allConfigured";
 
   @Inject
-  public ConfiguredUsersUserManager(SecuritySystem securitySystem,
-                                    ConfigurationManager configuration)
+  public ConfiguredUsersUserManager(final SecuritySystem securitySystem,
+                                    final ConfigurationManager configuration)
   {
     this.securitySystem = securitySystem;
     this.configuration = configuration;
@@ -125,13 +125,10 @@ public class ConfiguredUsersUserManager
     return this.securitySystem;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see org.sonatype.security.usermanagement.AbstractUserManager#matchesCriteria(java.lang.String, java.lang.String,
-   * java.util.Collection, org.sonatype.security.usermanagement.UserSearchCriteria)
-   */
-  protected boolean matchesCriteria(String userId, String userSource, Collection<String> usersRoles,
-                                    UserSearchCriteria criteria)
+  protected boolean matchesCriteria(final String userId,
+                                    final String userSource,
+                                    final Collection<String> usersRoles,
+                                    final UserSearchCriteria criteria)
   {
     // basically the same as the super, but we don't want to check the source
     if (StringUtils.isNotEmpty(criteria.getUserId())
@@ -157,5 +154,4 @@ public class ConfiguredUsersUserManager
   public String getAuthenticationRealmName() {
     return null;
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/InvalidCredentialsException.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/InvalidCredentialsException.java
@@ -14,8 +14,6 @@ package org.sonatype.security.usermanagement;
 
 /**
  * Thrown if the password isn't correct on reset password.
- *
- * @author cstamas
  */
 public class InvalidCredentialsException
     extends Exception

--- a/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/NoSuchUserManagerException.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/NoSuchUserManagerException.java
@@ -14,13 +14,10 @@ package org.sonatype.security.usermanagement;
 
 /**
  * Thrown when UserManager could not be found.
- *
- * @author Brian Demers
  */
 public class NoSuchUserManagerException
     extends Exception
 {
-
   private static final long serialVersionUID = -2561129270233203244L;
 
   public NoSuchUserManagerException() {
@@ -37,5 +34,4 @@ public class NoSuchUserManagerException
   public NoSuchUserManagerException(Throwable cause) {
     super(cause);
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/RoleIdentifier.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/RoleIdentifier.java
@@ -16,21 +16,16 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Identifies a role and what source it comes from. Its basically a just a complex key for a role.
+ * Identifies a role and what source it comes from.
  *
- * @author Brian Demers
+ * Its basically a just a complex key for a role.
  */
 public class RoleIdentifier
 {
-
   private String source;
 
   private String roleId;
 
-  /**
-   * @param source
-   * @param roleId
-   */
   public RoleIdentifier(String source, String roleId) {
     this.source = source;
     this.roleId = roleId;
@@ -110,5 +105,4 @@ public class RoleIdentifier
   public String toString() {
     return "source: " + this.source + ", roleId: " + this.roleId;
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/RoleMappingUserManager.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/RoleMappingUserManager.java
@@ -17,25 +17,21 @@ import java.util.Set;
 import org.sonatype.configuration.validation.InvalidConfigurationException;
 
 /**
- * Extends the UserManager interface to allow a UserManager to add roles to users from other UserManagers. For example,
- * a User might come from a JDBC UserManager, but has additional roles mapped in Nexus.
+ * Extends the UserManager interface to allow a UserManager to add roles to users from other UserManagers.
  *
- * @author Brian Demers
+ * For example, a User might come from a JDBC UserManager, but has additional roles mapped in Nexus.
  */
 public interface RoleMappingUserManager
     extends UserManager
 {
-
   /**
    * Returns a list of roles for a user.
    */
-  Set<RoleIdentifier> getUsersRoles(String userId, String userSource)
-      throws UserNotFoundException;
+  Set<RoleIdentifier> getUsersRoles(String userId, String userSource) throws UserNotFoundException;
 
   /**
    * Sets a users roles.
    */
   void setUsersRoles(String userId, String userSource, Set<RoleIdentifier> roleIdentifiers)
       throws UserNotFoundException, InvalidConfigurationException;
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/User.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/User.java
@@ -26,7 +26,6 @@ import org.codehaus.plexus.util.StringUtils;
 public class User
     implements Comparable<User>
 {
-
   private String userId;
 
   private String firstName;
@@ -227,5 +226,4 @@ public class User
     }
     return true;
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/UserManager.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/UserManager.java
@@ -19,13 +19,10 @@ import org.sonatype.configuration.validation.InvalidConfigurationException;
 import org.apache.shiro.realm.Realm;
 
 /**
- * A DAO for users comming from a given source.
- *
- * @author Brian Demers
+ * A DAO for users coming from a given source.
  */
 public interface UserManager
 {
-
   /**
    * Get the source string of this UserManager
    */
@@ -54,20 +51,17 @@ public interface UserManager
   /**
    * Add a user.
    */
-  User addUser(User user, String password)
-      throws InvalidConfigurationException;
+  User addUser(User user, String password) throws InvalidConfigurationException;
 
   /**
    * Update a user.
    */
-  User updateUser(User user)
-      throws UserNotFoundException, InvalidConfigurationException;
+  User updateUser(User user) throws UserNotFoundException, InvalidConfigurationException;
 
   /**
    * Delete a user based on id.
    */
-  void deleteUser(String userId)
-      throws UserNotFoundException;
+  void deleteUser(String userId) throws UserNotFoundException;
 
   /**
    * Searches for Subject objects by a criteria.
@@ -77,12 +71,10 @@ public interface UserManager
   /**
    * Get a Subject object by id
    */
-  User getUser(String userId)
-      throws UserNotFoundException;
+  User getUser(String userId) throws UserNotFoundException;
 
   /**
    * Update a users password.
    */
-  void changePassword(String userId, String newPassword)
-      throws UserNotFoundException, InvalidConfigurationException;
+  void changePassword(String userId, String newPassword) throws UserNotFoundException, InvalidConfigurationException;
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/UserManagerImpl.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/UserManagerImpl.java
@@ -55,9 +55,9 @@ public class UserManagerImpl
   private final PasswordService passwordService;
 
   @Inject
-  public UserManagerImpl(ConfigurationManager configuration,
-                         SecuritySystem securitySystem,
-                         PasswordService passwordService)
+  public UserManagerImpl(final ConfigurationManager configuration,
+                         final SecuritySystem securitySystem,
+                         final PasswordService passwordService)
   {
     this.configuration = configuration;
     this.securitySystem = securitySystem;
@@ -148,8 +148,7 @@ public class UserManagerImpl
   public User getUser(String userId)
       throws UserNotFoundException
   {
-    User user = toUser(configuration.readUser(userId));
-    return user;
+    return toUser(configuration.readUser(userId));
   }
 
   public String getSource() {

--- a/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/UserNotFoundException.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/UserNotFoundException.java
@@ -37,5 +37,4 @@ public class UserNotFoundException
   private static String buildMessage(String userId, String message) {
     return "User: '" + userId + "' could not be found. " + message;
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/UserNotFoundTransientException.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/UserNotFoundTransientException.java
@@ -15,8 +15,6 @@ package org.sonatype.security.usermanagement;
 /**
  * Thrown when a user could not be found due to a temporary condition, for example when an LDAP server is unavailable.
  * Repeating the operation may succeed in the future without any intervention by the application.
- *
- * @since sonatype-security 2.8
  */
 public class UserNotFoundTransientException
     extends UserNotFoundException

--- a/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/UserSearchCriteria.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/UserSearchCriteria.java
@@ -16,9 +16,9 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * A UserSearchCriteria defines searchble fields. Null or empty fields will be ignored.
+ * A defines searchable fields.
  *
- * @author Brian Demers
+ * Null or empty fields will be ignored.
  */
 public class UserSearchCriteria
 {
@@ -74,5 +74,4 @@ public class UserSearchCriteria
   public void setEmail(String email) {
     this.email = email;
   }
-
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/UserStatus.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/usermanagement/UserStatus.java
@@ -14,12 +14,8 @@ package org.sonatype.security.usermanagement;
 
 /**
  * Enum of possible User statuses.
- *
- * @author Brian Demers
  */
 public enum UserStatus
 {
-
-  active, locked, disabled;
-
+  active, locked, disabled
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/web/DefaultProtectedPathManager.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/web/DefaultProtectedPathManager.java
@@ -53,11 +53,11 @@ public class DefaultProtectedPathManager
   }
 
   public void addProtectedResource(String pathPattern, String filterExpression) {
-    // Only save the pathPattern and filterExpression in the pseudoChains, does not put real filters into the real
-    // chain.
+    // Only save the pathPattern and filterExpression in the pseudoChains,
+    // does not put real filters into the real chain.
+
     // We can not get the real filters because this method is invoked when the application is starting, when
-    // ShiroSecurityFilter
-    // might not be located.
+    // ShiroSecurityFilter might not be located.
 
     if (this.filterChainManager != null) {
       this.filterChainManager.createChain(pathPattern, filterExpression);

--- a/components/nexus-security/src/main/java/org/sonatype/security/web/FilterChainManagerAware.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/web/FilterChainManagerAware.java
@@ -16,13 +16,8 @@ import org.apache.shiro.web.filter.mgt.FilterChainManager;
 
 /**
  * This class marks the ability to have a FilterChainManager set (if it cannot be injected).
- *
- * @author Brian Demers
  */
 public interface FilterChainManagerAware
 {
-  /**
-   * Sets the PathMatchingFilterChainResolver.
-   */
-  public void setFilterChainManager(FilterChainManager filterChainManager);
+  void setFilterChainManager(FilterChainManager filterChainManager);
 }

--- a/components/nexus-security/src/main/java/org/sonatype/security/web/ProtectedPathManager.java
+++ b/components/nexus-security/src/main/java/org/sonatype/security/web/ProtectedPathManager.java
@@ -14,8 +14,6 @@ package org.sonatype.security.web;
 
 /**
  * This component will manage how paths are dynamically added to the security infrastructure.
- *
- * @author Brian Demers
  */
 public interface ProtectedPathManager
 {
@@ -26,12 +24,5 @@ public interface ProtectedPathManager
    * @param pathPattern      the pattern of the path to protect (i.e. ant pattern)
    * @param filterExpression the configuration used for the filter protecting this pattern.
    */
-  public void addProtectedResource(String pathPattern, String filterExpression);
-
-  // TODO: this may require some shiro changes if we need this in the future.
-  // /**
-  // * Removes a protected path
-  // * @param pathPattern path to be removed
-  // */
-  // public void removeProtectedResource( String pathPattern );
+  void addProtectedResource(String pathPattern, String filterExpression);
 }

--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/security/rest/privileges/PrivilegeTypePlexusResource.java
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/security/rest/privileges/PrivilegeTypePlexusResource.java
@@ -90,18 +90,17 @@ public class PrivilegeTypePlexusResource
   {
     PrivilegeTypeResourceResponse result = new PrivilegeTypeResourceResponse();
 
-    for (PrivilegeDescriptor privDescriptor : privilegeDescriptors) {
+    for (PrivilegeDescriptor descriptor : privilegeDescriptors) {
       PrivilegeTypeResource type = new PrivilegeTypeResource();
-      type.setId(privDescriptor.getType());
-      type.setName(privDescriptor.getName());
+      type.setId(descriptor.getType());
+      type.setName(descriptor.getName());
 
-      for (PrivilegePropertyDescriptor propDescriptor : privDescriptor.getPropertyDescriptors()) {
+      for (PrivilegePropertyDescriptor property : descriptor.getPropertyDescriptors()) {
         PrivilegeTypePropertyResource typeProp = new PrivilegeTypePropertyResource();
-        typeProp.setId(propDescriptor.getId());
-        typeProp.setName(propDescriptor.getName());
-        typeProp.setHelpText(propDescriptor.getHelpText());
-        typeProp.setType(propDescriptor.getType());
-
+        typeProp.setId(property.getId());
+        typeProp.setName(property.getName());
+        typeProp.setHelpText(property.getHelpText());
+        typeProp.setType(property.getType());
         type.addProperty(typeProp);
       }
 


### PR DESCRIPTION
Remove use of injection for privilege properties.

Noticed these were all injected, but couldn't find a good reason why.  These property descriptors are also not used by anything in NX3 ATM (okay one place, in a legacy REST end-point PrivilegeTypePlexusResource thats all).

So to simplify things more, I removed the use of injection and simply returned new instances when a priv is asked for these to retain compatibility with the PrivilegeTypePlexusResource impl.