### PR TITLE
NEXUS-8857 removed default in favor of covering all enum values

### DIFF
--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/TaskComponent.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/TaskComponent.groovy
@@ -210,11 +210,11 @@ class TaskComponent
             return "Blocked";
           case RunState.CANCELED:
             return "Cancelling";
-          default:
-            return 'Unknown running'
+          case RunState.STARTING:
+            return "Starting";
         }
-      default:
-        return 'Unknown'
+      case State.DONE:
+        return 'Done'
     }
   }
 


### PR DESCRIPTION
Removed the default cases in the task description function in favor of covering all the possible cases based on the enums.

https://issues.sonatype.org/browse/NEXUS-8857
http://bamboo.s/browse/NX3-OSSF455-1