### PR TITLE
[NEXUS-8226] limit reconciliation to attributes modified since a given date

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/tasks/descriptors/ReconcileChecksumsTaskDescriptor.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/tasks/descriptors/ReconcileChecksumsTaskDescriptor.java
@@ -19,6 +19,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.sonatype.nexus.formfields.FormField;
+import org.sonatype.nexus.formfields.NumberTextFormField;
 import org.sonatype.nexus.formfields.RepoOrGroupComboFormField;
 import org.sonatype.nexus.formfields.StringTextFormField;
 
@@ -36,6 +37,10 @@ public class ReconcileChecksumsTaskDescriptor
 
   public static final String RESOURCE_STORE_PATH_FIELD_ID = "resourceStorePath";
 
+  public static final String MODIFIED_SINCE_DATE_ID = "modifiedSinceDate";
+
+  public static final String WALKING_LIMIT_TPS_FIELD_ID = "walkingLimitTps";
+
   private final RepoOrGroupComboFormField repoField = new RepoOrGroupComboFormField(REPO_OR_GROUP_FIELD_ID,
       FormField.MANDATORY);
 
@@ -43,6 +48,16 @@ public class ReconcileChecksumsTaskDescriptor
       "Repository path",
       "Enter a repository path to run the task in recursively (ie. \"/\" for root or \"/org/apache\").",
       FormField.OPTIONAL);
+
+  private final StringTextFormField modifiedSinceDateField = new StringTextFormField(MODIFIED_SINCE_DATE_ID,
+      "Modified since (yyyy-MM-dd)",
+      "Enter a date to limit reconciliation to those checksum attributes modified since the given date.",
+      FormField.OPTIONAL).withInitialValue("2015-01-01");
+
+  private final NumberTextFormField walkingLimitTpsField = new NumberTextFormField(WALKING_LIMIT_TPS_FIELD_ID,
+      "Walking limit (tps)",
+      "Set the walking limit to reduce the overhead of this task at the expense of it taking more time.",
+      FormField.OPTIONAL).withInitialValue(100);
 
   public String getId() {
     return ID;
@@ -57,8 +72,9 @@ public class ReconcileChecksumsTaskDescriptor
     final List<FormField> fields = new ArrayList<FormField>();
 
     fields.add(repoField);
-
     fields.add(resourceStorePathField);
+    fields.add(modifiedSinceDateField);
+    fields.add(walkingLimitTpsField);
 
     return fields;
   }


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-8226

http://bamboo.s/browse/NX-OSSF635-2 :white_check_mark: 

also resets any cached remote checksums if they're also affected