### PR TITLE
NEXUS-8083: Fix the connection leak in Browse Remote

### DIFF
--- a/plugins/basic/nexus-rrb-plugin/src/main/java/org/sonatype/nexus/plugins/rrb/MavenRepositoryReader.java
+++ b/plugins/basic/nexus-rrb-plugin/src/main/java/org/sonatype/nexus/plugins/rrb/MavenRepositoryReader.java
@@ -228,15 +228,16 @@ public class MavenRepositoryReader
       final BasicHttpContext httpContext = new BasicHttpContext();
       httpContext.setAttribute(Hc4Provider.HTTP_CTX_KEY_REPOSITORY, proxyRepository);
 
-      HttpResponse response = client.execute(method, httpContext);
+      final HttpResponse response = client.execute(method, httpContext);
 
       int statusCode = response.getStatusLine().getStatusCode();
       logger.debug("Status code: {}", statusCode);
 
-      BufferedReader reader = new BufferedReader(new InputStreamReader(response.getEntity().getContent()));
-      String line;
-      while ((line = reader.readLine()) != null) {
-        buff.append(line).append("\n");
+      try (BufferedReader reader = new BufferedReader(new InputStreamReader(response.getEntity().getContent()))) {
+        String line;
+        while ((line = reader.readLine()) != null) {
+          buff.append(line).append("\n");
+        }
       }
 
       // HACK: Deal with S3 edge-case


### PR DESCRIPTION
Fix the connection leak in RRB. Response entity stream is not closed. Still, in "normal" cases this might go unnoticed as GC and HttpClient will gracefully handle this. But, in case of gzip content encoding, where HttpClient's ResponseContentEncoding interceptor is interfering by swapping out entity wrapped in GzipInputStream this leads to severe leak.

Issue
https://issues.sonatype.org/browse/NEXUS-8083

CI
TBD