### PR TITLE
Fixes a few problems with ellipses and copyright symbols on IE

### DIFF
--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/app/PluginStrings.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/app/PluginStrings.js
@@ -70,7 +70,7 @@ Ext.define('NX.app.PluginStrings', {
     GLOBAL_HEADER_HELP_SUPPORT_TOOLTIP: 'Sonatype Nexus product support',
 
     // Footer
-    GLOBAL_FOOTER_COPYRIGHT: 'Copyright © 2008-2015, Sonatype Inc. All rights reserved.',
+    GLOBAL_FOOTER_COPYRIGHT: 'Copyright &copy; 2008-2015, Sonatype Inc. All rights reserved.',
 
     // Sign in
     GLOBAL_SIGN_IN_TITLE: 'Sign In',

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/drilldown/Master.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/drilldown/Master.js
@@ -53,7 +53,7 @@ Ext.define('NX.view.drilldown.Master', {
     // Add a drilldown affordance to the end of the list
     ct.add(
       {
-        width: 24,
+        width: 28,
         hideable: false,
         sortable: false,
         menuDisabled: true,


### PR DESCRIPTION
Issues:
https://issues.sonatype.org/browse/NEXUS-8110
https://issues.sonatype.org/browse/NEXUS-8182

@joedragons doesn’t see the copyright symbol or ellipses in his copy of Windows/IE. I wonder if the problem is that I use literals in code, rather than the HTML shorthand… `©` instead of `&copy;`, for example.

This PR tests that theory on the copyright symbol in the footer.

![welcome - sonatype nexus 2015-03-06 11-24-15](https://cloud.githubusercontent.com/assets/186715/6532168/613eb60c-c3f3-11e4-9d43-6dc74b6f276d.png)