### PR TITLE
[NEXUS-8249] Fix duplicate search results

### DIFF
--- a/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/storage/StorageFacetImpl.java
+++ b/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/storage/StorageFacetImpl.java
@@ -249,9 +249,8 @@ public class StorageFacetImpl
       super(db);
       database.registerHook(hook = new ODocumentHookAbstract()
       {
-        @Override
-        public String[] getIncludeClasses() {
-          return new String[]{V_COMPONENT};
+        {
+          setIncludeClasses(V_COMPONENT);
         }
 
         @Override
@@ -262,7 +261,9 @@ public class StorageFacetImpl
         @Override
         public void onRecordAfterCreate(final ODocument doc) {
           // TODO should indexing failures affect storage? (catch and log?)
-          searchFacet.put(componentMetadataFactory.from(new OrientVertex(IndexHookedGraphTx.this, doc)));
+          if (doc.getIdentity().isPersistent()) {
+            searchFacet.put(componentMetadataFactory.from(new OrientVertex(IndexHookedGraphTx.this, doc)));
+          }
         }
 
         @Override


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-8249

The orient hook was called multiple times, before and after a proper RID was set on the component.
The fix will only index the component after the proper RID is set on record.
It also fixes a bug related to only acting on component records.