### PR TITLE
Fixes the list of dependencies in the Menu controller

### DIFF
--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/controller/Menu.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/controller/Menu.js
@@ -35,10 +35,9 @@ Ext.define('NX.controller.Menu', {
     'feature.Menu',
     'feature.NotFound',
     'feature.NotVisible',
-    'header.DashboardMode',
-    'header.SearchMode',
     'header.BrowseMode',
-    'header.AdminMode'
+    'header.AdminMode',
+    'header.Mode'
   ],
 
   models: [


### PR DESCRIPTION
Nexus won’t start, because it can’t find certain views which have been added/deleted. This PR fixes those entries.