### PR TITLE
Fixes load order of JS files when in production mode

### DIFF
--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/internal/UiPluginDescriptorImpl.java
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/internal/UiPluginDescriptorImpl.java
@@ -29,7 +29,7 @@ import org.eclipse.sisu.Priority;
  */
 @Named
 @Singleton
-@Priority(Integer.MAX_VALUE - 100) // after nexus-rapture-plugin
+@Priority(Integer.MAX_VALUE - 100) // after nexus-coreui_legacy-plugin
 public class UiPluginDescriptorImpl
   extends UiPluginDescriptorSupport
 {

--- a/plugins/rapture/nexus-coreui_legacy-plugin/src/main/java/org/sonatype/nexus/coreui_legacy/internal/UiPluginDescriptorImpl.java
+++ b/plugins/rapture/nexus-coreui_legacy-plugin/src/main/java/org/sonatype/nexus/coreui_legacy/internal/UiPluginDescriptorImpl.java
@@ -29,7 +29,7 @@ import org.eclipse.sisu.Priority;
  */
 @Named
 @Singleton
-@Priority(Integer.MAX_VALUE - 100) // after nexus-rapture-plugin
+@Priority(Integer.MAX_VALUE - 50) // after nexus-rapture-plugin
 public class UiPluginDescriptorImpl
   extends UiPluginDescriptorSupport
 {


### PR DESCRIPTION
Forces `nexus-coreui_legacy-plugin-prod.js` to load before `nexus-coreui-plugin-prod.js`, which eliminates dependency errors when running the console without the `?debug` flag.