### PR TITLE
[NEXUS-7654] Use NFC instead of attributes for attribute checksum "not-found"

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
@@ -189,6 +189,11 @@ public class ChecksumContentValidator
 
       // If attributes does not contain checksum hash, then attempt to fetch and store it
       String hash = attributes.get(attrname);
+
+      // FIXME: This is unable to detect if the checksum in the proxy is _old_ and needs to be checked in the remote again
+      // FIXME: If we add a check here, then we also have to cope with the proxy-cache invalidation token which is an
+      // FIXME: optimization to expire entire trees, but if not handled here specifically it will cause more problems
+
       if (hash == null || checksumRequest.isRequestAsExpired()) {
         try {
           StorageFileItem checksumItem =

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
@@ -134,7 +134,7 @@ public class ChecksumContentValidator
         response = doRetrieveMD5(proxy, request, item);
       }
       catch (ItemNotFoundException e1) {
-        log.debug("Item checksums (SHA1, MD5) remotely unavailable " + uid.toString());
+        log.debug("Item checksums (SHA1, MD5) remotely unavailable: {}", uid);
       }
       finally {
         request.popRequestPath();

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
@@ -197,7 +197,7 @@ public class ChecksumContentValidator
           doStoreChechsumItem(proxy, artifact, attrname, checksumItem);
         }
         catch (ItemNotFoundException | RemoteStorageException e) {
-          // add checksum path to NFC
+          // could not fetch checksum, add request to NFC
           proxy.addToNotFoundCache(checksumRequest);
         }
       }

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
@@ -193,8 +193,8 @@ public class ChecksumContentValidator
           StorageFileItem checksumItem =
               (StorageFileItem) proxy.getRemoteStorage().retrieveItem(proxy, checksumRequest, proxy.getRemoteUrl());
 
-          // fetched checksum, now store it in attributes
-          doStoreChechsumItem(proxy, artifact, attrname, checksumItem);
+          // fetched checksum item, extract hash and store it in attributes
+          hash = doStoreChechsumItem(proxy, artifact, attrname, checksumItem);
         }
         catch (ItemNotFoundException | RemoteStorageException e) {
           // could not fetch checksum, add request to NFC
@@ -239,10 +239,10 @@ public class ChecksumContentValidator
     }
   }
 
-  private static void doStoreChechsumItem(final ProxyRepository proxy,
-                                          final StorageItem artifact,
-                                          final String attrname,
-                                          final StorageFileItem checksumItem)
+  private static String doStoreChechsumItem(final ProxyRepository proxy,
+                                            final StorageItem artifact,
+                                            final String attrname,
+                                            final StorageFileItem checksumItem)
       throws IOException
   {
     // Load checksum hash to store in attributes from item
@@ -268,6 +268,8 @@ public class ChecksumContentValidator
     finally {
       itemUid.getLock().unlock();
     }
+
+    return hash;
   }
 
   public static DefaultStorageFileItem newHashItem(ProxyRepository proxy, ResourceStoreRequest request,

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
@@ -77,11 +77,8 @@ public class ChecksumContentValidator
         String path = remoteHash.getHashItem().getRepositoryItemUid().getPath();
         proxy.getLocalStorage().deleteItem(proxy, new ResourceStoreRequest(path, true));
       }
-      catch (ItemNotFoundException e) {
+      catch (ItemNotFoundException | UnsupportedStorageOperationException e) {
         // ignore
-      }
-      catch (UnsupportedStorageOperationException e) {
-        // huh?
       }
     }
   }

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
@@ -184,10 +184,8 @@ public class ChecksumContentValidator
         throw new LocalStorageException("Null item repository attributes");
       }
 
-      // Check if checksum path is in NFC
-      if (proxy.getNotFoundCache().contains(checksumRequest.getRequestPath()) && !checksumRequest.isRequestAsExpired()) {
-        throw new ItemNotFoundException(checksumRequest);
-      }
+      // check/expire checksum item NFC or throw not-found exception
+      proxy.maintainNotFoundCache(checksumRequest);
 
       // If attributes does not contain checksum hash, then attempt to fetch and store it
       String hash = attributes.get(attrname);
@@ -198,6 +196,9 @@ public class ChecksumContentValidator
 
           // fetched checksum item, extract hash and store it in attributes
           hash = doStoreChechsumItem(proxy, artifact, attrname, checksumItem);
