### PR TITLE
use jruby-1.7.19

### DIFF
--- a/plugins/rubygem/pom.xml
+++ b/plugins/rubygem/pom.xml
@@ -28,7 +28,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <jruby.version>1.7.18</jruby.version>
+    <jruby.version>1.7.19</jruby.version>
     <jruby-plugins.version>1.0.7</jruby-plugins.version>
   </properties>
 


### PR DESCRIPTION
with jruby-1.7.18 the scripting container which the ruby plugin uses is just
not working on windows.

trivial + review