### PR TITLE
[NEXUS-7726] Wrap search criteria boxes

### DIFF
--- a/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/controller/Search.js
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/controller/Search.js
@@ -348,6 +348,7 @@ Ext.define('NX.coreui.controller.Search', {
     searchCriteriaPanel.add({
       xtype: 'button',
       itemId: 'addButton',
+      margin: '36px 0 0 0',
       text: NX.I18n.get('BROWSE_SEARCH_COMPONENTS_MORE_BUTTON'),
       glyph: 'xf055@FontAwesome' /* fa-plus-circle */,
       menu: addCriteriaMenu

--- a/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/view/search/SearchFeature.js
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/view/search/SearchFeature.js
@@ -43,11 +43,13 @@ Ext.define('NX.coreui.view.search.SearchFeature', {
             'background-color': '#FFFFFF'
           },
 
-          layout: {
-            type: 'hbox',
-            align: 'bottom'
+          layout: 'column',
+          defaults: {
+            style: {
+              margin: '10px 0 0 0'
+            }
           },
-          bodyPadding: 10
+          bodyPadding: '0 10px 10px 10px'
 
           // disable saving for now
           //tbar: [


### PR DESCRIPTION
Issue: https://issues.sonatype.org/browse/NEXUS-7726

Before: http://take.ms/h8OEV

After: http://take.ms/ERCN1

One of the complaints in the ticket was that some of the input fields are too short for their data types. Can someone more familiar with this area update the widths of those fields? @adreghiciu or @jdillon, perhaps? Feel free to push changes to this PR.