### PR TITLE
NEXUS-7939 - Privilege add validates with incorrect message?

### DIFF
--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/PrivilegeRepositoryTargetXO.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/PrivilegeRepositoryTargetXO.groovy
@@ -32,6 +32,8 @@ class PrivilegeRepositoryTargetXO
   @NotEmpty
   String repositoryTargetId
 
-  @NotEmpty
+  /**
+   * Empty value is interpreted as 'All Repositories'
+   */
   String repositoryId
 }

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/controller/ExtDirect.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/controller/ExtDirect.js
@@ -75,7 +75,11 @@ Ext.define('NX.controller.ExtDirect', {
     if (message) {
       NX.Messages.add({text: message, type: 'warning'});
     }
-    me.logDebug(transaction.action + ':' + transaction.method + " -> " + (message ? 'Failed: ' + message : 'OK'));
+    var logMsg = transaction.action + ':' + transaction.method + " -> " + (message ? 'Failed: ' + message : 'OK');
+    if (result.errors) {
+      logMsg += (' Errors: ' + Ext.encode(result.errors));
+    }
+    me.logDebug(logMsg);
   }
 
 });


### PR DESCRIPTION
- allow empty values for repositoryId, which gets translated to a '*' permission element for repos

https://issues.sonatype.org/browse/NEXUS-7939