### PR TITLE
Maven2 fixes

### DIFF
--- a/plugins/basic/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/MavenFacetImpl.java
+++ b/plugins/basic/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/MavenFacetImpl.java
@@ -234,7 +234,6 @@ public class MavenFacetImpl
           .group(coordinates.getGroupId())
           .name(coordinates.getArtifactId())
           .version(coordinates.getVersion());
-      component.formatAttributes().set(StorageFacet.P_PATH, path.getPath());
 
       // Set format specific attributes
       final NestedAttributesMap componentAttributes = component.formatAttributes();

--- a/plugins/basic/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/maven2/Maven2Format.java
+++ b/plugins/basic/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/maven2/Maven2Format.java
@@ -16,6 +16,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.sonatype.nexus.repository.Format;
+import org.sonatype.nexus.repository.view.ContentTypes;
 
 /**
  * Maven 2 format.
@@ -28,6 +29,21 @@ public class Maven2Format
     extends Format
 {
   public static final String NAME = "maven2";
+
+  /**
+   * File name of Maven2 repository metadata files.
+   */
+  public static final String METADATA_FILENAME = "maven-metadata.xml";
+
+  /**
+   * Content type of Maven2 repository metadata files.
+   */
+  public static final String METADATA_CONTENT_TYPE = ContentTypes.TEXT_XML;
+
+  /**
+   * Content Type of Maven2 checksum files (sha1, md5).
+   */
+  public static final String CHECKSUM_CONTENT_TYPE = ContentTypes.TEXT_PLAIN;
 
   public Maven2Format() {
     super(NAME);

--- a/plugins/basic/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/maven2/Maven2GroupFacet.java
+++ b/plugins/basic/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/maven2/Maven2GroupFacet.java
@@ -10,7 +10,7 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
-package org.sonatype.nexus.repository.maven.internal;
+package org.sonatype.nexus.repository.maven.internal.maven2;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -32,6 +32,8 @@ import org.sonatype.nexus.repository.config.Configuration;
 import org.sonatype.nexus.repository.group.GroupFacetImpl;
 import org.sonatype.nexus.repository.http.HttpStatus;
 import org.sonatype.nexus.repository.manager.RepositoryManager;
+import org.sonatype.nexus.repository.maven.internal.MavenFacet;
+import org.sonatype.nexus.repository.maven.internal.MavenPath;
 import org.sonatype.nexus.repository.maven.internal.MavenPath.HashType;
 import org.sonatype.nexus.repository.maven.internal.maven2.Maven2MetadataMerger;
 import org.sonatype.nexus.repository.maven.internal.maven2.Maven2MetadataMerger.MetadataEnvelope;
@@ -59,13 +61,13 @@ import org.joda.time.DateTime;
 import static com.google.common.base.Preconditions.checkArgument;
 
 /**
- * Maven specific implementation of {@link GroupFacetImpl}.
+ * Maven2 specific implementation of {@link GroupFacetImpl}: metadata merge is specific to Maven2 format.
  *
  * @since 3.0
  */
 @Named
 @Facet.Exposed
-public class MavenGroupFacet
+public class Maven2GroupFacet
     extends GroupFacetImpl
 {
   private final Maven2MetadataMerger metadataMerger;
@@ -73,7 +75,7 @@ public class MavenGroupFacet
   private MavenFacet mavenFacet;
 
   @Inject
-  public MavenGroupFacet(final RepositoryManager repositoryManager) {
+  public Maven2GroupFacet(final RepositoryManager repositoryManager) {
     super(repositoryManager);
     this.metadataMerger = new Maven2MetadataMerger();
   }

--- a/plugins/basic/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/maven2/Maven2GroupFacet.java
+++ b/plugins/basic/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/maven2/Maven2GroupFacet.java
@@ -35,13 +35,11 @@ import org.sonatype.nexus.repository.manager.RepositoryManager;
 import org.sonatype.nexus.repository.maven.internal.MavenFacet;
 import org.sonatype.nexus.repository.maven.internal.MavenPath;
 import org.sonatype.nexus.repository.maven.internal.MavenPath.HashType;
-import org.sonatype.nexus.repository.maven.internal.maven2.Maven2MetadataMerger;
 import org.sonatype.nexus.repository.maven.internal.maven2.Maven2MetadataMerger.MetadataEnvelope;
 import org.sonatype.nexus.repository.storage.AssetEvent;
 import org.sonatype.nexus.repository.storage.StorageFacet;
 import org.sonatype.nexus.repository.util.TypeTokens;
 import org.sonatype.nexus.repository.view.Content;
-import org.sonatype.nexus.repository.view.ContentTypes;
 import org.sonatype.nexus.repository.view.PayloadResponse;
 import org.sonatype.nexus.repository.view.Response;
 import org.sonatype.nexus.repository.view.payloads.BytesPayload;
@@ -158,7 +156,7 @@ public class Maven2GroupFacet
     final Content content = new Content(
         new BytesPayload(
             byteArray,
-            ContentTypes.TEXT_XML
+            Maven2Format.METADATA_CONTENT_TYPE
         ));
     content.getAttributes().set(Content.CONTENT_LAST_MODIFIED, DateTime.now());
     content.getAttributes().set(Content.CONTENT_ETAG, "{SHA1{" + hashCodes.get(HashAlgorithm.SHA1).toString() + "}}");
@@ -175,7 +173,7 @@ public class Maven2GroupFacet
     for (HashType hashType : HashType.values()) {
       final HashCode hashCode = hashCodes.get(hashType.getHashAlgorithm());
       if (hashCode != null) {
-        final Content hashContent = new Content(new StringPayload(hashCode.toString(), ContentTypes.TEXT_PLAIN));
+        final Content hashContent = new Content(new StringPayload(hashCode.toString(), Maven2Format.CHECKSUM_CONTENT_TYPE));
         hashContent.getAttributes().set(Content.CONTENT_LAST_MODIFIED, now);
         mavenFacet.put(mavenPath.hash(hashType), hashContent);
       }

--- a/plugins/basic/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/maven2/Maven2GroupMetadataHandler.java
+++ b/plugins/basic/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/maven2/Maven2GroupMetadataHandler.java
@@ -10,7 +10,7 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
-package org.sonatype.nexus.repository.maven.internal;
+package org.sonatype.nexus.repository.maven.internal.maven2;
 
 import java.util.LinkedHashMap;
 
@@ -21,18 +21,19 @@ import javax.inject.Singleton;
 import org.sonatype.nexus.repository.Repository;
 import org.sonatype.nexus.repository.group.GroupHandler;
 import org.sonatype.nexus.repository.http.HttpResponses;
+import org.sonatype.nexus.repository.maven.internal.MavenPath;
 import org.sonatype.nexus.repository.view.Content;
 import org.sonatype.nexus.repository.view.Context;
 import org.sonatype.nexus.repository.view.Response;
 
 /**
- * Maven group metadata handler.
+ * Maven2 specific group metadata handler: metadata merge is specific to Maven2 format.
  *
  * @since 3.0
  */
 @Singleton
 @Named
-public class GroupMetadataHandler
+public class Maven2GroupMetadataHandler
     extends GroupHandler
 {
   @Override
@@ -40,7 +41,7 @@ public class GroupMetadataHandler
       throws Exception
   {
     final MavenPath mavenPath = context.getAttributes().require(MavenPath.class);
-    final MavenGroupFacet groupFacet = context.getRepository().facet(MavenGroupFacet.class);
+    final Maven2GroupFacet groupFacet = context.getRepository().facet(Maven2GroupFacet.class);
     // get cached one
     Content content = groupFacet.getCachedMergedMetadata(mavenPath);
     if (content != null) {

--- a/plugins/basic/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/maven2/Maven2GroupRecipe.groovy
+++ b/plugins/basic/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/maven2/Maven2GroupRecipe.groovy
@@ -23,10 +23,8 @@ import org.sonatype.nexus.repository.RecipeSupport
 import org.sonatype.nexus.repository.Repository
 import org.sonatype.nexus.repository.Type
 import org.sonatype.nexus.repository.group.GroupHandler
-import org.sonatype.nexus.repository.maven.internal.GroupMetadataHandler
 import org.sonatype.nexus.repository.maven.internal.MavenArtifactMatcher
 import org.sonatype.nexus.repository.maven.internal.MavenFacetImpl
-import org.sonatype.nexus.repository.maven.internal.MavenGroupFacet
 import org.sonatype.nexus.repository.maven.internal.MavenHeadersHandler
 import org.sonatype.nexus.repository.maven.internal.MavenMetadataMatcher
 import org.sonatype.nexus.repository.maven.internal.MavenPathParser
@@ -64,7 +62,7 @@ class Maven2GroupRecipe
   Provider<StorageFacetImpl> storageFacet
 
   @Inject
-  Provider<MavenGroupFacet> mavenGroupFacet
+  Provider<Maven2GroupFacet> mavenGroupFacet
 
   @Inject
   TimingHandler timingHandler
@@ -85,7 +83,7 @@ class Maven2GroupRecipe
   GroupHandler groupHandler
 
   @Inject
-  GroupMetadataHandler groupMetadataHandler
+  Maven2GroupMetadataHandler groupMetadataHandler
 
   @Inject
   @Named(Maven2Format.NAME)

--- a/plugins/basic/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/maven2/Maven2MavenPathParser.java
+++ b/plugins/basic/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/maven2/Maven2MavenPathParser.java
@@ -32,8 +32,6 @@ import org.sonatype.nexus.repository.maven.internal.MavenPathParser;
 public class Maven2MavenPathParser
     implements MavenPathParser
 {
-  private static final String MAVEN2_METADATA_NAME = "maven-metadata.xml";
-
   @Override
   public MavenPath parsePath(final String path) {
     final Coordinates coordinates = maven2LayoutedPathToCoordinates(path);
@@ -42,7 +40,7 @@ public class Maven2MavenPathParser
 
   @Override
   public boolean isRepositoryMetadata(final MavenPath path) {
-    return path.main().getFileName().equals(MAVEN2_METADATA_NAME);
+    return path.main().getFileName().equals(Maven2Format.METADATA_FILENAME);
   }
 
   /**
@@ -93,7 +91,7 @@ public class Maven2MavenPathParser
         str = str.substring(0, str.length() - (signatureType.getExt().length() + 1));
       }
 
-      if (str.endsWith("maven-metadata.xml")) {
+      if (str.endsWith(Maven2Format.METADATA_FILENAME)) {
         return null;
       }
 


### PR DESCRIPTION
Set of smaller changes and fixes.

Changes:
1) maven components has formatAttribute StorageFace.P_PATH that made no sense
2) Merging groups are specific to Maven2 format only (as repo metadata itself is), move them into maven2 package
3) centralise and expose some constants instead of litter them around as private (this is especially true for "walker" branch that uses these)
