### PR TITLE
NEXUS-8236 - Store NuGet package feed metadata at the asset level

### DIFF
--- a/plugins/basic/nexus-repository-nuget/src/main/java/com/sonatype/nexus/repository/nuget/internal/NugetGalleryFacetImpl.java
+++ b/plugins/basic/nexus-repository-nuget/src/main/java/com/sonatype/nexus/repository/nuget/internal/NugetGalleryFacetImpl.java
@@ -210,7 +210,7 @@ public class NugetGalleryFacetImpl
     try (StorageTx tx = openStorageTx()) {
       final Bucket bucket = tx.getBucket();
       Component component = findComponent(tx, id, version);
-      checkState(component != null && component.firstAsset() != null, "Component metadata does not exist yet");
+      checkState(component != null && !component.assets().isEmpty(), "Component metadata does not exist yet");
       createOrUpdateAssetAndContents(tx, bucket, component, content, null);
       tx.commit();
     }
@@ -480,7 +480,7 @@ public class NugetGalleryFacetImpl
                                                final Map<String, String> data)
   {
     Asset asset = createOrUpdateAsset(storageTx, bucket, component, data);
-    
+
     final ImmutableMap<String, String> headers = ImmutableMap
         .of(BlobStore.BLOB_NAME_HEADER, blobName(component), BlobStore.CREATED_BY_HEADER, "unknown");
     storageTx.setBlob(in, headers, asset, Arrays.asList(HashAlgorithm.SHA512), "application/zip");
@@ -505,7 +505,7 @@ public class NugetGalleryFacetImpl
     final String version = checkVersion(data.get(VERSION));
 
     final Component component = findOrCreateComponent(storageTx, bucket, id, version);
-    
+
     NestedAttributesMap nugetAttr = component.formatAttributes();
     nugetAttr.set(P_ID, data.get(ID));
     nugetAttr.set(P_PACKAGE_HASH, data.get(PACKAGE_HASH));

--- a/plugins/basic/nexus-repository-nuget/src/main/java/com/sonatype/nexus/repository/nuget/internal/NugetGalleryFacetImpl.java
+++ b/plugins/basic/nexus-repository-nuget/src/main/java/com/sonatype/nexus/repository/nuget/internal/NugetGalleryFacetImpl.java
@@ -173,14 +173,13 @@ public class NugetGalleryFacetImpl
         ));
       }
 
