### PR TITLE
NEXUS-8568: Fix for concurrent mod Ex

### DIFF
--- a/plugins/npm/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/service/internal/ProxyMetadataServiceImpl.java
+++ b/plugins/npm/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/service/internal/ProxyMetadataServiceImpl.java
@@ -94,7 +94,7 @@ public class ProxyMetadataServiceImpl
         registryRoot.getProperties().put(PROP_EXPIRED, Boolean.TRUE.toString());
         metadataStore.updatePackage(getNpmRepository(), registryRoot);
       }
-      return 0 < metadataStore.updatePackages(getNpmRepository(), null, new Function<PackageRoot, PackageRoot>()
+      int count = metadataStore.updatePackages(getNpmRepository(), null, new Function<PackageRoot, PackageRoot>()
       {
         @Override
         public PackageRoot apply(@Nullable final PackageRoot input) {
@@ -102,6 +102,8 @@ public class ProxyMetadataServiceImpl
           return input;
         }
       });
+      log.info("Expired registry root of {} with {} packages", getNpmRepository().getId(), count);
+      return count > 0;
     }
   }
 

--- a/plugins/npm/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/service/internal/orient/OrientMetadataStore.java
+++ b/plugins/npm/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/service/internal/orient/OrientMetadataStore.java
@@ -331,7 +331,6 @@ public class OrientMetadataStore
     final EntityHandler<PackageRoot> entityHandler = getHandlerFor(PackageRoot.class);
     int count = 0;
     try (ODatabaseDocumentTx db = db()) {
-      db.begin();
       final OSQLSynchQuery<ODocument> query = new OSQLSynchQuery<>(
           "select @rid as orid from " + entityHandler.getSchemaName() + " where repositoryId='" + repository.getId() +
               "' and @rid > ? limit 1000");
@@ -339,6 +338,7 @@ public class OrientMetadataStore
       List<ODocument> resultset = db.query(query, last);
       while (!resultset.isEmpty()) {
         try {
+          db.begin();
           for (ODocument d : resultset) {
             final ORID orid = d.field("orid", ORID.class);
             final ODocument npmDoc = db.load(orid);

--- a/plugins/npm/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/service/internal/orient/OrientMetadataStore.java
+++ b/plugins/npm/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/service/internal/orient/OrientMetadataStore.java
@@ -46,6 +46,7 @@ import com.orientechnologies.orient.core.command.OCommandOutputListener;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.db.OPartitionedDatabasePool;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import com.orientechnologies.orient.core.exception.OConcurrentModificationException;
 import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.metadata.schema.OType;
@@ -321,39 +322,45 @@ public class OrientMetadataStore
   }
 
   @Override
-  public int updatePackages(final NpmRepository repository, final Predicate<PackageRoot> predicate,
+  public int updatePackages(final NpmRepository repository,
+                            final Predicate<PackageRoot> predicate,
                             final Function<PackageRoot, PackageRoot> function)
   {
     checkNotNull(repository);
     checkNotNull(function);
     final EntityHandler<PackageRoot> entityHandler = getHandlerFor(PackageRoot.class);
+    int count = 0;
     try (ODatabaseDocumentTx db = db()) {
       db.begin();
-      try {
-        final OSQLSynchQuery<ODocument> query = new OSQLSynchQuery<>(
-            "select from " + entityHandler.getSchemaName() + " where repositoryId='" + repository.getId() +
-                "' and @rid > ? limit 1000");
-        ORID last = new ORecordId();
-        List<ODocument> resultset = db.query(query, last);
-        int count = 0;
-        while (!resultset.isEmpty()) {
-          for (ODocument doc : resultset) {
-            PackageRoot root = entityHandler.toEntity(doc);
+      final OSQLSynchQuery<ODocument> query = new OSQLSynchQuery<>(
+          "select @rid as orid from " + entityHandler.getSchemaName() + " where repositoryId='" + repository.getId() +
+              "' and @rid > ? limit 1000");
+      ORID last = new ORecordId();
+      List<ODocument> resultset = db.query(query, last);
+      while (!resultset.isEmpty()) {
+        try {
+          for (ODocument d : resultset) {
+            final ORID orid = d.field("orid", ORID.class);
+            final ODocument npmDoc = db.load(orid);
+            PackageRoot root = entityHandler.toEntity(npmDoc);
             if (predicate != null && !predicate.apply(root)) {
               continue;
             }
             root = function.apply(root);
-            db.save(entityHandler.toDocument(root, doc));
+            db.save(entityHandler.toDocument(root, npmDoc));
             count++;
           }
-          last = resultset.get(resultset.size() - 1).getIdentity();
+          last = resultset.get(resultset.size() - 1).field("orid", ORID.class);
+          db.commit();
           resultset = db.query(query, last);
         }
-        return count;
+        catch (OConcurrentModificationException e) {
+          // this leaves out 1000 documents unexpired
+          log.debug("Batch update failed on {}", repository, e);
+          return count;
+        }
       }
-      finally {
-        db.commit();
-      }
+      return count;
     }
   }
 

--- a/plugins/npm/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/service/internal/orient/OrientMetadataStore.java
+++ b/plugins/npm/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/service/internal/orient/OrientMetadataStore.java
@@ -342,6 +342,9 @@ public class OrientMetadataStore
           for (ODocument d : resultset) {
             final ORID orid = d.field("orid", ORID.class);
             final ODocument npmDoc = db.load(orid);
+            if (npmDoc == null) {
+              continue;
+            }
             PackageRoot root = entityHandler.toEntity(npmDoc);
             if (predicate != null && !predicate.apply(root)) {
               continue;

--- a/plugins/npm/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/service/internal/orient/OrientMetadataStore.java
+++ b/plugins/npm/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/service/internal/orient/OrientMetadataStore.java
@@ -357,9 +357,18 @@ public class OrientMetadataStore
           resultset = db.query(query, orid);
         }
         catch (OConcurrentModificationException e) {
-          // this leaves out 1000 documents unexpired
-          log.debug("Batch update failed on {}", repository, e);
           db.rollback();
+          final ODocument npmDoc = db.load(e.getRid());
+          if (npmDoc == null) {
+            // doc deleted, no way to load it up
+            log.info("Batch update failed on {} due to {}", repository, e.getMessage());
+          }
+          else {
+            // add package name to log
+            PackageRoot root = entityHandler.toEntity(npmDoc);
+            log.info("Batch update failed on {}/{} due to {}", repository, root.getName(), e.getMessage());
+          }
+
         }
       }
     }

--- a/plugins/npm/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/service/internal/orient/OrientMetadataStore.java
+++ b/plugins/npm/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/service/internal/orient/OrientMetadataStore.java
@@ -357,18 +357,9 @@ public class OrientMetadataStore
           resultset = db.query(query, orid);
         }
         catch (OConcurrentModificationException e) {
+          // this leaves out 1000 documents unexpired
+          log.debug("Batch update failed on {}", repository, e);
           db.rollback();
-          final ODocument npmDoc = db.load(e.getRid());
-          if (npmDoc == null) {
-            // doc deleted, no way to load it up
-            log.info("Batch update failed on {} due to {}", repository, e.getMessage());
-          }
-          else {
-            // add package name to log
-            PackageRoot root = entityHandler.toEntity(npmDoc);
-            log.info("Batch update failed on {}/{} due to {}", repository, root.getName(), e.getMessage());
-          }
-
         }
       }
     }

--- a/plugins/npm/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/service/internal/orient/OrientMetadataStore.java
+++ b/plugins/npm/nexus-npm-repository-plugin/src/main/java/com/bolyuba/nexus/plugin/npm/service/internal/orient/OrientMetadataStore.java
@@ -353,18 +353,17 @@ public class OrientMetadataStore
             db.save(entityHandler.toDocument(root, npmDoc));
             count++;
           }
-          last = resultset.get(resultset.size() - 1).field("orid", ORID.class);
           db.commit();
+          last = resultset.get(resultset.size() - 1).field("orid", ORID.class);
           resultset = db.query(query, last);
         }
         catch (OConcurrentModificationException e) {
           // this leaves out 1000 documents unexpired
           log.debug("Batch update failed on {}", repository, e);
-          return count;
         }
       }
-      return count;
     }
+    return count;
   }
 
   // ==


### PR DESCRIPTION
Two problems:
- if during expire caches task Orient throws OConcurrentModificationException on one proxy repository, it bubbles all way up and results in task failure, hence, all the potential subsequent members of expire caches task will not be processed.
- the TX was poorly written: the TX window was _covering all documents_ of a given proxy, and was loaded upfront (they became too easily stale).

Changes:
- narrow TX window to pages only
- handle OConcurrentModEx per page
- do not load ODocuments upfront, but only ORIDs, and load the actual document only before being updated, lowering the concurrent modification probability

These changes means that in repository if concurrent metadata modification does happen (it's still possible, but by way less possibility), only one page (1000) documents will left _not expired_, and the task will not fail, it will continue processing members.

Issue
https://issues.sonatype.org/browse/NEXUS-8568

CI
http://bamboo.s/browse/NX-OSSF818