### PR TITLE
Bump to HttpClient 4.5

### DIFF
--- a/buildsupport/httpclient/pom.xml
+++ b/buildsupport/httpclient/pom.xml
@@ -33,7 +33,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.4.1</version>
+        <version>4.5</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -45,7 +45,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpmime</artifactId>
-        <version>4.4.1</version>
+        <version>4.5</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Bump to HttpClient 4.5 (client and mime is 4.5, httpcore remains 4.4.1).

Post M4

Release Notes of HttpClient 4.5
https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310360&version=12329460

CI
http://bamboo.s/browse/NX3-OSSF402