### PR TITLE
[NEXUS-8542] Remove create panels when sliding panels

### DIFF
--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/drilldown/Drilldown.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/drilldown/Drilldown.js
@@ -299,7 +299,14 @@ Ext.define('NX.view.drilldown.Drilldown', {
     var me = this,
       feature = me.up('nx-feature-content'),
       items = me.query('nx-drilldown-item'),
-      item = items[index];
+      item = items[index],
+      createContainer;
+
+    // Destroy any create wizard panels after current
+    for (var i = index + 1; i < items.length; ++i) {
+      createContainer = items[i].down('#create' + i);
+      createContainer.removeAll();
+    }
 
     if (item.el) {
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-8542

The problem is that editable conditions are based on the fact that there is only one form of a certain type active when the edit panel is shown. yet, the add panels are still there but hidden, so the fix will remove the ones after the current shown one.