### PR TITLE
NEXUS-8144: index files never expire (specs.4.8, latest_specs.4.8 and prereleased_specs.4.8)

### DIFF
--- a/plugins/rubygem/nexus-ruby-plugin/src/main/java/org/sonatype/nexus/plugins/ruby/group/GroupNexusStorage.java
+++ b/plugins/rubygem/nexus-ruby-plugin/src/main/java/org/sonatype/nexus/plugins/ruby/group/GroupNexusStorage.java
@@ -114,9 +114,7 @@ public class GroupNexusStorage
 
     boolean outdated = true; // outdated is true if there are no local-specs
     if (localItem != null) {
-      // using the timestamp from the file since localSpecsItem.getModified() produces something but
-      // not from .nexus/attributes/* file !!!
-      long modified = ((FileContentLocator) localItem.getContentLocator()).getFile().lastModified();
+      long modified = localItem.getModified();
       outdated = false;
       for (StorageItem item : items) {
         outdated = outdated || (item.getModified() > modified);

--- a/plugins/rubygem/nexus-ruby-plugin/src/main/java/org/sonatype/nexus/plugins/ruby/proxy/DefaultProxyRubyRepository.java
+++ b/plugins/rubygem/nexus-ruby-plugin/src/main/java/org/sonatype/nexus/plugins/ruby/proxy/DefaultProxyRubyRepository.java
@@ -116,7 +116,7 @@ public class DefaultProxyRubyRepository
 
   @Override
   protected boolean isOld(StorageItem item) {
-    if (item.getName().contains("specs.4.8")) {
+    if (item.getName().endsWith("specs.4.8")) {
       // whenever there is retrieve call to the ungzipped file it will be forwarded to call for the gzipped file
       return false;
     }

--- a/plugins/rubygem/nexus-ruby-tools/src/main/java/org/sonatype/nexus/ruby/GemRunner.java
+++ b/plugins/rubygem/nexus-ruby-tools/src/main/java/org/sonatype/nexus/ruby/GemRunner.java
@@ -26,8 +26,6 @@ public class GemRunner
 {
   private final String baseUrl;
 
-  private boolean listRemoteFirstRun = true;
-
   public GemRunner(ScriptingContainer ruby, String baseUrl) {
     super(ruby, newScript(ruby));
     this.baseUrl = baseUrl;
@@ -84,6 +82,14 @@ public class GemRunner
     return callMethod("exec", args.toArray(), String.class);
   }
 
+  public String clearCache() {
+    List<String> args = new ArrayList<String>();
+    args.add("sources");
+    args.add("--clear-all");
+
+    return callMethod("exec", args.toArray(), String.class);
+  }
+
   public String list() {
     return list(null);
   }
@@ -95,12 +101,6 @@ public class GemRunner
       args.add("-l");
     }
     else {
-      if (this.listRemoteFirstRun) {
-        this.listRemoteFirstRun = false;
-      }
-      else {
-        System.err.println(">>>>>>>>>>>>> repeated calls here only show the cached first call");
-      }
       args.add("-r");
       setSource(args, repoId);
     }

--- a/testsuite/modern-testsuite/src/test/java/org/sonatype/nexus/testsuite/ruby/GemLifecycleIT.java
+++ b/testsuite/modern-testsuite/src/test/java/org/sonatype/nexus/testsuite/ruby/GemLifecycleIT.java
@@ -48,8 +48,8 @@ public class GemLifecycleIT
     repositories().get(RubyProxyRepository.class, "gemsproxy").withMetadataMaxAge(0).save();
 
     // start with an empty repo
-    String list = gemRunner().list(repoId);
-    assertThat(list, numberOfLines(list), is(0));
+    assertFileDownloadSize(repoId, "latest_specs.4.8.gz", equalTo(24l));
+    assertFileDownloadSize(repoId, "specs.4.8.gz", equalTo(24l));
 
     Thread.sleep(900L); // give chance for "cached" and "remote" file timestamps to drift as Last-Modified header has second resolution
 
@@ -71,11 +71,9 @@ public class GemLifecycleIT
 
     assertGem(repoId, nexusGem.getName());
 
-    // now we have one remote gem
-    gemRunner().clearCache();
-    list = gemRunner().list(repoId);
-
-    assertThat(repoId + "\n" + list, numberOfLines(list), is(1));
+    // now we have one remote gem - i.e. a bigger size of the index files
+    assertFileDownloadSize(repoId, "latest_specs.4.8.gz", equalTo(76l));
+    assertFileDownloadSize(repoId, "specs.4.8.gz", equalTo(76l));
 
     // reinstall the gem from repository
     assertThat(lastLine(gemRunner().install(repoId, "nexus")), equalTo("1 gem installed"));

--- a/testsuite/modern-testsuite/src/test/java/org/sonatype/nexus/testsuite/ruby/RubyITSupport.java
+++ b/testsuite/modern-testsuite/src/test/java/org/sonatype/nexus/testsuite/ruby/RubyITSupport.java
@@ -176,6 +176,7 @@ public abstract class RubyITSupport
     return configuration
         .setLogLevel("org.sonatype.nexus.ruby", "TRACE")
         .setLogLevel("org.sonatype.nexus.plugins.ruby", "TRACE")
+        .setLogLevel("remote.storage.outbound", "DEBUG")
         .addPlugins(
             artifactResolver().resolvePluginFromDependencyManagement(
                 "org.sonatype.nexus.plugins", "nexus-ruby-plugin"

--- a/testsuite/modern-testsuite/src/test/java/org/sonatype/nexus/testsuite/ruby/RubyITSupport.java
+++ b/testsuite/modern-testsuite/src/test/java/org/sonatype/nexus/testsuite/ruby/RubyITSupport.java
@@ -146,6 +146,20 @@ public abstract class RubyITSupport
     return new BundleRunner(ruby());
   }
 
+  protected File assertFileDownloadSize(String repoId, String name, Matcher<Long> matcher) {
+    File download = new File(util.createTempDir(), "null");
+    try {
+      content().download(new Location(repoId, name), download);
+    }
+    catch (Exception e) {
+      // just ignore it and let matcher test
+    }
+    assertThat("exists " + name, download.exists(), is(true));
+    assertThat("size of " + name, download.length(), matcher);
+    download.deleteOnExit();
+    return download;
+  }
+
   protected File assertFileDownload(String repoId, String name, Matcher<Boolean> matcher) {
     File download = new File(util.createTempDir(), "null");
     try {


### PR DESCRIPTION
treat only specs.4.8, latest_specs.4.8 and prereleased_specs.4.8 files differently

these files *.4.8 are anyways not used with client side tools and are virtual, i.e. generated
on the fly by gunzipping the *.4.8.gz files

fixes NEXUS-8144 and allows the *.gz files to expire like other volatile files.

WIP since ITs are missing