### PR TITLE
[NEXUS-8489] Bring back ssl certificate details window

### DIFF
--- a/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/controller/SslTrustStore.js
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/controller/SslTrustStore.js
@@ -119,7 +119,7 @@ Ext.define('NX.coreui.controller.SslTrustStore', {
     NX.direct.ssl_Certificate.retrieveFromHost(hostAndPort.host, hostAndPort.port, undefined, function(response) {
       me.getMain().getEl().unmask();
       if (Ext.isObject(response) && response.success) {
-        sslCertificates.showCertificateDetails(response.data);
+        sslCertificates.showCertificateDetailsWindow(response.data);
       }
     });
   },

--- a/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/view/ssl/SslCertificateDetailsPanel.js
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/view/ssl/SslCertificateDetailsPanel.js
@@ -13,28 +13,24 @@
 /*global Ext, NX*/
 
 /**
- * Ssl Certificate detail window.
+ * Ssl Certificate detail panel.
  *
  * @since 3.0
  */
-Ext.define('NX.coreui.view.ssl.SslCertificateDetailsWindow', {
-  extend: 'NX.view.AddWindow',
-  alias: 'widget.nx-coreui-sslcertificate-details-window',
+Ext.define('NX.coreui.view.ssl.SslCertificateDetailsPanel', {
+  extend: 'NX.view.AddPanel',
+  alias: 'widget.nx-coreui-sslcertificate-details-panel',
   requires: [
     'NX.Conditions',
     'NX.I18n'
   ],
-  ui: 'nx-inset',
 
-  title: NX.I18n.get('ADMIN_SSL_DETAILS_TITLE'),
-
-  items: {
+  settingsForm: {
     xtype: 'nx-coreui-sslcertificate-details-form',
-    frame: false,
     buttons: [
       { text: NX.I18n.get('ADMIN_SSL_DETAILS_CANCEL_BUTTON'),
         handler: function () {
-          this.up('window').close();
+          this.up('nx-drilldown').showChild(0, true);
         }
       }
     ]


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-8489

The certificate window was transformed to a panel and used as part of drill down.