### PR TITLE
Graceful handling of unfetched blobs

### DIFF
--- a/plugins/basic/nexus-repository-nuget/src/main/java/com/sonatype/nexus/repository/nuget/internal/NugetGalleryFacetImpl.java
+++ b/plugins/basic/nexus-repository-nuget/src/main/java/com/sonatype/nexus/repository/nuget/internal/NugetGalleryFacetImpl.java
@@ -31,6 +31,7 @@ import com.sonatype.nexus.repository.nuget.odata.ODataTemplates;
 import com.sonatype.nexus.repository.nuget.odata.ODataUtils;
 
 import org.sonatype.nexus.blobstore.api.Blob;
+import org.sonatype.nexus.blobstore.api.BlobRef;
 import org.sonatype.nexus.common.collect.NestedAttributesMap;
 import org.sonatype.nexus.common.hash.HashAlgorithm;
 import org.sonatype.nexus.common.io.TempStreamSupplier;
@@ -351,11 +352,17 @@ public class NugetGalleryFacetImpl
       }
       Asset asset = tx.firstAsset(component);
 
-      final Blob blob = tx.requireBlob(asset.requireBlobRef());
+      final BlobRef blobRef = asset.blobRef();
+      if (blobRef == null) {
+        return null;
+      }
+
+      final Blob blob = tx.requireBlob(blobRef);
       String contentType = asset.contentType();
 
       return new StreamPayload(
-          new InputStreamSupplier() {
+          new InputStreamSupplier()
+          {
             @Nonnull
             @Override
             public InputStream get() throws IOException {

--- a/plugins/basic/nexus-repository-nuget/src/test/java/com/sonatype/nexus/repository/nuget/internal/NugetGalleryFacetImplGetTest.java
+++ b/plugins/basic/nexus-repository-nuget/src/test/java/com/sonatype/nexus/repository/nuget/internal/NugetGalleryFacetImplGetTest.java
@@ -81,7 +81,7 @@ public class NugetGalleryFacetImplGetTest
     doReturn(component).when(galleryFacet).findComponent(tx, packageId, version);
     when(tx.firstAsset(component)).thenReturn(asset);
     when(asset.contentType()).thenReturn(contentType);
-    when(asset.requireBlobRef()).thenReturn(blobRef);
+    when(asset.blobRef()).thenReturn(blobRef);
     when(tx.requireBlob(eq(blobRef))).thenReturn(blob);
     when(blob.getInputStream()).thenReturn(blobStream);
 

--- a/plugins/basic/nexus-repository-nuget/src/test/java/com/sonatype/nexus/repository/nuget/internal/NugetGalleryFacetImplGetTest.java
+++ b/plugins/basic/nexus-repository-nuget/src/test/java/com/sonatype/nexus/repository/nuget/internal/NugetGalleryFacetImplGetTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -39,6 +40,22 @@ import static org.mockito.Mockito.when;
  */
 public class NugetGalleryFacetImplGetTest
 {
+  @Test
+  public void testGetNonexistentPackage() throws Exception {
+    final String version = "2.1.1";
+    final String packageId = "jQuery";
+
+    final NugetGalleryFacetImpl galleryFacet = spy(new NugetGalleryFacetImpl());
+
+    final StorageTx tx = mock(StorageTx.class);
+    doReturn(tx).when(galleryFacet).openStorageTx();
+    doReturn(null).when(galleryFacet).findComponent(tx, packageId, version);
+
+    final Payload payload = galleryFacet.get(packageId, version);
+
+    assertThat(payload, is(nullValue()));
+  }
+
   @Test
   public void testPayloadMadeFromBlob() throws Exception {
     final NugetGalleryFacetImpl galleryFacet = spy(new NugetGalleryFacetImpl());

--- a/testsuite/modern-testsuite/src/test/java/org/sonatype/nexus/testsuite/nuget/NugetProxyIT.java
+++ b/testsuite/modern-testsuite/src/test/java/org/sonatype/nexus/testsuite/nuget/NugetProxyIT.java
@@ -210,6 +210,21 @@ public class NugetProxyIT
   }
 
   @Test
+  public void downloadEntryThenPackage() throws Exception {
+    final String packageName = "SONATYPE.TEST";
+    final String version = "1.0";
+
+    final HttpResponse entry = nuget.entry(packageName, version);
+
+    assertThat(status(entry),is(HttpStatus.OK));
+
+    final HttpResponse response = nuget.packageContent(packageName, version);
+
+    assertThat(status(response), is(HttpStatus.OK));
+    assertThat(bytes(response), is(Files.toByteArray(resolveTestFile("SONATYPE.TEST.1.0.nupkg"))));
+  }
+
+  @Test
   public void downloadPackageBeforeEntry() throws Exception {
     final HttpResponse response = nuget.packageContent("SONATYPE.TEST", "1.0");
 


### PR DESCRIPTION
Discovered during testing of: https://issues.sonatype.org/browse/NEXUS-8611
NuGet proxies need to expect that sometimes assets will exist with no blobs.