### PR TITLE
 [NEXUS-8571] escape html values when rendering description values

### DIFF
--- a/plugins/basic/nexus-repository-httpbridge/src/main/java/org/sonatype/nexus/repository/httpbridge/internal/describe/DescriptionRendererImpl.java
+++ b/plugins/basic/nexus-repository-httpbridge/src/main/java/org/sonatype/nexus/repository/httpbridge/internal/describe/DescriptionRendererImpl.java
@@ -59,7 +59,7 @@ public class DescriptionRendererImpl
     TemplateParameters params = new TemplateParameters();
     params.setAll(description.getParameters());
     params.set("items", description.getItems());
-
+    params.set("esc", new EscapeHelper());
     return templateEngine.render(this, template, params);
   }
 

--- a/plugins/basic/nexus-repository-httpbridge/src/main/java/org/sonatype/nexus/repository/httpbridge/internal/describe/EscapeHelper.java
+++ b/plugins/basic/nexus-repository-httpbridge/src/main/java/org/sonatype/nexus/repository/httpbridge/internal/describe/EscapeHelper.java
@@ -1,0 +1,34 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2008-2015 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.httpbridge.internal.describe;
+
+import org.sonatype.sisu.goodies.template.TemplateAccessible;
+
+import org.apache.commons.lang.StringEscapeUtils;
+
+/**
+ * Helper to escape values.
+ *
+ * @since 3.0
+ */
+@TemplateAccessible
+public class EscapeHelper
+{
+  public String html(final String value) {
+    return StringEscapeUtils.escapeHtml(value);
+  }
+
+  public String html(final Object value) {
+    return html(String.valueOf(value));
+  }
+}

--- a/plugins/basic/nexus-repository-httpbridge/src/main/resources/org/sonatype/nexus/repository/httpbridge/internal/describe/describe.vm
+++ b/plugins/basic/nexus-repository-httpbridge/src/main/resources/org/sonatype/nexus/repository/httpbridge/internal/describe/describe.vm
@@ -37,7 +37,7 @@
           #foreach ($entry in $map.entrySet())
           <tr>
             <td>$entry.key</td>
-            <td>$entry.value</td>
+            <td>$esc.html($entry.value)</td>
           </tr>
           #end
         </tbody>
@@ -64,7 +64,7 @@
       <h2>$item.name</h2>
     #elseif($item.type == "string")
       <h3>$item.name</h3>
-      <p>$item.value</p>
+      <p>$esc.html($item.value)</p>
     #elseif($item.type == "table")
       <h3>$item.name</h3>
       #table($item.value)


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-8571

Note this won't actually fix the preset master state or resolve the ?describe on /content (legacy repository framework), nor will this actually show timing information in new CMA ?describe due to https://issues.sonatype.org/browse/NEXUS-8573