### PR TITLE
Suppressing AuthorizationExceptions in Nexus console

### DIFF
--- a/plugins/basic/nexus-repository-httpbridge/src/main/java/org/sonatype/nexus/repository/httpbridge/internal/ViewServlet.java
+++ b/plugins/basic/nexus-repository-httpbridge/src/main/java/org/sonatype/nexus/repository/httpbridge/internal/ViewServlet.java
@@ -44,6 +44,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
+import org.apache.shiro.authz.AuthorizationException;
 import org.jboss.logging.MDC;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -121,6 +122,9 @@ public class ViewServlet
       log.debug("Service completed");
     }
     catch (Exception e) {
+      if (!(e instanceof AuthorizationException)) {
+        log.warn("Service failure", e);
+      }
       Throwables.propagateIfPossible(e, ServletException.class, IOException.class);
       throw new ServletException(e);
     }


### PR DESCRIPTION
Exceptions get logged to the console, but cutting out AuthorizationExceptions (which makes format debugging really noisy).