### PR TITLE
[NEXUS-8676] use FilenameUtils.getExtension in DefaultMimeSupport

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/mime/DefaultMimeSupport.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/mime/DefaultMimeSupport.java
@@ -31,6 +31,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Lists;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.detect.Detector;
 import org.apache.tika.io.TikaInputStream;
@@ -130,7 +131,7 @@ public class DefaultMimeSupport
 
   @Override
   public List<String> guessMimeTypesListFromPath(final String path) {
-    final String pathExtension = getExtension(path);
+    final String pathExtension = FilenameUtils.getExtension(path);
     try {
       return extensionToMimeTypeCache.get(pathExtension);
     }
@@ -187,19 +188,5 @@ public class DefaultMimeSupport
       mediaType = tikaConfig.getMediaTypeRegistry().getSupertype(mediaType);
     }
     return detected;
-  }
-
-  // ==
-
-  /**
-   * Copied and sanitized from MimeUtil2 to retain same behaviour for extension discovery, needed not only here,
-   * but also in {@link NexusMimeTypes} class.
-   */
-  public static String getExtension(final String fileName) {
-    if (fileName == null || fileName.length() == 0) {
-      return "";
-    }
-    int index = fileName.indexOf(".");
-    return index < 0 ? "" : fileName.substring(index + 1);
   }
 }

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/mime/NexusMimeTypes.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/mime/NexusMimeTypes.java
@@ -24,6 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,7 +130,7 @@ public class NexusMimeTypes
       if (extensions.containsKey(extension)) {
         return extensions.get(extension);
       }
-      extension = DefaultMimeSupport.getExtension(extension);
+      extension = FilenameUtils.getExtension(extension);
     }
     return null;
   }


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-8676
http://bamboo.s/browse/NX-OSSF889-2 :white_check_mark: 

Note that NX3 has already fixed this, as part of the general clean-up (see https://github.com/sonatype/nexus-oss/commit/3c758e36bcdcb03ff6f24d3a78af86f4d4235c0d#diff-79832a54d2ec998dffa7765a7556afa6L129)