### PR TITLE
NEXUS-8637: Make nuget aware if redeploy attempts

### DIFF
--- a/plugins/basic/nexus-repository-nuget/src/main/java/com/sonatype/nexus/repository/nuget/internal/AbstractNugetHandler.java
+++ b/plugins/basic/nexus-repository-nuget/src/main/java/com/sonatype/nexus/repository/nuget/internal/AbstractNugetHandler.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import com.sonatype.nexus.repository.nuget.odata.ODataTemplates;
 
+import org.sonatype.nexus.repository.IllegalOperationException;
 import org.sonatype.nexus.repository.http.HttpStatus;
 import org.sonatype.nexus.repository.view.Context;
 import org.sonatype.nexus.repository.view.Handler;
@@ -48,8 +49,12 @@ abstract class AbstractNugetHandler
       log.debug("Invalid package being uploaded", e);
       return xmlErrorMessage(HttpStatus.BAD_REQUEST, e.getMessage());
     }
-    if (e instanceof IllegalArgumentException) {
+    else if (e instanceof IllegalArgumentException) {
       log.debug("Bad argument", e);
+      return xmlErrorMessage(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+    else if (e instanceof IllegalOperationException) {
+      log.warn("Illegal operation", e);
       return xmlErrorMessage(HttpStatus.BAD_REQUEST, e.getMessage());
     }
     else if (e instanceof IOException) {


### PR DESCRIPTION
And do not report it as internal error. ViewSerlvet change in original PR https://github.com/sonatype/nexus-oss/pull/1320 for NuGet is not enough (actually, is completely circumvented), as NuGet handles PUT requests in it's own handler along with XML error message creation for client.

Issue
https://issues.sonatype.org/browse/NEXUS-8637

CI
TBD