### PR TITLE
NEXUS-8791 base url manager detect url fix

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/internal/app/BaseUrlManagerImpl.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/internal/app/BaseUrlManagerImpl.java
@@ -97,20 +97,11 @@ public class BaseUrlManagerImpl
     // attempt to detect from HTTP request
     HttpServletRequest request = httpRequest();
     if (request != null) {
-      StringBuilder buff = new StringBuilder();
-      String requestUrl = request.getRequestURL().toString();
-      String pathInfo = request.getPathInfo();
-      if (!Strings.isNullOrEmpty(pathInfo)) {
-        requestUrl = requestUrl.substring(0, requestUrl.length() - pathInfo.length());
-      }
-
-      String servletPath = request.getServletPath();
-      if (!Strings.isNullOrEmpty(servletPath)) {
-        requestUrl = requestUrl.substring(0, requestUrl.length() - servletPath.length());
-      }
-      buff.append(requestUrl);
-
-      return buff.toString();
+      StringBuffer url = request.getRequestURL();
+      String uri = request.getRequestURI();
+      String ctx = request.getContextPath();
+      String base = url.substring(0, url.length() - uri.length() + ctx.length());
+      return base;
     }
 
     // no request in context, non-forced base-url

--- a/components/nexus-core/src/test/java/org/sonatype/nexus/internal/app/BaseUrlManagerImplTest.java
+++ b/components/nexus-core/src/test/java/org/sonatype/nexus/internal/app/BaseUrlManagerImplTest.java
@@ -1,0 +1,101 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2008-2015 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.internal.app;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.sonatype.sisu.litmus.testsupport.TestSupport;
+
+import org.junit.Before;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.mockito.Mockito.when;
+import com.google.inject.Provider;
+import org.junit.Test;
+import org.mockito.Mock;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link BaseUrlManagerImpl}
+ */
+public class BaseUrlManagerImplTest
+    extends TestSupport
+{
+  static final String NUGET_QUERY = "/repository/nuget.org-proxy/Packages(Id='jQuery',Version='2.1.4')";
+  static final String ENCODED_NUGET_QUERY = "/repository/nuget.org-proxy/Packages(Id=%27jQuery%27,Version=%272.1.4%27)";
+  static final String FAKE_URL = "http://example.com:1234/foo/bar";
+
+  @Mock
+  Provider<HttpServletRequest> requestProvider;
+
+  @Mock
+  HttpServletRequest request;
+
+  BaseUrlManagerImpl underTest;
+
+  @Before
+  public void setUp() {
+    underTest = new BaseUrlManagerImpl(requestProvider);
+  }
+
+  @Test
+  public void forceUrl() {
+    underTest.setForce(true);
+    underTest.setUrl(FAKE_URL);
+    assertThat(underTest.detectUrl(), equalTo(FAKE_URL));
+  }
+
+  @Test
+  public void noRequest() {
+    underTest.setUrl(FAKE_URL);
+
+    when(requestProvider.get()).thenReturn(null);
+
+    assertThat(underTest.detectUrl(), equalTo(FAKE_URL));
+  }
+
+  @Test
+  public void noBaseUrl() {
+    when(requestProvider.get()).thenReturn(null);
+
+    assertThat(underTest.detectUrl(), nullValue());
+  }
+
+  @Test
+  public void defaultContext() {
+    testNuGetQuery("http://localhost:8081", "");
+  }
+
+  @Test
+  public void nexusContext() {
+    testNuGetQuery("http://localhost:8081", "/nexus");
+  }
+
+  @Test
+  public void nexusFooBarBazContext() {
+    testNuGetQuery("http://localhost:8081", "/nexus/foo/bar/baz");
+  }
+
+  void testNuGetQuery(String protocolHostPort, String context) {
+    String expectedBaseUrl = protocolHostPort + context;
+
+    when(requestProvider.get()).thenReturn(request);
+    when(request.getRequestURL()).thenReturn(new StringBuffer(expectedBaseUrl + ENCODED_NUGET_QUERY));
+    when(request.getContextPath()).thenReturn(context);
+    when(request.getRequestURI()).thenReturn(context + ENCODED_NUGET_QUERY);
+    when(request.getServletPath()).thenReturn(NUGET_QUERY);
+
+    assertThat(underTest.detectUrl(), equalTo(expectedBaseUrl));
+  }
+}


### PR DESCRIPTION
Support encoded urls in base url detection.

Replaces: https://github.com/sonatype/nexus-oss/pull/1409

https://issues.sonatype.org/browse/NEXUS-8791