### PR TITLE
NEXUS-8077: Fixing OFF log level for Loggers visible as TRACE in the UI

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/log/internal/LogbackLogManager.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/log/internal/LogbackLogManager.java
@@ -564,6 +564,9 @@ public class LogbackLogManager
   private LoggerLevel convert(final Level level) {
     switch (level.toInt()) {
 
+      case Level.OFF_INT:
+        return LoggerLevel.OFF;
+
       case Level.ERROR_INT:
         return LoggerLevel.ERROR;
 


### PR DESCRIPTION
Seems in 2.7 new levels were introduced, but on back-end the translation
of them did not happen correctly.

Issue
https://issues.sonatype.org/browse/NEXUS-8077

CI
http://bamboo.s/browse/NX-OSSF578