### PR TITLE
NEXUS-7978 - User Creation does not transition back to list view after saving

### DIFF
--- a/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/controller/Users.js
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/controller/Users.js
@@ -290,6 +290,7 @@ Ext.define('NX.coreui.controller.Users', {
         callback: cb
       });
     }
+    me.callParent();  // triggers transition between list/detail view
   },
 
   /**


### PR DESCRIPTION
- simply call the parent of our overloaded method to ensure the transition is triggered
- minor modifications to test case to ensure visibility on transition and speed up by entering password before moving on to the following status field

https://issues.sonatype.org/browse/NEXUS-7978