### PR TITLE
Restores drilldown carets missing due to ca8b83d06

### DIFF
--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/drilldown/Master.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/drilldown/Master.js
@@ -24,6 +24,10 @@ Ext.define('NX.view.drilldown.Master', {
   // Prevent columns from expanding out of bounds
   forceFit: true,
 
+  listeners: {
+    viewready: function(view) { view.refreshDrilldown(view.headerCt) }
+  },
+
   /**
    * @private
    */


### PR DESCRIPTION
When columns are added statically (i.e. as part of the grid definition), `add` is never triggered. The only way to add drilldown carets to these grids is through the `viewready` event, which I’ve reinstituted in this PR.

Before:
![plugins - sonatype nexus 2015-02-02 10-36-01](https://cloud.githubusercontent.com/assets/186715/6006486/b27ea0ee-aac7-11e4-8b73-7d9cf5c7e6c2.png)

After:
![plugins - sonatype nexus 2015-02-02 10-35-24](https://cloud.githubusercontent.com/assets/186715/6006487/b5cc8bd0-aac7-11e4-8862-f112f0dfc77c.png)
