### PR TITLE
NEXUS-8555: On npm metadata fetch evict NFC

### DIFF
--- a/plugins/npm/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/service/internal/ProxyMetadataServiceImpl.java
+++ b/plugins/npm/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/service/internal/ProxyMetadataServiceImpl.java
@@ -222,7 +222,7 @@ public class ProxyMetadataServiceImpl
       if (packageRoot == null) {
         return null;
       }
-      // NEXUS-8570: On remote fetch of metadata, evict /packageName and children from NFC
+      // On remote fetch of metadata, evict /packageName and children from NFC
       getNpmRepository().getNotFoundCache().removeWithChildren("/" + packageName);
       packageRoot.getProperties().put(PROP_EXPIRED, Boolean.FALSE.toString());
       packageRoot.getProperties().put(PROP_CACHED, Long.toString(now));

--- a/plugins/npm/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/service/internal/ProxyMetadataServiceImpl.java
+++ b/plugins/npm/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/service/internal/ProxyMetadataServiceImpl.java
@@ -222,6 +222,8 @@ public class ProxyMetadataServiceImpl
       if (packageRoot == null) {
         return null;
       }
+      // NEXUS-8570: On remote fetch of metadata, evict /packageName and children from NFC
+      getNpmRepository().getNotFoundCache().removeWithChildren("/" + packageName);
       packageRoot.getProperties().put(PROP_EXPIRED, Boolean.FALSE.toString());
       packageRoot.getProperties().put(PROP_CACHED, Long.toString(now));
       return metadataStore.updatePackage(getNpmRepository(), packageRoot);

--- a/plugins/npm/nexus-npm-repository-plugin/src/test/java/com/bolyuba/nexus/plugin/npm/service/MetadataServiceIT.java
+++ b/plugins/npm/nexus-npm-repository-plugin/src/test/java/com/bolyuba/nexus/plugin/npm/service/MetadataServiceIT.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.sonatype.nexus.apachehttpclient.Hc4Provider;
 import org.sonatype.nexus.configuration.application.ApplicationDirectories;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
+import org.sonatype.nexus.proxy.cache.PathCache;
 import org.sonatype.nexus.proxy.item.ContentLocator;
 import org.sonatype.nexus.proxy.item.PreparedContentLocator;
 import org.sonatype.nexus.proxy.item.RepositoryItemUid;
@@ -202,6 +203,9 @@ public class MetadataServiceIT
 
       @Override
       public ProxyMode getProxyMode() { return ProxyMode.ALLOW; }
+
+      @Override
+      public PathCache getNotFoundCache() { return mock(PathCache.class); }
     };
 
     // not using mock as it would OOM when it tracks invocations, as we work with large files here

--- a/testsuite/modern-testsuite/src/test/java/org/sonatype/nexus/testsuite/npm/smoke/NpmCacheNfcEvictIT.java
+++ b/testsuite/modern-testsuite/src/test/java/org/sonatype/nexus/testsuite/npm/smoke/NpmCacheNfcEvictIT.java
@@ -1,0 +1,78 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2008-2015 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.testsuite.npm.smoke;
+
+import java.io.File;
+
+import org.sonatype.nexus.bundle.launcher.NexusBundleConfiguration;
+import org.sonatype.nexus.client.core.exception.NexusClientNotFoundException;
+import org.sonatype.nexus.client.core.subsystem.content.Location;
+import org.sonatype.nexus.testsuite.npm.NpmMockRegistryITSupport;
+import org.sonatype.sisu.litmus.testsupport.hamcrest.FileMatchers;
+
+import com.bolyuba.nexus.plugin.npm.client.NpmProxyRepository;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * NPM IT for NPM plugin verifying that on metadata fetch NFC is evicted for given package and children.
+ */
+public class NpmCacheNfcEvictIT
+    extends NpmMockRegistryITSupport
+{
+  public NpmCacheNfcEvictIT(String nexusBundleCoordinates) {
+    super(nexusBundleCoordinates);
+  }
+
+  @Override
+  protected NexusBundleConfiguration configureNexus(final NexusBundleConfiguration configuration) {
+    return super.configureNexus(configuration)
+        .setLogLevel("remote.storage.outbound", "DEBUG");
+  }
+
+  /**
+   * We ask for a tarball without asking for package metadata (something npm client would never do), and it will
+   * result in tarball getting into NFC. Then we ask for package metadata and then again for tarball, and 2nd call
+   * should succeed, as metadata fetch should evict NFC.
+   */
+  @Test
+  public void cacheEvict() throws Exception {
+    // create a NPM Proxy repository that proxies mock NPM registry
+    NpmProxyRepository proxy = createNpmProxyRepository(testMethodName());
+
+    final File irrelevant = util.createTempFile();
+    final Location commonjs = Location.repositoryLocation(proxy.id(), "/commonjs");
+    final Location commonjs001Tar = Location.repositoryLocation(proxy.id(), "/commonjs/-/commonjs-0.0.1.tgz");
+
+    try {
+      content().download(commonjs001Tar, irrelevant);
+      fail("Nexus did not cache metadata, should not be able to get tarball");
+    }
+    catch (NexusClientNotFoundException e) {
+      // we expect this
+    }
+
+    // Fetch metadata, should evict NFC too
+    content().download(commonjs, irrelevant);
+
+    // now try again the tarball, should succeed
+    content().download(commonjs001Tar, irrelevant);
+
+    // sanity check: tarball is here, exists, and is not 0 sized
+    assertThat(irrelevant, FileMatchers.isFile());
+    assertThat(irrelevant, not(FileMatchers.sized(0l)));
+  }
+}


### PR DESCRIPTION
When npm proxy fetches metadata, evict the package path (`/packageName`) and all of it's children (tgz paths like `/packageName/-/packageName-1.0.tgz`) from NFC. More subtle solution would be to inspect metadata and expire only paths that does exists in metadata.

Issue
https://issues.sonatype.org/browse/NEXUS-8555
(also related to: https://issues.sonatype.org/browse/NEXUS-8570)

CI
http://bamboo.s/browse/NX-OSSF813