### PR TITLE
[NEXUS-8493] Default timeout values for proxy repositories

### DIFF
--- a/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/httpclient/ConnectionConfig.java
+++ b/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/httpclient/ConnectionConfig.java
@@ -30,10 +30,10 @@ public class ConnectionConfig
   private String urlParameters;
 
   /**
-   * Timeout milliseconds.
+   * Timeout seconds.
    */
   @Min(0L)
-  @Max(3600000L) // 1 hour
+  @Max(3600L) // 1 hour
   private Integer timeout;
 
   @Min(0L)

--- a/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/httpclient/HttpClientFactoryImpl.java
+++ b/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/httpclient/HttpClientFactoryImpl.java
@@ -88,16 +88,16 @@ public class HttpClientFactoryImpl
 
   private void applyConfiguration(final Builder builder, final HttpClientConfig config) {
     // connection/socket timeouts
-    int timeout = 1000;
+    int timeout = 20000; // default 20 seconds
     if (config.getConnection() != null && config.getConnection().getTimeout() != null) {
-      timeout = config.getConnection().getTimeout();
+      timeout = config.getConnection().getTimeout() * 1000;
     }
     builder.getSocketConfigBuilder().setSoTimeout(timeout);
     builder.getRequestConfigBuilder().setConnectTimeout(timeout);
     builder.getRequestConfigBuilder().setSocketTimeout(timeout);
 
     // obey the given retries count and apply it to client.
-    int retries = 0;
+    int retries = 3; // default 3 retries
     if (config.getConnection() != null && config.getConnection().getRetries() != null) {
       retries = config.getConnection().getRetries();
     }

--- a/plugins/basic/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/MavenDefaultRepositoriesContributor.groovy
+++ b/plugins/basic/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/MavenDefaultRepositoriesContributor.groovy
@@ -78,12 +78,6 @@ class MavenDefaultRepositoriesContributor
                     remoteUrl     : 'https://repo1.maven.org/maven2/',
                     artifactMaxAge: 3600
                 ],
-                httpclient: [
-                    connection: [
-                        timeout: 1500,
-                        retries: 3
-                    ]
-                ],
                 storage   : [
                     writePolicy: WritePolicy.ALLOW.toString()
                 ]

--- a/plugins/basic/nexus-repository-nuget/src/main/java/com/sonatype/nexus/repository/nuget/internal/NugetDefaultRepositoriesContributor.groovy
+++ b/plugins/basic/nexus-repository-nuget/src/main/java/com/sonatype/nexus/repository/nuget/internal/NugetDefaultRepositoriesContributor.groovy
@@ -48,12 +48,6 @@ class NugetDefaultRepositoriesContributor
                 proxy     : [
                     remoteUrl     : 'http://www.nuget.org/api/v2/',
                     artifactMaxAge: 5
-                ],
-                httpclient: [
-                    connection: [
-                        timeout: 20000,
-                        retries: 2
-                    ]
                 ]
             ]
         ),

--- a/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/app/PluginStrings.js
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/app/PluginStrings.js
@@ -264,7 +264,7 @@ Ext.define('NX.coreui.app.PluginStrings', {
     ADMIN_REPOSITORIES_SETTINGS_CONNECTION_RETRIES: 'Connection retries',
     ADMIN_REPOSITORIES_SETTINGS_CONNECTION_RETRIES_HELP: 'How many times to try to connect before giving up',
     ADMIN_REPOSITORIES_SETTINGS_CONNECTION_TIMEOUT: 'Connection timeout',
-    ADMIN_REPOSITORIES_SETTINGS_CONNECTION_TIMEOUT_HELP: 'How long (in ms) to wait before timing out connections',
+    ADMIN_REPOSITORIES_SETTINGS_CONNECTION_TIMEOUT_HELP: 'How long (in seconds) to wait before timing out connections',
     ADMIN_REPOSITORIES_SETTINGS_CONTENT_TYPE_VALIDATION: 'Strict Content Type Validation',
     ADMIN_REPOSITORIES_SETTINGS_NEGATIVE_CACHE_ENABLED: 'Not found cache enabled',
     ADMIN_REPOSITORIES_SETTINGS_NEGATIVE_CACHE_TTL: 'Not found cache TTL',


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-8493

The fix changes the config to use seconds instead of milliseconds, changes the defaults to 3 retries / 20 seconds timeout (this will be changed when we will take the defaults from global http config) and removes the default configuration for maven/nuget proxies.