### PR TITLE
NEXUS-8092: replacement IT support based on Pax-Exam

### DIFF
--- a/buildsupport/goodies/pom.xml
+++ b/buildsupport/goodies/pom.xml
@@ -28,7 +28,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <goodies.version>1.12</goodies.version>
+    <goodies.version>1.13-SNAPSHOT</goodies.version>
   </properties>
 
   <dependencyManagement>

--- a/buildsupport/testing/pom.xml
+++ b/buildsupport/testing/pom.xml
@@ -28,6 +28,7 @@
   <packaging>pom</packaging>
 
   <properties>
+    <pax-exam.version>4.4.0</pax-exam.version>
     <selenium.version>2.38.0</selenium.version>
   </properties>
 
@@ -136,6 +137,28 @@
         <artifactId>junit</artifactId>
         <version>4.11</version>
       </dependency>
+
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam</artifactId>
+        <version>${pax-exam.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-junit4</artifactId>
+        <version>${pax-exam.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-container-karaf</artifactId>
+        <version>${pax-exam.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.url</groupId>
+        <artifactId>pax-url-aether</artifactId>
+        <version>2.3.0</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 

--- a/components/nexus-extender/pom.xml
+++ b/components/nexus-extender/pom.xml
@@ -39,6 +39,16 @@
     </dependency>
 
     <!--
+    Optional support for Pax-Exam if/when deployed alongside Nexus
+    -->
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam</artifactId>
+      <optional>true</optional>
+      <scope>provided</scope>
+    </dependency>
+
+    <!--
     To be removed once all plugins are migrated off the Plexus API
     -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -326,6 +326,12 @@
 
       <dependency>
         <groupId>org.sonatype.nexus</groupId>
+        <artifactId>nexus-pax-exam</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.sonatype.nexus</groupId>
         <artifactId>nexus-it-helper-plugin</artifactId>
         <version>3.0.0-SNAPSHOT</version>
       </dependency>
@@ -625,6 +631,23 @@
               <id>xstream</id>
             </excludedArtifactIds>
           </configuration>
+        </plugin>
+
+        <!--
+        Generate Pax-Exam test-dependency XML.
+        -->
+        <plugin>
+          <groupId>org.apache.servicemix.tooling</groupId>
+          <artifactId>depends-maven-plugin</artifactId>
+          <version>1.2</version>
+          <executions>
+            <execution>
+              <id>generate-depends-file</id>
+              <goals>
+                <goal>generate-depends-file</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
 
         <plugin>
@@ -1194,6 +1217,19 @@
                       </pluginExecutionFilter>
                       <action>
                         <ignore/>
+                      </action>
+                    </pluginExecution>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.apache.servicemix.tooling</groupId>
+                        <artifactId>depends-maven-plugin</artifactId>
+                        <versionRange>[1.2,)</versionRange>
+                        <goals>
+                          <goal>generate-depends-file</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <execute/>
                       </action>
                     </pluginExecution>
                   </pluginExecutions>

--- a/testsupport/nexus-pax-exam/pom.xml
+++ b/testsupport/nexus-pax-exam/pom.xml
@@ -1,0 +1,143 @@
+<!--
+
+    Sonatype Nexus (TM) Open Source Version
+    Copyright (c) 2008-2015 Sonatype, Inc.
+    All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+
+    This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+    which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+
+    Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+    of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+    Eclipse Foundation. All other trademarks are the property of their respective owners.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.sonatype.nexus</groupId>
+    <artifactId>nexus-testsupport</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>nexus-pax-exam</artifactId>
+  <name>${project.groupId}:${project.artifactId}</name>
+  <packaging>bundle</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.compendium</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!--
+    Pax-Exam setup for Karaf-based distributions
+    -->
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-junit4</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-container-karaf</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.url</groupId>
+      <artifactId>pax-url-aether</artifactId>
+    </dependency>
+
+    <!--
+    Test utilities (bundled with nexus-pax-exam)
+    -->
+    <dependency>
+      <groupId>org.sonatype.sisu.goodies</groupId>
+      <artifactId>goodies-testsupport</artifactId>
+    </dependency>
+
+    <!--
+    Support use of core nexus components in test
+    -->
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-core</artifactId>
+    </dependency>
+
+    <!--
+    Run sanity test against OSS base distribution
+    -->
+    <dependency>
+      <groupId>org.sonatype.nexus.assemblies</groupId>
+      <artifactId>nexus-base-template</artifactId>
+      <type>zip</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!--
+      Allow use of 'versionAsInProject' in Pax-Exam configuration
+      -->
+      <plugin>
+        <groupId>org.apache.servicemix.tooling</groupId>
+        <artifactId>depends-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <!--
+            Registers our delayed pax-exam testsuite invoker
+            -->
+            <Bundle-Activator>
+              org.sonatype.nexus.pax.exam.internal.Activator
+            </Bundle-Activator>
+            <!--
+            For convenience embed+export the test utilities
+            -->
+            <Embed-Directory>testlib</Embed-Directory>
+            <_nodefaultversion>true</_nodefaultversion>
+            <Embed-Dependency>
+              goodies-testsupport
+            </Embed-Dependency>
+            <_exportcontents>
+              !*.internal,
+              org.sonatype.*
+            </_exportcontents>
+            <!--
+            These imports are available immediately at boot
+            -->
+            <Import-Package>
+              org.osgi.framework,
+              org.osgi.util.tracker,
+              org.ops4j.pax.exam,
+              org.ops4j.pax.exam.util
+            </Import-Package>
+            <!--
+            Other imports will arrive later as Nexus starts
+            -->
+            <DynamicImport-Package>*</DynamicImport-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/testsupport/nexus-pax-exam/src/main/java/org/sonatype/nexus/pax/exam/AbstractNexusPaxExamIT.java
+++ b/testsupport/nexus-pax-exam/src/main/java/org/sonatype/nexus/pax/exam/AbstractNexusPaxExamIT.java
@@ -1,0 +1,263 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2008-2015 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.pax.exam;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+import javax.inject.Inject;
+
+import org.sonatype.nexus.configuration.ApplicationDirectories;
+import org.sonatype.sisu.litmus.testsupport.junit.TestDataRule;
+import org.sonatype.sisu.litmus.testsupport.junit.TestIndexRule;
+import org.sonatype.sisu.litmus.testsupport.port.PortRegistry;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.MavenUtils;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.options.MavenUrlReference;
+
+import static org.ops4j.pax.exam.CoreOptions.composite;
+import static org.ops4j.pax.exam.CoreOptions.maven;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
+import static org.ops4j.pax.exam.CoreOptions.vmOptions;
+import static org.ops4j.pax.exam.CoreOptions.wrappedBundle;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.doNotModifyLogConfiguration;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFileExtend;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFilePut;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.replaceConfigurationFile;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.useOwnKarafExamSystemConfiguration;
+
+/**
+ * Abstract class for testing Nexus distributions, test classes can inject any component from the distribution. <br>
+ * <br>
+ * Extend this class and choose the base distribution (and any optional plugins) that you want to test against:
+ * 
+ * <pre>
+ * &#064;Configuration
+ * public static Option[] config() {
+ *   return options( //
+ *       nexusDistribution(&quot;org.sonatype.nexus.assemblies&quot;, &quot;nexus-base-template&quot;), //
+ *       nexusPlugin(&quot;org.sonatype.nexus.plugins&quot;, &quot;nexus-yum-repository-plugin&quot;) //
+ *   );
+ * }
+ * </pre>
+ * 
+ * @since 3.0
+ */
+@RunWith(PaxExam.class)
+public abstract class AbstractNexusPaxExamIT
+{
+  private static final String BASEDIR = new File(System.getProperty("basedir", "")).getAbsolutePath();
+
+  public static final String NEXUS_PAX_EXAM_TIMEOUT_KEY = "nexus.pax.exam.timeout";
+
+  public static final int NEXUS_PAX_EXAM_TIMEOUT_DEFAULT = 180000;
+
+  // -------------------------------------------------------------------------
+
+  @Rule
+  public final TestDataRule testData = new TestDataRule(resolveBaseFile("src/test/it-resources"));
+
+  @Rule
+  public final TestIndexRule testIndex = new TestIndexRule(resolveBaseFile("target/it-reports"),
+      resolveBaseFile("target/it-data"));
+
+  protected static final PortRegistry portRegistry = new PortRegistry();
+
+  @Inject
+  protected ApplicationDirectories applicationDirectories;
+
+  // -------------------------------------------------------------------------
+
+  /**
+   * Resolves path against the basedir of the surrounding Maven project.
+   */
+  public static File resolveBaseFile(final String path) {
+    return Paths.get(BASEDIR, path).toFile();
+  }
+
+  /**
+   * Resolves path by searching the it-resources of the Maven project.
+   * 
+   * @see TestDataRule#resolveFile(String)
+   */
+  public File resolveTestFile(final String path) {
+    return testData.resolveFile(path);
+  }
+
+  /**
+   * Resolves path against the Nexus application directory.
+   */
+  public File resolveAppFile(final String path) {
+    return new File(applicationDirectories.getAppDirectory(), path);
+  }
+
+  /**
+   * Resolves path against the Nexus work directory.
+   */
+  public File resolveWorkFile(final String path) {
+    return new File(applicationDirectories.getWorkDirectory(), path);
+  }
+
+  /**
+   * Resolves path against the Nexus temp directory.
+   */
+  public File resolveTempFile(final String path) {
+    return new File(applicationDirectories.getTemporaryDirectory(), path);
+  }
+
+  // -------------------------------------------------------------------------
+
+  /**
+   * @return Pax-Exam option to install a Nexus distribution based on groupId and artifactId
+   */
+  public static Option nexusDistribution(final String groupId, final String artifactId) {
+    return nexusDistribution(maven(groupId, artifactId).versionAsInProject().type("zip"));
+  }
+
+  /**
+   * @return Pax-Exam option to install a Nexus distribution based on groupId, artifactId and classifier
+   */
+  public static Option nexusDistribution(final String groupId, final String artifactId, final String classifier) {
+    return nexusDistribution(maven(groupId, artifactId).classifier(classifier).versionAsInProject().type("zip"));
+  }
+
+  /**
+   * @return Pax-Exam option to install a Nexus distribution from the given framework zip
+   */
+  public static Option nexusDistribution(final MavenUrlReference frameworkZip) {
+
+    // support explicit CI setting as well as automatic detection
+    String localRepo = System.getProperty("maven.repo.local", "");
+    if (localRepo.length() > 0) {
+      // pass on explicit setting to Pax-URL (otherwise it uses wrong value)
+      System.setProperty("org.ops4j.pax.url.mvn.localRepository", localRepo);
+    }
+    else {
+      // use placeholder in karaf config
+      localRepo = "${maven.repo.local}";
+    }
+
+    return composite(
+
+        vmOptions("-Xmx400m", "-XX:MaxPermSize=192m"), // taken from testsuite config
+
+        systemProperty("basedir").value(BASEDIR),
+
+        karafDistributionConfiguration() //
+            .karafVersion("3") //
+            .frameworkUrl(frameworkZip) //
+            .unpackDirectory(resolveBaseFile("target/it-data")) //
+            .useDeployFolder(false), //
+
+        configureConsole().ignoreLocalConsole(), // no need for console
+
+        doNotModifyLogConfiguration(), // don't mess with our logging
+
+        keepRuntimeFolder(), // keep files around in case we need to debug
+
+        editConfigurationFilePut("etc/org.ops4j.pax.url.mvn.cfg", // so pax-exam can fetch its feature
+            "org.ops4j.pax.url.mvn.repositories", "https://repo1.maven.org/maven2@id=central"),
+
+        editConfigurationFilePut("etc/org.ops4j.pax.url.mvn.cfg", // so we can fetch local snapshots
+            "org.ops4j.pax.url.mvn.localRepository", localRepo),
+
+        useOwnKarafExamSystemConfiguration("nexus"),
+
+        nexusPaxExam(), // registers invoker factory that waits for nexus to start before running tests
+
+        // merge hamcrest-library extras with the core hamcrest bundle from Pax
+        wrappedBundle(maven("org.hamcrest", "hamcrest-library").versionAsInProject()) //
+            .instructions("Fragment-Host=org.ops4j.pax.tipi.hamcrest.core"),
+
+        // move work directory inside unpacked distribution
+        editConfigurationFilePut("etc/nexus.properties", //
+            "nexus-work", "${nexus-base}/sonatype-work/nexus"),
+
+        // randomize ports...
+        editConfigurationFilePut("etc/nexus.properties", //
+            "application-port", Integer.toString(portRegistry.reservePort())),
+        editConfigurationFilePut("etc/nexus.properties", //
+            "application-port-ssl", Integer.toString(portRegistry.reservePort())),
+        editConfigurationFilePut("etc/org.apache.karaf.management.cfg", //
+            "rmiRegistryPort", Integer.toString(portRegistry.reservePort())),
+        editConfigurationFilePut("etc/org.apache.karaf.management.cfg", //
+            "rmiServerPort", Integer.toString(portRegistry.reservePort()))
+
+    );
+  }
+
+  /**
+   * @return Pax-Exam option to install a Nexus plugin based on groupId and artifactId
+   */
+  public static Option nexusPlugin(final String groupId, final String artifactId) {
+    return nexusPlugin(maven(groupId, artifactId).versionAsInProject().classifier("features").type("xml"), artifactId);
+  }
+
+  /**
+   * @return Pax-Exam option to install a Nexus plugin from the given feature XML and name
+   */
+  public static Option nexusPlugin(final MavenUrlReference featureXml, final String name) {
+    return composite(features(featureXml), editConfigurationFileExtend("etc/nexus.properties", "nexus-features", name));
+  }
+
+  /**
+   * @return Pax-Exam option to install custom invoker factory that waits for Nexus to start
+   */
+  private static Option nexusPaxExam() {
+    final String version = MavenUtils.getArtifactVersion("org.sonatype.nexus", "nexus-pax-exam");
+    Option result = mavenBundle("org.sonatype.nexus", "nexus-pax-exam", version);
+
+    final File nexusPaxExam = resolveBaseFile("target/nexus-pax-exam-" + version + ".jar");
+    if (nexusPaxExam.isFile()) {
+      // when freshly built bundle of 'nexus-pax-exam' is available, copy it over to distribution's system repository
+      final String systemPath = "system/org/sonatype/nexus/nexus-pax-exam/" + version + "/" + nexusPaxExam.getName();
+      result = composite(replaceConfigurationFile(systemPath, nexusPaxExam), result);
+    }
+
+    return result;
+  }
+
+  // -------------------------------------------------------------------------
+
+  @Before
+  public void startTestRecording() {
+    // Pax-Exam guarantees unique test location, use that with index
+    testIndex.setDirectory(applicationDirectories.getAppDirectory());
+  }
+
+  @After
+  public void stopTestRecording() {
+    testIndex.recordAndCopyLink("karaf.log", resolveAppFile("data/log/karaf.log"));
+    testIndex.recordAndCopyLink("nexus.log", resolveWorkFile("logs/nexus.log"));
+    testIndex.recordAndCopyLink("request.log", resolveWorkFile("logs/request.log"));
+
+    final String surefirePrefix = "target/surefire-reports/" + getClass().getName();
+    testIndex.recordLink("surefire result", resolveBaseFile(surefirePrefix + ".txt"));
+    testIndex.recordLink("surefire output", resolveBaseFile(surefirePrefix + "-output.txt"));
+
+    final String failsafePrefix = "target/failsafe-reports/" + getClass().getName();
+    testIndex.recordLink("failsafe result", resolveBaseFile(failsafePrefix + ".txt"));
+    testIndex.recordLink("failsafe output", resolveBaseFile(failsafePrefix + "-output.txt"));
+  }
+}

--- a/testsupport/nexus-pax-exam/src/main/java/org/sonatype/nexus/pax/exam/internal/Activator.java
+++ b/testsupport/nexus-pax-exam/src/main/java/org/sonatype/nexus/pax/exam/internal/Activator.java
@@ -1,0 +1,39 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2008-2015 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.pax.exam.internal;
+
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.ops4j.pax.exam.ProbeInvokerFactory;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+/**
+ * Registers our delayed {@link ProbeInvokerFactory} which waits for Nexus to start before invoking the testsuite.
+ * 
+ * @since 3.0
+ */
+public class Activator
+    implements BundleActivator
+{
+  public void start(final BundleContext context) throws Exception {
+    final Dictionary<String, ?> properties = new Hashtable<>(Collections.singletonMap("driver", "nexus"));
+    context.registerService(ProbeInvokerFactory.class, new DelayedProbeInvokerFactory(context), properties);
+  }
+
+  public void stop(final BundleContext context) throws Exception {
+    // nothing to do...
+  }
+}

--- a/testsupport/nexus-pax-exam/src/main/java/org/sonatype/nexus/pax/exam/internal/DelayedProbeInvokerFactory.java
+++ b/testsupport/nexus-pax-exam/src/main/java/org/sonatype/nexus/pax/exam/internal/DelayedProbeInvokerFactory.java
@@ -1,0 +1,102 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2008-2015 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.pax.exam.internal;
+
+import org.ops4j.pax.exam.ProbeInvoker;
+import org.ops4j.pax.exam.ProbeInvokerFactory;
+import org.ops4j.pax.exam.TestContainerException;
+import org.ops4j.pax.exam.util.Injector;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Filter;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.util.tracker.ServiceTracker;
+
+import static org.sonatype.nexus.pax.exam.AbstractNexusPaxExamIT.NEXUS_PAX_EXAM_TIMEOUT_DEFAULT;
+import static org.sonatype.nexus.pax.exam.AbstractNexusPaxExamIT.NEXUS_PAX_EXAM_TIMEOUT_KEY;
+
+/**
+ * Delayed {@link ProbeInvokerFactory} that waits for Nexus to start before invoking the testsuite.
+ * 
+ * @since 3.0
+ */
+public class DelayedProbeInvokerFactory
+    implements ProbeInvokerFactory
+{
+  private final long examTimeout;
+
+  private final ServiceTracker<?, ProbeInvokerFactory> probeFactoryTracker;
+
+  private final ServiceTracker<?, Injector> examInjectorTracker;
+
+  public DelayedProbeInvokerFactory(final BundleContext context) {
+    examTimeout = getExamTimeout(context);
+
+    probeFactoryTracker = new ServiceTracker<>(context, junitInvokerFilter(), null);
+    examInjectorTracker = new ServiceTracker<>(context, nexusInjectorFilter(), null);
+
+    probeFactoryTracker.open();
+    examInjectorTracker.open();
+  }
+
+  public ProbeInvoker createProbeInvoker(final Object context, final String expr) {
+    try {
+      // wait for Nexus to start and register its Pax-Exam injector
+      if (examInjectorTracker.waitForService(examTimeout) != null) {
+
+        // use the original Pax-Exam JUnit factory to supply the testsuite invoker
+        return probeFactoryTracker.getService().createProbeInvoker(context, expr);
+      }
+      throw new TestContainerException("Nexus failed to start after " + examTimeout + "ms");
+    }
+    catch (final InterruptedException e) {
+      throw new TestContainerException("Nexus failed to start after " + examTimeout + "ms", e);
+    }
+  }
+
+  /**
+   * @return Timeout to apply when waiting for Nexus to start
+   */
+  private static int getExamTimeout(final BundleContext context) {
+    try {
+      return Integer.parseInt(context.getProperty(NEXUS_PAX_EXAM_TIMEOUT_KEY));
+    }
+    catch (final Exception e) {
+      return NEXUS_PAX_EXAM_TIMEOUT_DEFAULT;
+    }
+  }
+
+  /**
+   * @return Filter that matches the original JUnit Pax-Exam {@link ProbeInvokerFactory}
+   */
+  private static Filter junitInvokerFilter() {
+    try {
+      return FrameworkUtil.createFilter("(&(objectClass=" + ProbeInvokerFactory.class.getName() + ")(driver=junit))");
+    }
+    catch (final InvalidSyntaxException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  /**
+   * @return Filter that matches the nexus-specific Pax-Exam {@link Injector}
+   */
+  private static Filter nexusInjectorFilter() {
+    try {
+      return FrameworkUtil.createFilter("(&(objectClass=" + Injector.class.getName() + ")(name=nexus))");
+    }
+    catch (final InvalidSyntaxException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+}

--- a/testsupport/nexus-pax-exam/src/test/java/org/sonatype/nexus/pax/exam/SanityIT.java
+++ b/testsupport/nexus-pax-exam/src/test/java/org/sonatype/nexus/pax/exam/SanityIT.java
@@ -1,0 +1,48 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2008-2015 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.pax.exam;
+
+import javax.inject.Inject;
+
+import org.sonatype.nexus.SystemState;
+import org.sonatype.nexus.SystemStatus;
+
+import org.junit.Test;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
+/**
+ * Sanity test of the Pax-Exam test infrastructure.
+ * 
+ * @since 3.0
+ */
+public class SanityIT
+    extends AbstractNexusPaxExamIT
+{
+  @Configuration
+  public static Option[] config() {
+    return options(nexusDistribution("org.sonatype.nexus.assemblies", "nexus-base-template"));
+  }
+
+  @Inject
+  private SystemStatus status;
+
+  @Test
+  public void testNexusStarts() {
+    assertThat(SystemState.STARTED, is(status.getState()));
+  }
+}

--- a/testsupport/pom.xml
+++ b/testsupport/pom.xml
@@ -33,6 +33,7 @@
     <module>nexus-testsuite-support</module>
     <module>nexus-it-helper-plugin</module>
     <module>nexus-ldap-testsupport</module>
+    <module>nexus-pax-exam</module>
   </modules>
 
   <dependencyManagement>


### PR DESCRIPTION
[ depends on https://github.com/sonatype/sisu-goodies/pull/34 ]

https://issues.sonatype.org/browse/NEXUS-8092

Replacement IT support using Pax-Exam to start Nexus and wait for it to fully boot up. We can also add and remove features/bundles, and control whether the container is used per-test, per-class, or per-suite.

See https://ops4j1.jira.com/wiki/display/PAXEXAM4/Documentation for more information.  