### PR TITLE
NEXUS-8053 Fixes error when switching between features

### DIFF
--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/drilldown/Drilldown.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/drilldown/Drilldown.js
@@ -288,6 +288,9 @@ Ext.define('NX.view.drilldown.Drilldown', {
 
     if (item.el) {
 
+      // Restore the current card
+      items[index].getLayout().setActiveItem(items[index].cardIndex);
+
       // Hack to suppress resize events until the animation is complete
       if (animate) {
         me.ownerCt.suspendEvents(false);
@@ -298,9 +301,6 @@ Ext.define('NX.view.drilldown.Drilldown', {
       } else {
         me.hideAllExceptAndFocus(index);
       }
-
-      // Restore the current card
-      items[index].getLayout().setActiveItem(items[index].cardIndex);
 
       // Slide the requested panel into view
       var left = item.el.getLeft() - me.el.getLeft();

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/drilldown/Drilldown.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/drilldown/Drilldown.js
@@ -294,8 +294,8 @@ Ext.define('NX.view.drilldown.Drilldown', {
         me.hideAllExceptAndFocus(index);
       }
 
-      // Restore the current mode
-      items[index].getLayout().setActiveItem(items[index].currentMode);
+      // Restore the current card
+      items[index].getLayout().setActiveItem(items[index].cardIndex);
 
       // Slide the requested panel into view
       var left = item.el.getLeft() - me.el.getLeft();
@@ -354,7 +354,7 @@ Ext.define('NX.view.drilldown.Drilldown', {
     }
 
     // Show the proper card
-    items[index].setCurrentMode(1);
+    items[index].setCardIndex(1);
 
     me.slidePanels(index, animate);
   },
@@ -371,7 +371,7 @@ Ext.define('NX.view.drilldown.Drilldown', {
       item = me.query('nx-drilldown-item')[index];
 
     // Show the proper card
-    item.setCurrentMode(0);
+    item.setCardIndex(0);
 
     me.slidePanels(index, animate);
   },

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/drilldown/Drilldown.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/drilldown/Drilldown.js
@@ -41,6 +41,11 @@ Ext.define('NX.view.drilldown.Drilldown', {
   // List of actions to use in the detail view
   actions: null,
 
+  // Constants which represent card indexes
+  BROWSE_INDEX: 0,
+  CREATE_INDEX: 1,
+  BLANK_INDEX: 2,
+
   /**
    * @override
    */
@@ -258,7 +263,7 @@ Ext.define('NX.view.drilldown.Drilldown', {
     // Hide everything that’s not the specified panel
     for (var i = 0; i < items.length; ++i) {
       if (i != index) {
-        items[i].getLayout().setActiveItem(2);
+        items[i].getLayout().setActiveItem(me.BLANK_INDEX);
       }
     }
 
@@ -354,7 +359,7 @@ Ext.define('NX.view.drilldown.Drilldown', {
     }
 
     // Show the proper card
-    items[index].setCardIndex(1);
+    items[index].setCardIndex(me.CREATE_INDEX);
 
     me.slidePanels(index, animate);
   },
@@ -371,7 +376,7 @@ Ext.define('NX.view.drilldown.Drilldown', {
       item = me.query('nx-drilldown-item')[index];
 
     // Show the proper card
-    item.setCardIndex(0);
+    item.setCardIndex(me.BROWSE_INDEX);
 
     me.slidePanels(index, animate);
   },

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/drilldown/Drilldown.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/drilldown/Drilldown.js
@@ -41,9 +41,6 @@ Ext.define('NX.view.drilldown.Drilldown', {
   // List of actions to use in the detail view
   actions: null,
 
-  // Saved modes for each drilldown item
-  activeModes: [],
-
   /**
    * @override
    */
@@ -286,11 +283,6 @@ Ext.define('NX.view.drilldown.Drilldown', {
 
     if (item.el) {
 
-      // Restore the saved modes
-      for (var i = 0; i < items.length; ++i) {
-        items[i].getLayout().setActiveItem(me.activeModes[i]);
-      }
-
       // Hack to suppress resize events until the animation is complete
       if (animate) {
         me.ownerCt.suspendEvents(false);
@@ -302,7 +294,10 @@ Ext.define('NX.view.drilldown.Drilldown', {
         me.hideAllExceptAndFocus(index);
       }
 
-      // Show the requested panel
+      // Restore the current mode
+      items[index].getLayout().setActiveItem(items[index].currentMode);
+
+      // Slide the requested panel into view
       var left = item.el.getLeft() - me.el.getLeft();
       me.el.first().move('l', left, animate);
       me.currentIndex = index;
@@ -359,9 +354,7 @@ Ext.define('NX.view.drilldown.Drilldown', {
     }
 
     // Show the proper card
-    items[index].getLayout().setActiveItem(1);
-
-    me.activeModes[index] = items[index].getLayout().getActiveItem();
+    items[index].setCurrentMode(1);
 
     me.slidePanels(index, animate);
   },
@@ -378,9 +371,7 @@ Ext.define('NX.view.drilldown.Drilldown', {
       item = me.query('nx-drilldown-item')[index];
 
     // Show the proper card
-    item.getLayout().setActiveItem(0);
-
-    me.activeModes[index] = item.getLayout().getActiveItem();
+    item.setCurrentMode(0);
 
     me.slidePanels(index, animate);
   },

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/drilldown/Item.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/drilldown/Item.js
@@ -25,7 +25,7 @@ Ext.define('NX.view.drilldown.Item', {
   itemName: 'item',
   itemClass: null,
   itemBookmark: null,
-  currentMode: 0,
+  cardIndex: 0,
 
   layout: 'card',
 
@@ -55,9 +55,9 @@ Ext.define('NX.view.drilldown.Item', {
 
   /**
    * @public
-   * Set the currently selected mode (corresponds with a card index)
+   * Set the currently selected card (will not change the active index by itself)
    */
-  setCurrentMode: function(index) {
-    this.currentMode = index;
+  setCardIndex: function(index) {
+    this.cardIndex = index;
   }
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/drilldown/Item.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/drilldown/Item.js
@@ -25,10 +25,12 @@ Ext.define('NX.view.drilldown.Item', {
   itemName: 'item',
   itemClass: null,
   itemBookmark: null,
+  currentMode: 0,
 
   layout: 'card',
 
   /**
+   * @public
    * Set the name of this drilldown item (appears in the breadcrumb)
    */
   setItemName: function(text) {
@@ -36,6 +38,7 @@ Ext.define('NX.view.drilldown.Item', {
   },
 
   /**
+   * @public
    * Set the icon class of this drilldown item (appears in the breadcrumb)
    */
   setItemClass: function(cls) {
@@ -43,9 +46,18 @@ Ext.define('NX.view.drilldown.Item', {
   },
 
   /**
+   * @public
    * Set the page to load when the breadcrumb segment associated with this drilldown item is clicked
    */
   setItemBookmark: function(bookmark, scope) {
     this.itemBookmark = (bookmark ? { obj: bookmark, scope: scope } : null);
+  },
+
+  /**
+   * @public
+   * Set the currently selected mode (corresponds with a card index)
+   */
+  setCurrentMode: function(index) {
+    this.currentMode = index;
   }
 });


### PR DESCRIPTION
Issue: https://issues.sonatype.org/browse/NEXUS-8053

Got rid of the pesky activeModes array, and put its functionality inside the drilldown.Item views instead.

Related: https://github.com/sonatype/nexus-bundles/pull/127