### PR TITLE
[nexus-2.11.x] Update OrientDB to 2.0.11

### DIFF
--- a/plugins/npm/pom.xml
+++ b/plugins/npm/pom.xml
@@ -54,7 +54,7 @@
   </repositories>
 
   <properties>
-    <orientdb.version>2.0.9</orientdb.version>
+    <orientdb.version>2.0.11</orientdb.version>
 
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>


### PR DESCRIPTION
There isn't a specific issue that requires us to upgrade for our embedded use-case (and any change implies additional testing) but the following changes suggest we might want to consider upgrading:

https://github.com/orientechnologies/orientdb/issues?q=milestone%3A2.0.10
https://github.com/orientechnologies/orientdb/issues?q=milestone%3A2.0.11

http://bamboo.s/browse/NX-OSSF1010-1 :white_check_mark: 