### PR TITLE
[NEXUS-8442] increase timeout for support-zip generation to 3 minutes

### DIFF
--- a/plugins/internal/nexus-atlas-plugin/src/main/java/org/sonatype/nexus/atlas/ui/SupportZipComponent.groovy
+++ b/plugins/internal/nexus-atlas-plugin/src/main/java/org/sonatype/nexus/atlas/ui/SupportZipComponent.groovy
@@ -36,9 +36,8 @@ import org.apache.shiro.authz.annotation.RequiresPermissions
 @Singleton
 @DirectAction(action = 'atlas_SupportZip')
 class SupportZipComponent
-extends DirectComponentSupport
+    extends DirectComponentSupport
 {
-
   @Inject
   SupportZipGenerator supportZipGenerator
 
@@ -59,5 +58,4 @@ extends DirectComponentSupport
         truncated: result.truncated
     )
   }
-
 }

--- a/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/app/PluginStrings.js
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/app/PluginStrings.js
@@ -764,7 +764,8 @@ Ext.define('NX.coreui.app.PluginStrings', {
     // Admin -> Support -> Support ZIP
     ADMIN_SUPPORT_ZIP_TITLE: 'Support ZIP',
     ADMIN_SUPPORT_ZIP_SUBTITLE: 'Creates a ZIP file containing useful support information about your server',
-    ADMIN_SUPPORT_ZIP_HELP: '<p>No information will be sent to Sonatype when creating the support ZIP file.</p>',
+    ADMIN_SUPPORT_ZIP_HELP: '<p>No information will be sent to Sonatype when creating the support ZIP file.</p>' +
+      '<p>Support ZIP creation may take a few minutes to complete.</p>',
     ADMIN_SUPPORT_ZIP_CONTENTS: 'Contents',
     ADMIN_SUPPORT_ZIP_REPORT: 'System information report',
     ADMIN_SUPPORT_ZIP_DUMP: 'JVM thread-dump',
@@ -777,7 +778,7 @@ Ext.define('NX.coreui.app.PluginStrings', {
     ADMIN_SUPPORT_ZIP_INCLUDED: 'Limit files in the ZIP archive to 30 MB apiece',
     ADMIN_SUPPORT_ZIP_MAX: 'Limit the ZIP archive to 20 MB',
     ADMIN_SUPPORT_ZIP_CREATE_BUTTON: 'Create support ZIP',
-    ADMIN_SUPPORT_ZIP_CREATING: 'Creating support ZIP',
+    ADMIN_SUPPORT_ZIP_CREATING: '<div align="center">Creating support ZIP <br/>(may take a few minutes)</div>',
     ADMIN_SUPPORT_ZIP_TRUNCATED: 'Contents have been truncated due to exceeded size limits.',
     ADMIN_SUPPORT_ZIP_CREATED: 'Support ZIP created',
     ADMIN_SUPPORT_ZIP_CREATED_NAME: 'Name',

--- a/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/view/support/SupportZip.js
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/view/support/SupportZip.js
@@ -35,6 +35,7 @@ Ext.define('NX.coreui.view.support.SupportZip', {
       xtype: 'nx-settingsform',
       settingsFormSubmitMessage: NX.I18n.get('ADMIN_SUPPORT_ZIP_CREATING'),
       settingsFormSuccessMessage: NX.I18n.get('ADMIN_SUPPORT_ZIP_CREATED'),
+      timeout: 60 * 3, // 3 minutes
       api: {
         submit: 'NX.direct.atlas_SupportZip.create'
       },

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/app/Application.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/app/Application.js
@@ -229,9 +229,16 @@ Ext.define('NX.app.Application', {
    * Initialize Ex.Direct remote providers.
    */
   initDirect: function () {
-    var me = this;
+    var me = this,
+        remotingProvider;
 
-    Ext.direct.Manager.addProvider(NX.direct.api.REMOTING_API);
+    remotingProvider = Ext.direct.Manager.addProvider(NX.direct.api.REMOTING_API);
+
+    // disable retry
+    remotingProvider.maxRetries = 0;
+
+    // default request timeout to 60 seconds
+    remotingProvider.timeout = 60 * 1000;
 
     //<if debug>
     me.logDebug('Configured Ext.Direct');


### PR DESCRIPTION
Also updates default ext.direct remoting provider to not retry and have 60 second timeout (instead of 30)

https://issues.sonatype.org/browse/NEXUS-8442