### PR TITLE
NEXUS-8080: Detect when cleanup of cache is needed

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
@@ -1368,6 +1368,8 @@ public abstract class AbstractProxyRepository
 
       Exception lastException = null;
 
+      // flag that is true if we've seen content at all, so cleanup is needed
+      boolean storageCleanupNeeded = false;
       all_urls:
       for (String remoteUrl : remoteUrls) {
         int retryCount = 1;
@@ -1409,6 +1411,9 @@ public abstract class AbstractProxyRepository
 
             AbstractStorageItem remoteItem =
                 getRemoteStorage().retrieveItem(this, request, remoteUrl);
+
+            // we are here, RRS returned us content that we are about to cache
+            storageCleanupNeeded = true;
 
             remoteItem = doCacheItem(remoteItem);
 
@@ -1506,17 +1511,18 @@ public abstract class AbstractProxyRepository
       }
 
       // if we got here, requested item was not retrieved for some reason
+      if (storageCleanupNeeded || request.isRequestRemoteOnly()) {
+        sendContentValidationEvents(request, events, false);
 
-      sendContentValidationEvents(request, events, false);
-
-      try {
-        getLocalStorage().deleteItem(this, request);
-      }
-      catch (ItemNotFoundException e) {
-        // good, we want this item deleted
-      }
-      catch (UnsupportedStorageOperationException e) {
-        log.warn("Unexpected Exception in " + RepositoryStringUtils.getHumanizedNameString(this), e);
+        try {
+          getLocalStorage().deleteItem(this, request);
+        }
+        catch (ItemNotFoundException e) {
+          // good, we want this item deleted
+        }
+        catch (UnsupportedStorageOperationException e) {
+          log.warn("Unexpected Exception in " + RepositoryStringUtils.getHumanizedNameString(this), e);
+        }
       }
 
       if (lastException instanceof StorageException) {
@@ -1526,10 +1532,15 @@ public abstract class AbstractProxyRepository
         throw (ItemNotFoundException) lastException;
       }
 
-      // validation failed, I guess.
-      throw new ItemNotFoundException(reasonFor(request, this,
-          "Path %s fetched from remote storage of %s but failed validation.", request.getRequestPath(),
-          this));
+      if (storageCleanupNeeded) {
+        // validation failed
+        throw new ItemNotFoundException(reasonFor(request, this,
+            "Path %s fetched from remote storage of %s but failed validation.", request.getRequestPath(), this));
+      } else {
+        // request for a directory or something else
+        throw new ItemNotFoundException(reasonFor(request, this,
+            "Path %s could not be fetched from remote storage of %s", request.getRequestPath(), this), lastException);
+      }
     }
     finally {
       itemUidLock.unlock();

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
@@ -1515,7 +1515,10 @@ public abstract class AbstractProxyRepository
         sendContentValidationEvents(request, events, false);
 
         try {
-          getLocalStorage().deleteItem(this, request);
+          final StorageItem item = getLocalStorage().retrieveItem(this, request);
+          if (!(item instanceof StorageCollectionItem)) {
+            getLocalStorage().deleteItem(this, request);
+          }
         }
         catch (ItemNotFoundException e) {
           // good, we want this item deleted

--- a/components/nexus-core/src/test/java/org/sonatype/nexus/proxy/repository/AnAbstractProxyRepositoryRetrieveRemoteItemMethodTest.java
+++ b/components/nexus-core/src/test/java/org/sonatype/nexus/proxy/repository/AnAbstractProxyRepositoryRetrieveRemoteItemMethodTest.java
@@ -1,0 +1,225 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2008-2015 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.repository;
+
+import java.lang.reflect.Field;
+
+import org.sonatype.nexus.mime.MimeSupport;
+import org.sonatype.nexus.proxy.ItemNotFoundException;
+import org.sonatype.nexus.proxy.LocalStorageException;
+import org.sonatype.nexus.proxy.RemoteStorageException;
+import org.sonatype.nexus.proxy.ResourceStoreRequest;
+import org.sonatype.nexus.proxy.StorageException;
+import org.sonatype.nexus.proxy.item.DefaultRepositoryItemUidFactory;
+import org.sonatype.nexus.proxy.item.DefaultStorageCollectionItem;
+import org.sonatype.nexus.proxy.item.DefaultStorageFileItem;
+import org.sonatype.nexus.proxy.item.LinkPersister;
+import org.sonatype.nexus.proxy.item.RepositoryItemUid;
+import org.sonatype.nexus.proxy.item.RepositoryItemUidFactory;
+import org.sonatype.nexus.proxy.item.StorageItem;
+import org.sonatype.nexus.proxy.item.StringContentLocator;
+import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
+import org.sonatype.nexus.proxy.storage.local.LocalRepositoryStorage;
+import org.sonatype.nexus.proxy.storage.local.fs.DefaultFSLocalRepositoryStorage;
+import org.sonatype.nexus.proxy.storage.local.fs.FSPeer;
+import org.sonatype.nexus.proxy.storage.remote.RemoteItemNotFoundException;
+import org.sonatype.nexus.proxy.storage.remote.RemoteRepositoryStorage;
+import org.sonatype.nexus.proxy.wastebasket.Wastebasket;
+import org.sonatype.sisu.goodies.eventbus.EventBus;
+import org.sonatype.sisu.litmus.testsupport.TestSupport;
+import org.sonatype.sisu.locks.LocalResourceLockFactory;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.slf4j.LoggerFactory;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for cleanup detection. See NEXUS-8080.
+ */
+public class AnAbstractProxyRepositoryRetrieveRemoteItemMethodTest
+    extends TestSupport
+{
+  @Mock
+  private RepositoryRegistry repositoryRegistry;
+
+  @Mock
+  private AbstractProxyRepository abstractRepository;
+
+  @Mock
+  private LocalRepositoryStorage localRepositoryStorage;
+
+  @Mock
+  private RemoteRepositoryStorage remoteRepositoryStorage;
+
+  private RepositoryItemUidFactory repositoryItemUidFactory;
+
+  private DefaultStorageFileItem file;
+
+  private DefaultStorageCollectionItem coll;
+
+  @Before
+  public void prepare() throws Exception {
+    // FIXME: HACK Warning, ComponentSupport uses method call on itself to init log, so in mock the log variable is null
+    // FIXME: maybe move this code into own "helper" class a la Spring's ReflectionTestUtils
+    Field logField = AbstractRepository.class.getSuperclass().getSuperclass().getSuperclass().getSuperclass()
+        .getDeclaredField("log");
+    logField.setAccessible(true);
+    logField.set(abstractRepository, LoggerFactory.getLogger(AbstractRepository.class));
+
+    doCallRealMethod().when(abstractRepository).doRetrieveRemoteItem(any(ResourceStoreRequest.class));
+    doReturn("test").when(abstractRepository).getId();
+    doReturn("test").when(abstractRepository).getName();
+    doReturn(repositoryItemUidFactory).when(abstractRepository).getRepositoryItemUidFactory();
+    doReturn(localRepositoryStorage).when(abstractRepository).getLocalStorage();
+    doReturn(remoteRepositoryStorage).when(abstractRepository).getRemoteStorage();
+    doReturn(ImmutableList.of("http://repo1.maven.org/maven2/")).when(abstractRepository)
+        .getRemoteUrls(any(ResourceStoreRequest.class));
+
+    when(repositoryRegistry.getRepository(anyString())).thenReturn(abstractRepository);
+
+    this.repositoryItemUidFactory = new DefaultRepositoryItemUidFactory(mock(EventBus.class), repositoryRegistry,
+        new LocalResourceLockFactory());
+    when(abstractRepository.createUid(anyString())).thenAnswer(new Answer<RepositoryItemUid>()
+    {
+      @Override
+      public RepositoryItemUid answer(final InvocationOnMock invocationOnMock) throws Throwable {
+        return repositoryItemUidFactory.createUid(abstractRepository, (String) invocationOnMock.getArguments()[0]);
+      }
+    });
+
+    this.file = new DefaultStorageFileItem(abstractRepository, new ResourceStoreRequest("/foo"), true, true,
+        new StringContentLocator("irrelevant"));
+    this.coll = new DefaultStorageCollectionItem(abstractRepository, new ResourceStoreRequest("/foo"), true, true);
+  }
+
+  @Test
+  public void fileRequestedFoundRemotelyButFailsCaching() throws Exception {
+    when(remoteRepositoryStorage
+        .retrieveItem(any(ProxyRepository.class), any(ResourceStoreRequest.class), anyString())).thenReturn(
+        file);
+    doThrow(new LocalStorageException("unimportant")).when(localRepositoryStorage).storeItem(any(Repository.class),
+        any(StorageItem.class));
+    when(localRepositoryStorage.retrieveItem(any(Repository.class), any(ResourceStoreRequest.class))).thenReturn(file);
+    try {
+      abstractRepository.doRetrieveRemoteItem(new ResourceStoreRequest("/foo"));
+    } catch (ItemNotFoundException e) {
+      // we expect this
+    }
+    // we need cleanup: file was returned and caching was attempted
+    verify(localRepositoryStorage, times(1)).deleteItem(any(Repository.class), any(ResourceStoreRequest.class));
+  }
+
+  @Test
+  public void directoryRequestedFoundRemotelyButFailsCaching() throws Exception {
+    when(remoteRepositoryStorage.retrieveItem(any(ProxyRepository.class), any(ResourceStoreRequest.class), anyString())).thenReturn(
+        file);
+    doThrow(new LocalStorageException("unimportant")).when(localRepositoryStorage).storeItem(any(Repository.class),
+        any(StorageItem.class));
+    when(localRepositoryStorage.retrieveItem(any(Repository.class), any(ResourceStoreRequest.class))).thenReturn(coll);
+    try {
+      abstractRepository.doRetrieveRemoteItem(new ResourceStoreRequest("/foo"));
+    } catch (ItemNotFoundException e) {
+      // we expect this
+    }
+    // we do not need cleanup: file was returned and caching was attempted but LS has coll
+    verify(localRepositoryStorage, times(0)).deleteItem(any(Repository.class), any(ResourceStoreRequest.class));
+  }
+
+  @Test
+  public void fileRequestedNotFoundRemotely() throws Exception {
+    // remote throws RemoteItemNotFoundEx
+    final RemoteItemNotFoundException rinf = new RemoteItemNotFoundException(new ResourceStoreRequest("/foo"), abstractRepository, "nan", "nan");
+    when(remoteRepositoryStorage.retrieveItem(any(ProxyRepository.class), any(ResourceStoreRequest.class), anyString()))
+        .thenThrow(rinf);
+
+    when(localRepositoryStorage.retrieveItem(any(Repository.class), any(ResourceStoreRequest.class))).thenReturn(file);
+    try {
+      abstractRepository.doRetrieveRemoteItem(new ResourceStoreRequest("/foo"));
+    } catch (RemoteItemNotFoundException e) {
+      // we expect this
+    }
+    // we do not need cleanup: no caching was attempted
+    verify(localRepositoryStorage, times(0)).deleteItem(any(Repository.class), any(ResourceStoreRequest.class));
+  }
+
+  @Test
+  public void directoryRequestedNotFoundRemotely() throws Exception {
+    // remote throws RemoteItemNotFoundEx
+    final RemoteItemNotFoundException rinf = new RemoteItemNotFoundException(new ResourceStoreRequest("/foo"), abstractRepository, "nan", "nan");
+    when(remoteRepositoryStorage.retrieveItem(any(ProxyRepository.class), any(ResourceStoreRequest.class), anyString()))
+        .thenThrow(rinf);
+
+    when(localRepositoryStorage.retrieveItem(any(Repository.class), any(ResourceStoreRequest.class))).thenReturn(coll);
+    try {
+      abstractRepository.doRetrieveRemoteItem(new ResourceStoreRequest("/foo"));
+    } catch (RemoteItemNotFoundException e) {
+      // we expect this
+    }
+    // we do not need cleanup: no caching was attempted
+    verify(localRepositoryStorage, times(0)).deleteItem(any(Repository.class), any(ResourceStoreRequest.class));
+  }
+
+  @Test
+  public void fileRequestedForceRemoteNotFoundRemotely() throws Exception {
+    // remote throws RemoteItemNotFoundEx
+    final RemoteItemNotFoundException rinf = new RemoteItemNotFoundException(new ResourceStoreRequest("/foo"), abstractRepository, "nan", "nan");
+    when(remoteRepositoryStorage.retrieveItem(any(ProxyRepository.class), any(ResourceStoreRequest.class), anyString()))
+        .thenThrow(rinf);
+
+    when(localRepositoryStorage.retrieveItem(any(Repository.class), any(ResourceStoreRequest.class))).thenReturn(file);
+    try {
+      final ResourceStoreRequest resourceStoreRequest = new ResourceStoreRequest("/foo");
+      resourceStoreRequest.setRequestRemoteOnly(true);
+      abstractRepository.doRetrieveRemoteItem(resourceStoreRequest);
+    } catch (RemoteItemNotFoundException e) {
+      // we expect this
+    }
+    // we do need cleanup
+    verify(localRepositoryStorage, times(1)).deleteItem(any(Repository.class), any(ResourceStoreRequest.class));
+  }
+
+  @Test
+  public void directoryRequestedForceRemoteNotFoundRemotely() throws Exception {
+    // remote throws RemoteItemNotFoundEx
+    final RemoteItemNotFoundException rinf = new RemoteItemNotFoundException(new ResourceStoreRequest("/foo"), abstractRepository, "nan", "nan");
+    when(remoteRepositoryStorage.retrieveItem(any(ProxyRepository.class), any(ResourceStoreRequest.class), anyString()))
+        .thenThrow(rinf);
+
+    when(localRepositoryStorage.retrieveItem(any(Repository.class), any(ResourceStoreRequest.class))).thenReturn(coll);
+    try {
+      final ResourceStoreRequest resourceStoreRequest = new ResourceStoreRequest("/foo");
+      resourceStoreRequest.setRequestRemoteOnly(true);
+      abstractRepository.doRetrieveRemoteItem(resourceStoreRequest);
+    } catch (RemoteItemNotFoundException e) {
+      // we expect this
+    }
+    // we do not need cleanup: no caching was attempted, and LS has coll
+    verify(localRepositoryStorage, times(0)).deleteItem(any(Repository.class), any(ResourceStoreRequest.class));
+  }
+
+}


### PR DESCRIPTION
And do not perform it unconditionally, nor report failed
validation when there actually happened no validation as
no content were received from remote.

Issues
https://issues.sonatype.org/browse/NEXUS-8080
https://issues.sonatype.org/browse/NEXUS-8004

CI
http://bamboo.s/browse/NX-OSSF556