### PR TITLE
NEXUS-8749 Nuget proxy mangling remote communication errors

### DIFF
--- a/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/http/HttpResponses.java
+++ b/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/http/HttpResponses.java
@@ -155,6 +155,16 @@ public class HttpResponses
     return serviceUnavailable(null);
   }
 
+  public static Response badGateway(final @Nullable String message) {
+    return new Response.Builder()
+        .status(Status.failure(BAD_GATEWAY, message))
+        .build();
+  }
+
+  public static Response badGateway() {
+    return badGateway(null);
+  }
+
   public static Response notImplemented(final @Nullable String message) {
     return new Response.Builder()
         .status(Status.failure(NOT_IMPLEMENTED, message))

--- a/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/proxy/ProxyFacetSupport.java
+++ b/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/proxy/ProxyFacetSupport.java
@@ -273,7 +273,7 @@ public abstract class ProxyFacetSupport
   protected abstract void indicateUpToDate(final Context context) throws IOException;
 
   /**
-   * Provide the relative URL to the
+   * Provide the relative URL of the content to the repository root.
    */
   protected abstract String getUrl(final @Nonnull Context context);
 

--- a/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/proxy/ProxyFacetSupport.java
+++ b/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/proxy/ProxyFacetSupport.java
@@ -273,7 +273,7 @@ public abstract class ProxyFacetSupport
   protected abstract void indicateUpToDate(final Context context) throws IOException;
 
   /**
-   * Provide the relative URL of the content to the repository root.
+   * Provide the URL of the content relative to the repository root.
    */
   protected abstract String getUrl(final @Nonnull Context context);
 

--- a/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/proxy/ProxyHandler.java
+++ b/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/proxy/ProxyHandler.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 
 import javax.annotation.Nonnull;
 
-import org.sonatype.nexus.repository.http.HttpMethods;
 import org.sonatype.nexus.repository.http.HttpResponses;
 import org.sonatype.nexus.repository.view.Context;
 import org.sonatype.nexus.repository.view.Handler;
@@ -53,7 +52,7 @@ public class ProxyHandler
       return HttpResponses.notFound();
     }
     catch (IOException e) {
-      return HttpResponses.serviceUnavailable();
+      return HttpResponses.badGateway();
     }
   }
 

--- a/plugins/basic/nexus-repository-nuget/src/main/java/com/sonatype/nexus/repository/nuget/internal/proxy/NugetProxyFacet.java
+++ b/plugins/basic/nexus-repository-nuget/src/main/java/com/sonatype/nexus/repository/nuget/internal/proxy/NugetProxyFacet.java
@@ -111,8 +111,10 @@ public class NugetProxyFacet
 
   @Override
   protected String getUrl(final @Nonnull Context context) {
-    // Unnecessary to implement this, as we override fetch in a way that doesn't use it
-    throw new UnsupportedOperationException();
+    // This is only implemented for error-reporting purposes. It returns the Nexus
+    // URL for the content, rather than the remote one, as these can differ.
+    final String[] coords = coords(context);
+    return coords[0] + "/" + coords[1];
   }
 
   private NugetGalleryFacet gallery() {

--- a/testsuite/modern-testsuite/src/test/java/org/sonatype/nexus/testsuite/nuget/NugetProxyIT.java
+++ b/testsuite/modern-testsuite/src/test/java/org/sonatype/nexus/testsuite/nuget/NugetProxyIT.java
@@ -30,7 +30,6 @@ import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
-
 import org.apache.http.HttpResponse;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -218,12 +217,27 @@ public class NugetProxyIT
 
     final HttpResponse entry = nuget.entry(packageName, version);
 
-    assertThat(status(entry),is(HttpStatus.OK));
+    assertThat(status(entry), is(HttpStatus.OK));
 
     final HttpResponse response = nuget.packageContent(packageName, version);
 
     assertThat(status(response), is(HttpStatus.OK));
     assertThat(bytes(response), is(Files.toByteArray(resolveTestFile("SONATYPE.TEST.1.0.nupkg"))));
+  }
+
+  @Test
+  public void downloadingPackageFromDeadRemoteServerTurnsInto404() throws Exception {
+    final String packageName = "SONATYPE.TEST";
+    final String version = "1.0";
+
+    final HttpResponse entry = nuget.entry(packageName, version);
+
+    assertThat(status(entry), is(HttpStatus.OK));
+
+    proxyServer.stop();
+
+    // Nexus has not yet cached the actual package content, so this should return 502
+    assertThat(status(nuget.packageContent(packageName, version)), is(HttpStatus.BAD_GATEWAY));
   }
 
   @Test


### PR DESCRIPTION
Two things fixed:
a) Nuget had no implementation for getUrl(), so constructing a message for IOException would itself throw an exception
b) When a proxy can't fetch an uncached artifact due to IOException, it now reports HTTP 502 (bad gateway) rather than 503 (service unavailable)