### PR TITLE
Fix regex pattern for identifying tarball requests

### DIFF
--- a/plugins/npm/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/service/internal/ProxyMetadataServiceImpl.java
+++ b/plugins/npm/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/service/internal/ProxyMetadataServiceImpl.java
@@ -117,7 +117,7 @@ public class ProxyMetadataServiceImpl
    * 2. the complete filename after "/-/"
    */
   private final static Pattern TARBALL_PATH_PATTERN = Pattern
-      .compile("/([[a-z][A-Z][0-9]-_\\.]+)/-/([[a-z][A-Z][0-9]-_\\.]+\\.tgz)");
+      .compile("/([[a-z][A-Z][0-9]-_\\.]+)/-/([[a-z][A-Z][0-9]-_\\.]+tgz)");
 
   @Nullable
   @Override


### PR DESCRIPTION
The regex for identifying tarball requests is invalid for some packages. See ticket: https://issues.sonatype.org/browse/NEXUS-8554

The regex pattern ``TARBALL_PATH_PATTERN`` in ``ProxyMetadataServiceImpl`` does not match this string ``"/gulp/-/gulp-3.8.11.tgz"``, and as a result, the ``createTarballRequest()`` method returns ``null``.

When this happens, the package is not downloaded, and ``ItemNotFoundException`` is thrown. This means that npm packages cannot be downloaded from Nexus when it is proxying an npmjs remote repository (https://registry.npmjs.org) as per documentation at https://books.sonatype.com/nexus-book/reference/npm-proxying-registries.html

This PR updates the regex pattern to correctly match the npm package naming format.

It also results in the following groups being available on the matcher instance, which are used in the createTarballRequest() method:

* Group 0: ``[0,23] /gulp/-/gulp-3.8.11.tgz``
* Group 1: ``[1,5] gulp``
* Group 2: ``[8,23] gulp-3.8.11.tgz``