### PR TITLE
NEXUS-8576 - Cannot submit tasks with advanced (cron) filled in

### DIFF
--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/TaskXO.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/TaskXO.groovy
@@ -13,6 +13,7 @@
 package org.sonatype.nexus.coreui
 
 import javax.validation.constraints.NotNull
+import javax.validation.constraints.Pattern
 
 import org.sonatype.nexus.validation.group.Create
 import org.sonatype.nexus.validation.group.Update
@@ -60,6 +61,11 @@ class TaskXO
 
   Date startDate
   Integer[] recurringDays
+  
+  @Pattern(
+      regexp = '^([[0-9]|\\-|,|\\*]+) ([[0-9]|\\-|,|\\*]+) ([[0-9]|\\-|,|\\*]+) (\\?|\\*|[[0-9]|\\-|,|/|L|W]+) (\\*|[JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|[0-9]|\\-|,]+) (\\*|\\?|[MON|TUE|WED|THU|FRI|SAT|SUN|[0-9]|\\-|,|/|L|W]+)( [[0-9]{4}|,]+)?$',
+      message = 'Invalid CRON expression'
+  )
   String cronExpression
 
   public interface Schedule

--- a/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/view/task/TaskSettingsForm.js
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/view/task/TaskSettingsForm.js
@@ -94,8 +94,8 @@ Ext.define('NX.coreui.view.task.TaskSettingsForm', {
     if (task.startDate) {
       task.startDate = task.startDate.toJSON();
     }
-    
-    if(task.schedule === 'advanced') {
+
+    if (task.schedule === 'advanced') {
       task.cronExpression = values.cronExpression;
     }
 

--- a/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/view/task/TaskSettingsForm.js
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/view/task/TaskSettingsForm.js
@@ -94,6 +94,10 @@ Ext.define('NX.coreui.view.task.TaskSettingsForm', {
     if (task.startDate) {
       task.startDate = task.startDate.toJSON();
     }
+    
+    if(task.schedule === 'advanced') {
+      task.cronExpression = values.cronExpression;
+    }
 
     return task;
   },


### PR DESCRIPTION
- include cronExpression in form submit
- ensure that rejected cronExpression is matched to the right field, otherwise it shows as a transient popup that is easy to miss

https://issues.sonatype.org/browse/NEXUS-8576
http://bamboo.s/browse/NX3-OSSF271-1

Regex validated at submit:
![screen shot 2015-05-08 at 4 52 23 pm](https://cloud.githubusercontent.com/assets/76356/7547476/befa5806-f5a2-11e4-9508-3ae231dfc397.png)

Quartz fails due to a logical constraint:
![screen shot 2015-05-08 at 4 52 35 pm](https://cloud.githubusercontent.com/assets/76356/7547479/cf71ca70-f5a2-11e4-87ba-b9acb58e4828.png)
