### PR TITLE
[NEXUS-8195][2.11.x] Deadlock between yum merge metadata task and yum generate metadata task

### DIFF
--- a/plugins/yum/nexus-yum-repository-plugin/src/main/java/org/sonatype/nexus/yum/internal/task/GenerateMetadataTask.java
+++ b/plugins/yum/nexus-yum-repository-plugin/src/main/java/org/sonatype/nexus/yum/internal/task/GenerateMetadataTask.java
@@ -165,27 +165,26 @@ public class GenerateMetadataTask
         LOG.warn("Yum metadata generation failed", e);
         throw new IOException("Yum metadata generation failed", e);
       }
-      // TODO dubious
-      Thread.sleep(100);
-
-      if (repository != null) {
-        final MavenRepository mavenRepository = repository.adaptToFacet(MavenRepository.class);
-        if (mavenRepository != null) {
-          try {
-            routingManager.forceUpdatePrefixFile(mavenRepository);
-          }
-          catch (Exception e) {
-            logger.warn("Could not update Whitelist for repository '{}'", mavenRepository, e);
-          }
-        }
-      }
-
-      regenerateMetadataForGroups();
-      return new YumRepositoryImpl(getRepoDir(), repositoryId, getVersion());
     }
     finally {
       mdUid.getLock().unlock();
     }
+
+    // TODO dubious
+    Thread.sleep(100);
+
+    final MavenRepository mavenRepository = repository.adaptToFacet(MavenRepository.class);
+    if (mavenRepository != null) {
+      try {
+        routingManager.forceUpdatePrefixFile(mavenRepository);
+      }
+      catch (Exception e) {
+        logger.warn("Could not update Whitelist for repository '{}'", mavenRepository, e);
+      }
+    }
+
+    regenerateMetadataForGroups();
+    return new YumRepositoryImpl(getRepoDir(), repositoryId, getVersion());
   }
 
   protected void setDefaults()


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-8195

Move marking of a Yum group repository as dirty outside of block that we keep the UID lock to avoid deadlock between the group that has to be marked and its member repository. 