### PR TITLE
[NEXUS-8856] apply fix for HTTPCLIENT-1478 to NexusSSLConnectionSocketFactory

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/apachehttpclient/NexusSSLConnectionSocketFactory.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/apachehttpclient/NexusSSLConnectionSocketFactory.java
@@ -115,6 +115,9 @@ public class NexusSSLConnectionSocketFactory
       ((SSLSocketImpl) sock).setHost(host.getHostName());
     }
     try {
+      if (connectTimeout > 0 && sock.getSoTimeout() == 0) {
+        sock.setSoTimeout(connectTimeout);
+      }
       sock.connect(remoteAddress, connectTimeout);
     }
     catch (final IOException e) {


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-8823
https://issues.sonatype.org/browse/NEXUS-8856
http://bamboo.s/browse/NX-OSSF994-1 :white_check_mark: 

We have our own custom version of SSLConnectionSocketFactory which needs to pick up the same fix that was applied in https://issues.apache.org/jira/browse/HTTPCLIENT-1478

http://svn.apache.org/viewvc/httpcomponents/httpclient/branches/4.3.x/httpclient/src/main/java/org/apache/http/conn/ssl/SSLConnectionSocketFactory.java?r1=1560975&r2=1626784