-      final Iterable<Component> components = storageTx.findComponents(componentQuery.getWhere(),
+      final Iterable<Asset> assets = storageTx.findAssets(componentQuery.getWhere(),
           componentQuery.getParameters(), getRepositories(), componentQuery.getQuerySuffix());
 
       int n = 0;
-      for (Component component : components) {
+      for (Asset asset : assets) {
         n++;
-
-        final NestedAttributesMap nugetAttributes = component.formatAttributes();
+        final NestedAttributesMap nugetAttributes = asset.formatAttributes();
         final Map<String, ?> data = toData(nugetAttributes, extraTemplateVars(base, operation));
 
         xml.append(interpolateTemplate(ODataTemplates.NUGET_ENTRY, data));
@@ -200,7 +199,7 @@ public class NugetGalleryFacetImpl
   @Override
   public void putMetadata(final Map<String, String> metadata) {
     try (StorageTx tx = openStorageTx()) {
-      final Component component = createOrUpdateComponent(tx, tx.getBucket(), metadata);
+      createOrUpdatePackage(tx, metadata);
       maintainAggregateInfo(tx, metadata.get(ID));
       tx.commit();
     }
@@ -211,8 +210,8 @@ public class NugetGalleryFacetImpl
     try (StorageTx tx = openStorageTx()) {
       final Bucket bucket = tx.getBucket();
       Component component = findComponent(tx, id, version);
-      checkState(component != null, "Component metadata does not exist yet");
-      createOrUpdateAsset(tx, bucket, component, content);
+      checkState(component != null && component.firstAsset() != null, "Component metadata does not exist yet");
+      createOrUpdateAssetAndContents(tx, bucket, component, content, null);
       tx.commit();
     }
   }
@@ -281,7 +280,7 @@ public class NugetGalleryFacetImpl
       recordMetadata.put(PUBLISHED, creationTime);
       Component component;
       try (InputStream in = tempStream.get()) {
-        component = createOrUpdatePackage(storageTx, recordMetadata, in);
+        component = createOrUpdatePackageAndContents(storageTx, recordMetadata, in);
       }
 
       String id = recordMetadata.get(ID);
@@ -360,13 +359,65 @@ public class NugetGalleryFacetImpl
   }
 
   @VisibleForTesting
-  Component createOrUpdatePackage(final StorageTx storageTx, final Map<String, String> recordMetadata,
-                                     final InputStream packageStream)
+  Component createOrUpdatePackageAndContents(final StorageTx storageTx, final Map<String, String> recordMetadata,
+                                             final InputStream packageStream)
   {
     final Bucket bucket = storageTx.getBucket();
     final Component component = createOrUpdateComponent(storageTx, bucket, recordMetadata);
-    createOrUpdateAsset(storageTx, bucket, component, packageStream);
+    createOrUpdateAssetAndContents(storageTx, bucket, component, packageStream, recordMetadata);
     return component;
+  }
+
+  @VisibleForTesting
+  Component createOrUpdatePackage(final StorageTx storageTx, final Map<String, String> recordMetadata)
+  {
+    final Bucket bucket = storageTx.getBucket();
+    final Component component = createOrUpdateComponent(storageTx, bucket, recordMetadata);
+    createOrUpdateAsset(storageTx, bucket, component, recordMetadata);
+    return component;
+  }
+
+  private Asset createOrUpdateAsset(final StorageTx storageTx, final Bucket bucket, final Component component,
+                                   final Map<String, String> data) {
+    Asset asset = null;
+
+    final List<Asset> assets = component.assets();
+    if (assets.isEmpty()) {
+      asset = storageTx.createAsset(bucket, component);
+    }
+    else {
+      asset = assets.get(0);
+    }
+
+    if (data != null) {
+      final NestedAttributesMap nugetAttr = asset.formatAttributes();
+
+      setDerivedAttributes(data, nugetAttr,  !component.isNew());
+
+      nugetAttr.set(P_AUTHORS, data.get(AUTHORS));
+      nugetAttr.set(P_COPYRIGHT, data.get(COPYRIGHT));
+      nugetAttr.set(P_DEPENDENCIES, data.get(DEPENDENCIES));
+      nugetAttr.set(P_DESCRIPTION, data.get(DESCRIPTION));
+      nugetAttr.set(P_GALLERY_DETAILS_URL, data.get(GALLERY_DETAILS_URL));
+      nugetAttr.set(P_ICON_URL, data.get(ICON_URL));
+      nugetAttr.set(P_ID, data.get(ID));
+      nugetAttr.set(P_IS_PRERELEASE, Boolean.parseBoolean(data.get(IS_PRERELEASE)));
+      nugetAttr.set(P_LANGUAGE, data.get(LANGUAGE));
+      nugetAttr.set(P_LICENSE_URL, data.get(LICENSE_URL));
+      nugetAttr.set(P_LOCATION, data.get(LOCATION));
+      nugetAttr.set(P_PACKAGE_HASH, data.get(PACKAGE_HASH));
+      nugetAttr.set(P_PACKAGE_HASH_ALGORITHM, data.get(PACKAGE_HASH_ALGORITHM));
+      nugetAttr.set(P_PACKAGE_SIZE, Integer.parseInt(data.get(PACKAGE_SIZE)));
+      nugetAttr.set(P_PROJECT_URL, data.get(PROJECT_URL));
+      nugetAttr.set(P_RELEASE_NOTES, data.get(RELEASE_NOTES));
+      nugetAttr.set(P_REPORT_ABUSE_URL, data.get(REPORT_ABUSE_URL));
+      nugetAttr.set(P_REQUIRE_LICENSE_ACCEPTANCE, Boolean.parseBoolean(data.get(REQUIRE_LICENSE_ACCEPTANCE)));
+      nugetAttr.set(P_SUMMARY, data.get(SUMMARY));
+      nugetAttr.set(P_TAGS, data.get(TAGS));
+      nugetAttr.set(P_TITLE, data.get(TITLE));
+      nugetAttr.set(NugetProperties.P_VERSION, data.get(VERSION));
+    }
+    return asset;
   }
 
   private String blobName(Component component) {
@@ -391,7 +442,7 @@ public class NugetGalleryFacetImpl
     SortedSet<Component> allReleases = Sets.newTreeSet(new ComponentVersionComparator());
 
     for (Component version : versions) {
-      final NestedAttributesMap nugetAttributes = version.formatAttributes();
+      final NestedAttributesMap nugetAttributes = version.firstAsset().formatAttributes();
 
       final boolean isPrerelease = nugetAttributes.require(P_IS_PRERELEASE, Boolean.class);
       if (!isPrerelease) {
@@ -407,7 +458,7 @@ public class NugetGalleryFacetImpl
     Component absoluteLatestVersion = allReleases.isEmpty() ? null : allReleases.last();
 
     for (Component component : allReleases) {
-      final NestedAttributesMap nugetAttributes = component.formatAttributes();
+      final NestedAttributesMap nugetAttributes = component.firstAsset().formatAttributes();
 
       nugetAttributes.set(P_IS_LATEST_VERSION, component.equals(latestVersion));
       nugetAttributes.set(P_IS_ABSOLUTE_LATEST_VERSION, component.equals(absoluteLatestVersion));
@@ -424,22 +475,14 @@ public class NugetGalleryFacetImpl
     return storageTx.findComponents(whereClause, parameters, getRepositories(), null);
   }
 
-  private Asset createOrUpdateAsset(final StorageTx storageTx, final Bucket bucket,
-                                    final Component component, final InputStream in)
+  private Asset createOrUpdateAssetAndContents(final StorageTx storageTx, final Bucket bucket,
+                                               final Component component, final InputStream in,
+                                               final Map<String, String> data)
   {
-    Asset asset = null;
-
-    final List<Asset> assets = component.assets();
-    if (assets.isEmpty()) {
-      asset = storageTx.createAsset(bucket, component);
-    }
-    else {
-      asset = assets.get(0);
-    }
-
+    Asset asset = createOrUpdateAsset(storageTx, bucket, component, data);
+    
     final ImmutableMap<String, String> headers = ImmutableMap
         .of(BlobStore.BLOB_NAME_HEADER, blobName(component), BlobStore.CREATED_BY_HEADER, "unknown");
-
     storageTx.setBlob(in, headers, asset, Arrays.asList(HashAlgorithm.SHA512), "application/zip");
 
     return asset;
@@ -462,33 +505,11 @@ public class NugetGalleryFacetImpl
     final String version = checkVersion(data.get(VERSION));
 
     final Component component = findOrCreateComponent(storageTx, bucket, id, version);
-
-    final boolean republishing = !component.isNew();
-
-    final NestedAttributesMap nugetAttr = component.formatAttributes();
-
-    setDerivedAttributes(data, nugetAttr, republishing);
-
-    nugetAttr.set(P_AUTHORS, data.get(AUTHORS));
-    nugetAttr.set(P_COPYRIGHT, data.get(COPYRIGHT));
-    nugetAttr.set(P_DEPENDENCIES, data.get(DEPENDENCIES));
-    nugetAttr.set(P_DESCRIPTION, data.get(DESCRIPTION));
-    nugetAttr.set(P_GALLERY_DETAILS_URL, data.get(GALLERY_DETAILS_URL));
-    nugetAttr.set(P_ICON_URL, data.get(ICON_URL));
+    
+    NestedAttributesMap nugetAttr = component.formatAttributes();
     nugetAttr.set(P_ID, data.get(ID));
-    nugetAttr.set(P_IS_PRERELEASE, Boolean.parseBoolean(data.get(IS_PRERELEASE)));
-    nugetAttr.set(P_LANGUAGE, data.get(LANGUAGE));
-    nugetAttr.set(P_LICENSE_URL, data.get(LICENSE_URL));
-    nugetAttr.set(P_LOCATION, data.get(LOCATION));
     nugetAttr.set(P_PACKAGE_HASH, data.get(PACKAGE_HASH));
     nugetAttr.set(P_PACKAGE_HASH_ALGORITHM, data.get(PACKAGE_HASH_ALGORITHM));
-    nugetAttr.set(P_PACKAGE_SIZE, Integer.parseInt(data.get(PACKAGE_SIZE)));
-    nugetAttr.set(P_PROJECT_URL, data.get(PROJECT_URL));
-    nugetAttr.set(P_RELEASE_NOTES, data.get(RELEASE_NOTES));
-    nugetAttr.set(P_REPORT_ABUSE_URL, data.get(REPORT_ABUSE_URL));
-    nugetAttr.set(P_REQUIRE_LICENSE_ACCEPTANCE, Boolean.parseBoolean(data.get(REQUIRE_LICENSE_ACCEPTANCE)));
-    nugetAttr.set(P_SUMMARY, data.get(SUMMARY));
-    nugetAttr.set(P_TAGS, data.get(TAGS));
     nugetAttr.set(P_TITLE, data.get(TITLE));
     nugetAttr.set(NugetProperties.P_VERSION, data.get(VERSION));
 

--- a/plugins/basic/nexus-repository-nuget/src/test/java/com/sonatype/nexus/repository/nuget/internal/NugetGalleryFacetImplPutTest.java
+++ b/plugins/basic/nexus-repository-nuget/src/test/java/com/sonatype/nexus/repository/nuget/internal/NugetGalleryFacetImplPutTest.java
@@ -24,6 +24,7 @@ import com.sonatype.nexus.repository.nuget.internal.odata.ODataFeedUtils;
 import org.sonatype.nexus.common.collect.NestedAttributesMap;
 import org.sonatype.nexus.common.time.Clock;
 import org.sonatype.nexus.repository.Repository;
+import org.sonatype.nexus.repository.storage.Asset;
 import org.sonatype.nexus.repository.storage.Component;
 import org.sonatype.nexus.repository.storage.ComponentCreatedEvent;
 import org.sonatype.nexus.repository.storage.ComponentEvent;
@@ -95,7 +96,7 @@ public class NugetGalleryFacetImplPutTest
     Component component = mock(Component.class);
     ORID orid = mock(ORID.class);
     doReturn(component).when(galleryFacet)
-        .createOrUpdatePackage(any(StorageTx.class), any(Map.class), any(InputStream.class));
+        .createOrUpdatePackageAndContents(any(StorageTx.class), any(Map.class), any(InputStream.class));
     when(component.isNew()).thenReturn(isNew);
 
     galleryFacet.put(packageStream);
@@ -164,7 +165,7 @@ public class NugetGalleryFacetImplPutTest
 
     galleryFacet.maintainAggregateInfo(tx, Arrays.asList(preRelease));
 
-    verifyVersionFlags(preRelease.formatAttributes(), false, true);
+    verifyVersionFlags(preRelease.firstAsset().formatAttributes(), false, true);
   }
 
   @Test
@@ -176,7 +177,7 @@ public class NugetGalleryFacetImplPutTest
     final NugetGalleryFacetImpl galleryFacet = buildSpy();
     galleryFacet.maintainAggregateInfo(tx, Arrays.asList(release));
 
-    verifyVersionFlags(release.formatAttributes(), true, true);
+    verifyVersionFlags(release.firstAsset().formatAttributes(), true, true);
   }
 
   @Test
@@ -190,8 +191,8 @@ public class NugetGalleryFacetImplPutTest
     final NugetGalleryFacetImpl galleryFacet = buildSpy();
     galleryFacet.maintainAggregateInfo(tx, Arrays.asList(release, preRelease));
 
-    verifyVersionFlags(release.formatAttributes(), true, true);
-    verifyVersionFlags(preRelease.formatAttributes(), false, false);
+    verifyVersionFlags(release.firstAsset().formatAttributes(), true, true);
+    verifyVersionFlags(preRelease.firstAsset().formatAttributes(), false, false);
   }
 
   @Test
@@ -204,8 +205,8 @@ public class NugetGalleryFacetImplPutTest
     final NugetGalleryFacetImpl galleryFacet = buildSpy();
     galleryFacet.maintainAggregateInfo(tx, Arrays.asList(release, preRelease));
 
-    verifyVersionFlags(preRelease.formatAttributes(), false, true);
-    verifyVersionFlags(release.formatAttributes(), true, false);
+    verifyVersionFlags(preRelease.firstAsset().formatAttributes(), false, true);
+    verifyVersionFlags(release.firstAsset().formatAttributes(), true, false);
   }
 
   private NugetGalleryFacetImpl buildSpy() {
@@ -223,9 +224,11 @@ public class NugetGalleryFacetImplPutTest
 
   private Component buildVersionMock(final StorageTx tx, final String version, final boolean isPrerelease) {
     final Component component = mock(Component.class);
+    final Asset asset = mock(Asset.class);
     final NestedAttributesMap nugetAttributes = mock(NestedAttributesMap.class);
 
-    when(component.formatAttributes()).thenReturn(nugetAttributes);
+    when(component.firstAsset()).thenReturn(asset);
+    when(asset.formatAttributes()).thenReturn(nugetAttributes);
 
     when(component.requireVersion()).thenReturn(version);
     when(nugetAttributes.require(eq(P_VERSION))).thenReturn(version);


### PR DESCRIPTION
- store only top level attributes on the component, everything else at the Asset level

https://issues.sonatype.org/browse/NEXUS-8236