### PR TITLE
Eliminate possible NPE in NuGet proxy

### DIFF
--- a/plugins/basic/nexus-repository-nuget/src/main/java/com/sonatype/nexus/repository/nuget/internal/proxy/NugetFeedFetcher.java
+++ b/plugins/basic/nexus-repository-nuget/src/main/java/com/sonatype/nexus/repository/nuget/internal/proxy/NugetFeedFetcher.java
@@ -41,6 +41,7 @@ import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.HttpClientUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -79,6 +80,12 @@ public class NugetFeedFetcher
     do {
       // download and cache results, following 'next' links if requested
       final Payload payload = getPayload(proxy, remoteUrl);
+
+      if (payload == null) {
+        // The request returned no XML. Return whatever the splicer learned on the last correctly processed
+        // page of XML.
+        return splicer.getCount();
+      }
 
       remoteUrl = null;
       try (InputStream is = payload.openInputStream()) {
@@ -150,6 +157,7 @@ public class NugetFeedFetcher
     else {
       log.warn("Status code {} contacting {}", status.getStatusCode(), uri);
     }
+    HttpClientUtils.closeQuietly(response);
     return null;
   }
 }

--- a/plugins/basic/nexus-repository-nuget/src/main/java/com/sonatype/nexus/repository/nuget/internal/proxy/NugetProxyGalleryFacet.java
+++ b/plugins/basic/nexus-repository-nuget/src/main/java/com/sonatype/nexus/repository/nuget/internal/proxy/NugetProxyGalleryFacet.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -309,6 +310,7 @@ public class NugetProxyGalleryFacet
       {
         @Override
         public Integer call() throws Exception {
+          // The count cache shouldn't contain nulls, so return 0 if we fail to get a result from the feed
           return firstNonNull(fetcher.cachePackageFeed(remote, nugetQuery, false, new ODataConsumer()
           {
             @Override


### PR DESCRIPTION
When an upstream repository returns a non-200 status code, the Nuget proxy can throw an NPE internally and potentially leak http connections.