### PR TITLE
Make the shared metrics and healthcheck registries available for injection

### DIFF
--- a/components/nexus-extender/src/main/java/org/sonatype/nexus/extender/modules/MetricsRegistryModule.java
+++ b/components/nexus-extender/src/main/java/org/sonatype/nexus/extender/modules/MetricsRegistryModule.java
@@ -15,22 +15,21 @@ package org.sonatype.nexus.extender.modules;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
 import com.codahale.metrics.health.HealthCheckRegistry;
+import com.google.inject.AbstractModule;
 
 /**
- * Provides instrumentation of methods annotated with metrics annotations.
+ * Provides access to the shared metrics and healthcheck registries.
  * 
  * @since 3.0
  */
-public class InstrumentationModule
-    extends com.palominolabs.metrics.guice.InstrumentationModule
+public class MetricsRegistryModule
+    extends AbstractModule
 {
-  @Override
-  protected MetricRegistry createMetricRegistry() {
-    return SharedMetricRegistries.getOrCreate("nexus");
-  }
+  static final HealthCheckRegistry HEALTH_CHECK_REGISTRY = new HealthCheckRegistry();
 
   @Override
-  protected HealthCheckRegistry createHealthCheckRegistry() {
-    return MetricsRegistryModule.HEALTH_CHECK_REGISTRY;
+  protected void configure() {
+    bind(MetricRegistry.class).toInstance(SharedMetricRegistries.getOrCreate("nexus"));
+    bind(HealthCheckRegistry.class).toInstance(HEALTH_CHECK_REGISTRY);
   }
 }

--- a/components/nexus-extender/src/main/java/org/sonatype/nexus/extender/modules/NexusBundleModule.java
+++ b/components/nexus-extender/src/main/java/org/sonatype/nexus/extender/modules/NexusBundleModule.java
@@ -45,6 +45,8 @@ public class NexusBundleModule
 
   private static final SecurityFilterModule securityFilterModule = new SecurityFilterModule();
 
+  private static final MetricsRegistryModule metricsRegistryModule = new MetricsRegistryModule();
+
   private static final InstrumentationModule instrumentationModule = new InstrumentationModule();
 
   private static final ValidationModule validationModule = new ValidationModule();
@@ -77,6 +79,7 @@ public class NexusBundleModule
 
     maybeAddShiroAOP(modules);
     maybeAddSecurityFilter(modules);
+    maybeAddMetricsRegistry(modules);
     maybeAddInstrumentation(modules);
     maybeAddValidation(modules);
     maybeAddWebResources(modules);
@@ -110,6 +113,12 @@ public class NexusBundleModule
   private void maybeAddSecurityFilter(List<Module> modules) {
     if (imports.contains("org.sonatype.nexus.web")) {
       modules.add(securityFilterModule);
+    }
+  }
+
+  private void maybeAddMetricsRegistry(List<Module> modules) {
+    if (imports.contains("com.codahale.metrics")) {
+      modules.add(metricsRegistryModule);
     }
   }
 


### PR DESCRIPTION
The new MetricsRegistryModule is automatically installed for any bundle that
imports the 'com.codahale.metrics' package. Fixes the lack of health checks
registered by the HealthCheckMediator - as no registry was explicitly bound
the mediator was never activated. Instead the HealthCheckServlet ended up
using its own instance of the registry, created via an implicit binding.

http://bamboo.s/browse/NX3-OSSF25-1