+
+          // evict checksum item NFC now that it is found
+          proxy.removeFromNotFoundCache(checksumRequest);
         }
         catch (ItemNotFoundException | RemoteStorageException e) {
           // could not fetch checksum, add request to NFC

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
@@ -47,7 +47,6 @@ public class ChecksumContentValidator
     extends AbstractChecksumContentValidator
     implements ItemContentValidator
 {
-
   public static final String ID = "ChecksumContentValidator";
 
   public static final String SUFFIX_MD5 = ".md5";
@@ -55,15 +54,16 @@ public class ChecksumContentValidator
   public static final String SUFFIX_SHA1 = ".sha1";
 
   /**
-   * Key of item attribute that holds contents of remote .sha1 file. The attribute is not present if the item does
-   * not
-   * have corresponding .sha1 file
+   * Key of item attribute that holds contents of remote .sha1 file.
+   *
+   * The attribute is not present if the item does not have corresponding .sha1 file.
    */
   public static final String ATTR_REMOTE_SHA1 = "remote.sha1";
 
   /**
-   * Key of item attribute that holds contents of remote .md5 file. The attribute is not present if the item does not
-   * have corresponding .md5 file
+   * Key of item attribute that holds contents of remote .md5 file.
+   *
+   * The attribute is not present if the item does not have corresponding .md5 file.
    */
   public static final String ATTR_REMOTE_MD5 = "remote.md5";
 
@@ -239,6 +239,15 @@ public class ChecksumContentValidator
     }
   }
 
