### PR TITLE
[2.11.x] NEXUS-7650: Update to tika 1.7

### DIFF
--- a/buildsupport/other/pom.xml
+++ b/buildsupport/other/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>org.apache.tika</groupId>
         <artifactId>tika-core</artifactId>
-        <version>1.6</version>
+        <version>1.7</version>
       </dependency>
 
       <dependency>

--- a/components/nexus-core/src/main/resources/org/apache/tika/mime/custom-mimetypes.xml
+++ b/components/nexus-core/src/main/resources/org/apache/tika/mime/custom-mimetypes.xml
@@ -15,14 +15,4 @@
 -->
 <mime-info>
 
-  <!-- NEXUS-7603: Certain JARs detected as application/x-msdownload;format=pe -->
-  <mime-type type="application/zip">
-    <glob pattern="*.zip"/>
-    <magic priority="55">
-      <match value="PK\003\004" type="string" offset="0"/>
-      <match value="PK\005\006" type="string" offset="0"/>
-      <match value="PK\x07\x08" type="string" offset="0"/>
-    </magic>
-  </mime-type>
-
 </mime-info>


### PR DESCRIPTION
And remove the "hack" for MS PE files (see NEXUS-7603)

Ref
https://github.com/sonatype/nexus-oss/pull/978

Issue
https://issues.sonatype.org/browse/NEXUS-7650

CI
http://bamboo.s/browse/NX-OSSF508