### PR TITLE
Protect against potential NPE in legacy configuration code when scheduled tasks run early

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/configuration/AbstractConfigurable.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/configuration/AbstractConfigurable.java
@@ -228,7 +228,8 @@ public abstract class AbstractConfigurable<C>
   }
 
   public C getCurrentConfiguration(boolean forWrite) {
-    return getCurrentCoreConfiguration().getConfiguration(forWrite);
+    final CoreConfiguration<C> cc = getCurrentCoreConfiguration();
+    return cc != null ? cc.getConfiguration(forWrite) : null;
   }
 
   protected abstract CoreConfiguration<C> wrapConfiguration(Object configuration);


### PR DESCRIPTION
Noticed this exception stack in a couple of the quartz ITs on CI (which didn't fail, but also didn't complete)
```
  Caused by: java.lang.NullPointerException: null
    at org.sonatype.nexus.configuration.AbstractConfigurable.getCurrentConfiguration(AbstractConfigurable.java:231)
    at org.sonatype.nexus.configuration.DefaultGlobalRestApiSettings.isEnabled(DefaultGlobalRestApiSettings.java:65)
    at org.sonatype.nexus.web.BaseUrlDetector.detect(BaseUrlDetector.java:73)
    at org.sonatype.nexus.web.BaseUrlDetector.set(BaseUrlDetector.java:109)
    at org.sonatype.nexus.quartz.internal.nexus.NexusTaskJobSupport.execute(NexusTaskJobSupport.java:114)
    at org.sonatype.nexus.quartz.JobSupport.execute(JobSupport.java:44)
    ... 9 common frames omitted
```
Note: this only affects a couple of quartz tests which perform a partial boot of the system and will soon be replaced, but I think the extra guard is useful.

http://bamboo.s/browse/NX3-OSSF134-1