+  /**
+   * Store checksum information for given artifact in attributes.
+   *
+   * @param proxy         Proxy repository where artifact lives.
+   * @param artifact      Artifact storage-item.
+   * @param attrname      Checksum attribute name.
+   * @param checksumItem  Checksum storage-item.
+   * @return              Checksum hash, read from checksum storage-item.
+   */
   private static String doStoreChechsumItem(final ProxyRepository proxy,
                                             final StorageItem artifact,
                                             final String attrname,

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
@@ -195,7 +195,7 @@ public class ChecksumContentValidator
               (StorageFileItem) proxy.getRemoteStorage().retrieveItem(proxy, checksumRequest, proxy.getRemoteUrl());
 
           // fetched checksum item, extract hash and store it in attributes
-          hash = doStoreChechsumItem(proxy, artifact, attrname, checksumItem);
+          hash = doStoreChecksumItem(proxy, artifact, attrname, checksumItem);
 
           // evict checksum item NFC now that it is found
           proxy.removeFromNotFoundCache(checksumRequest);
@@ -225,7 +225,7 @@ public class ChecksumContentValidator
       throws LocalStorageException
   {
     try {
-      doStoreChechsumItem(proxy, artifact, ATTR_REMOTE_SHA1, checksumItem);
+      doStoreChecksumItem(proxy, artifact, ATTR_REMOTE_SHA1, checksumItem);
     }
     catch (IOException e) {
       throw new LocalStorageException(e);
@@ -236,7 +236,7 @@ public class ChecksumContentValidator
       throws LocalStorageException
   {
     try {
-      doStoreChechsumItem(proxy, artifact, ATTR_REMOTE_MD5, checksumItem);
+      doStoreChecksumItem(proxy, artifact, ATTR_REMOTE_MD5, checksumItem);
     }
     catch (IOException e) {
       throw new LocalStorageException(e);
@@ -252,7 +252,7 @@ public class ChecksumContentValidator
    * @param checksumItem  Checksum storage-item.
    * @return              Checksum hash, read from checksum storage-item.
    */
-  private static String doStoreChechsumItem(final ProxyRepository proxy,
+  private static String doStoreChecksumItem(final ProxyRepository proxy,
                                             final StorageItem artifact,
                                             final String attrname,
                                             final StorageFileItem checksumItem)

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
@@ -165,6 +165,12 @@ public class ChecksumContentValidator
     return doRetrieveChecksumItem(proxy, hashRequest, artifact, DIGEST_MD5_KEY, ATTR_REMOTE_MD5);
   }
 
+  /**
+   * Attempt to retrieve the checksum for the given artifact storage-item.
+   *
+   * If the checksum is cached in item attributes, then it is returned.  Otherwise attempt to fetch
+   * the remote checksum from upstream and cache in attributes.
+   */
   private static RemoteHashResponse doRetrieveChecksumItem(ProxyRepository proxy,
                                                            ResourceStoreRequest checksumRequest,
                                                            StorageItem artifact,

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
@@ -1097,19 +1097,23 @@ public abstract class AbstractRepository
     // NEXUS-6177: skip NFC if request is "asExpired"
     // On outcome, if remotely found, will invalidate NFC by caching it
     if (isNotFoundCacheActive() && !request.isRequestAsExpired()) {
-      if (getNotFoundCache().contains(request.getRequestPath())) {
-        if (getNotFoundCache().isExpired(request.getRequestPath())) {
-          log.debug("Removing expired path from NFC: {}", request.getRequestPath());
-          getNotFoundCache().removeWithParents(request.getRequestPath());
+      final PathCache nfc = getNotFoundCache();
+      final String requestPath = request.getRequestPath();
+
+      if (nfc.contains(requestPath)) {
+        if (nfc.isExpired(requestPath)) {
+          log.debug("Removing expired path from NFC: {}", requestPath);
+          nfc.removeWithParents(requestPath);
         }
         else {
-          StringBuilder sb = new StringBuilder("The path ").append(request.getRequestPath()).append(" is cached ");
-          long expirationTime = getNotFoundCache().getExpirationTime(request.getRequestPath());
-          if (expirationTime > 0) {
-            sb.append("until ").append(new DateTime(expirationTime)).append(" ");
-          }
-          final String message = sb.append("as not found in repository ").append(this).toString();
+          StringBuilder buff = new StringBuilder("The path ").append(requestPath).append(" is cached ");
 
+          long expirationTime = nfc.getExpirationTime(requestPath);
+          if (expirationTime > 0) {
+            buff.append("until ").append(new DateTime(expirationTime)).append(" ");
+          }
+
+          String message = buff.append("as not found in repository ").append(this).toString();
           log.debug(message);
           throw new ItemNotFoundException(reasonFor(request, this, message));
         }

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
@@ -1099,11 +1099,8 @@ public abstract class AbstractRepository
     if (isNotFoundCacheActive() && !request.isRequestAsExpired()) {
       if (getNotFoundCache().contains(request.getRequestPath())) {
         if (getNotFoundCache().isExpired(request.getRequestPath())) {
-          if (log.isDebugEnabled()) {
-            log.debug("The path " + request.getRequestPath() + " is in NFC but expired.");
-          }
-
-          removeFromNotFoundCache(request);
+          log.debug("Removing expired path from NFC: {}", request.getRequestPath());
+          getNotFoundCache().removeWithParents(request.getRequestPath());
         }
         else {
           StringBuilder sb = new StringBuilder("The path ").append(request.getRequestPath()).append(" is cached ");
@@ -1137,10 +1134,7 @@ public abstract class AbstractRepository
   @Override
   public void removeFromNotFoundCache(ResourceStoreRequest request) {
     if (isNotFoundCacheActive()) {
-      if (log.isDebugEnabled()) {
-        log.debug("Removing path " + request.getRequestPath() + " from NFC.");
-      }
-
+      log.debug("Removing path from NFC: {}", request.getRequestPath());
       getNotFoundCache().removeWithParents(request.getRequestPath());
     }
   }

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
@@ -31,7 +31,6 @@ import org.sonatype.nexus.proxy.AccessDeniedException;
 import org.sonatype.nexus.proxy.IllegalOperationException;
 import org.sonatype.nexus.proxy.IllegalRequestException;
 import org.sonatype.nexus.proxy.ItemNotFoundException;
-import org.sonatype.nexus.proxy.ItemNotFoundException.ItemNotFoundInRepositoryReason;
 import org.sonatype.nexus.proxy.LocalStorageException;
 import org.sonatype.nexus.proxy.RepositoryNotAvailableException;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
@@ -1127,10 +1126,7 @@ public abstract class AbstractRepository
   @Override
   public void addToNotFoundCache(ResourceStoreRequest request) {
     if (isNotFoundCacheActive()) {
-      if (log.isDebugEnabled()) {
-        log.debug("Adding path " + request.getRequestPath() + " to NFC.");
-      }
-
+      log.debug("Adding path to NFC: {}", request.getRequestPath());
       getNotFoundCache().put(request.getRequestPath(), Boolean.TRUE, getNotFoundCacheTimeToLive() * 60);
     }
   }


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-7654

Attempts to use the NFC to determine "not-found"-ness of a checksum request, instead of attributes.