### PR TITLE
Httpclient leak fix

### DIFF
--- a/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/proxy/ProxyFacetSupport.java
+++ b/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/proxy/ProxyFacetSupport.java
@@ -42,6 +42,7 @@ import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.DateUtils;
+import org.apache.http.client.utils.HttpClientUtils;
 import org.joda.time.DateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -218,6 +219,7 @@ public abstract class ProxyFacetSupport
     if (status.getStatusCode() == HttpStatus.SC_NOT_MODIFIED) {
       indicateUpToDate(context);
     }
+    HttpClientUtils.closeQuietly(response);
 
     return null;
   }


### PR DESCRIPTION
When response is non-200, it still might have entity
that reserves the connection.

Spotted this in a moment NX needed to have multiple repositories (not only maven-central), as in that case NX almost instantly depleted connPool (with 404 HTML page responses).