### PR TITLE
[NEXUS-8694] Add patch for Chrome 43 submenu hover bug

### DIFF
--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/Ext/patch/Ticket_17866.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/Ext/patch/Ticket_17866.js
@@ -1,0 +1,36 @@
+// Fixes bug where hover on a submenu causes it to disappear
+//
+// NOTE: This is a bug specifically in Chrome v43. Once v44 is released, check to see if this is fixed.
+// https://www.sencha.com/forum/showthread.php?301116-Submenus-disappear-in-Chrome-43-beta
+//
+Ext.define('Ext.patch.Ticket_17866', {
+  override: 'Ext.menu.Menu',
+  onMouseLeave: function(e) {
+    var me = this;
+
+
+    // BEGIN FIX
+    var visibleSubmenu = false;
+    me.items.each(function(item) {
+      if(item.menu && item.menu.isVisible()) {
+        visibleSubmenu = true;
+      }
+    });
+    if(visibleSubmenu) {
+      //console.log('apply fix hide submenu');
+      return;
+    }
+    // END FIX
+
+
+    me.deactivateActiveItem();
+
+
+    if (me.disabled) {
+      return;
+    }
+
+
+    me.fireEvent('mouseleave', me, e);
+  }
+});

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/app/Application.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/app/Application.js
@@ -40,6 +40,7 @@ Ext.define('NX.app.Application', {
   uses: [
     // framework patches
     'Ext.patch.Ticket_15227',
+    'Ext.patch.Ticket_17866',
     'Ext.patch.Ticket_18960',
     'Ext.patch.Ticket_18964',
     'Ext.patch.Ticket_21425',


### PR DESCRIPTION
Issue: https://issues.sonatype.org/browse/NEXUS-8694

Note: This is a bug with Chrome 43 (released on May 17th). When Chrome 44 is released, we should reevaluate and remove the patch, if fixed.