### PR TITLE
Use <if debug> to strip out ?debug classes

### DIFF
--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/app/PluginConfig.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/app/PluginConfig.js
@@ -53,6 +53,7 @@ Ext.define('NX.app.PluginConfig', {
       }
     },
 
+    //<if debug>
     // dev controllers (visible when ?debug and rapture capability debugAllowed = true)
     {
       id: 'dev.Conditions',
@@ -78,5 +79,6 @@ Ext.define('NX.app.PluginConfig', {
         return NX.app.Application.debugMode;
       }
     }
+    //</if>
   ]
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/controller/dev/Conditions.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/controller/dev/Conditions.js
@@ -19,6 +19,8 @@
  */
 Ext.define('NX.controller.dev.Conditions', {
   extend: 'Ext.app.Controller',
+
+  //<if debug>
   requires: [
     'Ext.util.Filter'
   ],
@@ -155,5 +157,5 @@ Ext.define('NX.controller.dev.Conditions', {
       store.filter();
     }
   }
-
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/controller/dev/Developer.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/controller/dev/Developer.js
@@ -19,6 +19,8 @@
  */
 Ext.define('NX.controller.dev.Developer', {
   extend: 'Ext.app.Controller',
+
+  //<if debug>
   requires: [
     'NX.State',
     'NX.Messages'
@@ -193,5 +195,5 @@ Ext.define('NX.controller.dev.Developer', {
   toggleUnsupportedBrowser: function() {
     NX.State.setBrowserSupported(!NX.State.isBrowserSupported());
   }
-
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/controller/dev/Permissions.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/controller/dev/Permissions.js
@@ -19,6 +19,8 @@
  */
 Ext.define('NX.controller.dev.Permissions', {
   extend: 'Ext.app.Controller',
+
+  //<if debug>
   requires: [
     'NX.Permissions'
   ],
@@ -138,5 +140,5 @@ Ext.define('NX.controller.dev.Permissions', {
 
     deleteButton.setDisabled(!records.length);
   }
-
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/controller/dev/Stores.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/controller/dev/Stores.js
@@ -19,6 +19,8 @@
  */
 Ext.define('NX.controller.dev.Stores', {
   extend: 'Ext.app.Controller',
+
+  //<if debug>
   requires: [
     'Ext.data.StoreManager'
   ],
@@ -104,5 +106,5 @@ Ext.define('NX.controller.dev.Stores', {
       grid.getStore().removeAll();
     }
   }
-
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/Main.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/Main.js
@@ -66,6 +66,7 @@ Ext.define('NX.view.Main', {
       hidden: false
     },
 
+    //<if debug>
     {
       xtype: 'nx-dev-panel',
       region: 'south',
@@ -80,6 +81,7 @@ Ext.define('NX.view.Main', {
       // default to hidden, only show if debug enabled
       hidden: true
     }
+    //</if>
   ],
 
   initComponent: function () {

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/Conditions.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/Conditions.js
@@ -21,6 +21,7 @@ Ext.define('NX.view.dev.Conditions', {
   extend: 'Ext.grid.Panel',
   alias: 'widget.nx-dev-conditions',
 
+  //<if debug>
   title: 'Conditions',
   store: 'NX.store.dev.Condition',
   emptyText: 'No condition',
@@ -52,5 +53,5 @@ Ext.define('NX.view.dev.Conditions', {
     { xtype: 'checkbox', itemId: 'showSatisfied', boxLabel: 'Show Satisfied', value: true },
     { xtype: 'checkbox', itemId: 'showUnsatisfied', boxLabel: 'Show Unsatisfied', value: true }
   ]
-
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/Features.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/Features.js
@@ -21,6 +21,7 @@ Ext.define('NX.view.dev.Features', {
   extend: 'Ext.grid.Panel',
   alias: 'widget.nx-dev-features',
 
+  //<if debug>
   title: 'Features',
   store: 'Feature',
   emptyText: 'No features',
@@ -57,4 +58,5 @@ Ext.define('NX.view.dev.Features', {
     deferEmptyText: false,
     markDirty: false
   }
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/Icons.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/Icons.js
@@ -21,6 +21,7 @@ Ext.define('NX.view.dev.Icons', {
   extend: 'Ext.grid.Panel',
   alias: 'widget.nx-dev-icons',
 
+  //<if debug>
   title: 'Icons',
   store: 'Icon',
   emptyText: 'No icons',
@@ -51,5 +52,5 @@ Ext.define('NX.view.dev.Icons', {
     { ptype: 'rowediting', clicksToEdit: 1 },
     'gridfilterbox'
   ]
-
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/Messages.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/Messages.js
@@ -21,6 +21,7 @@ Ext.define('NX.view.dev.Messages', {
   extend: 'Ext.grid.Panel',
   alias: 'widget.nx-dev-messages',
 
+  //<if debug>
   title: 'Messages',
   store: 'Message',
   emptyText: 'No messages',
@@ -47,5 +48,5 @@ Ext.define('NX.view.dev.Messages', {
     { ptype: 'rowediting', clicksToEdit: 1 },
     'gridfilterbox'
   ]
-
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/Panel.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/Panel.js
@@ -19,6 +19,8 @@
  */
 Ext.define('NX.view.dev.Panel', {
   extend: 'Ext.panel.Panel',
+
+  //<if debug>
   requires: [
     'NX.view.dev.Styles'
   ],
@@ -50,4 +52,5 @@ Ext.define('NX.view.dev.Panel', {
       { xtype: 'nx-dev-stores' }
     ]
   }
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/Permissions.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/Permissions.js
@@ -19,6 +19,8 @@
  */
 Ext.define('NX.view.dev.Permissions', {
   extend: 'Ext.grid.Panel',
+
+  //<if debug>
   requires: [
     'NX.Permissions'
   ],
@@ -58,4 +60,5 @@ Ext.define('NX.view.dev.Permissions', {
     { xtype: 'button', text: 'Add', action: 'add' },
     { xtype: 'button', text: 'Delete', action: 'delete', disabled: true }
   ]
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/State.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/State.js
@@ -21,6 +21,7 @@ Ext.define('NX.view.dev.State', {
   extend: 'Ext.grid.Panel',
   alias: 'widget.nx-dev-state',
 
+  //<if debug>
   title: 'State',
   store: 'State',
   emptyText: 'No values',
@@ -37,4 +38,5 @@ Ext.define('NX.view.dev.State', {
       }
     }
   ]
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/Stores.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/Stores.js
@@ -20,6 +20,8 @@
 Ext.define('NX.view.dev.Stores', {
   extend: 'Ext.panel.Panel',
   alias: 'widget.nx-dev-stores',
+
+  //<if debug>
   requires: [
     'Ext.data.Store'
   ],
@@ -87,5 +89,5 @@ Ext.define('NX.view.dev.Stores', {
 
     me.callParent();
   }
-
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/Styles.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/Styles.js
@@ -20,6 +20,8 @@
 Ext.define('NX.view.dev.Styles', {
   extend: 'Ext.panel.Panel',
   alias: 'widget.nx-dev-styles',
+
+  //<if debug>
   requires: [
     'NX.view.dev.styles.Header',
     'NX.view.dev.styles.Colors',
@@ -88,4 +90,5 @@ Ext.define('NX.view.dev.Styles', {
 
     me.callParent();
   }
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/Tests.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/Tests.js
@@ -21,6 +21,7 @@ Ext.define('NX.view.dev.Tests', {
   extend: 'Ext.panel.Panel',
   alias: 'widget.nx-dev-tests',
 
+  //<if debug>
   title: 'Tests',
 
   layout: {
@@ -35,4 +36,5 @@ Ext.define('NX.view.dev.Tests', {
     { xtype: 'button', text: 'message types', action: 'testMessages' },
     { xtype: 'button', text: 'toggle unsupported browser', action: 'toggleUnsupportedBrowser'}
   ]
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Buttons.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Buttons.js
@@ -19,6 +19,8 @@
  */
 Ext.define('NX.view.dev.styles.Buttons', {
   extend: 'NX.view.dev.styles.StyleSection',
+
+  //<if debug>
   requires: [
     'Ext.XTemplate'
   ],
@@ -105,4 +107,6 @@ Ext.define('NX.view.dev.styles.Buttons', {
 
     me.callParent();
   }
+  //</if>
+
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Colors.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Colors.js
@@ -19,6 +19,8 @@
  */
 Ext.define('NX.view.dev.styles.Colors', {
   extend: 'NX.view.dev.styles.StyleSection',
+
+  //<if debug>
   requires: [
     'Ext.XTemplate'
   ],
@@ -194,4 +196,5 @@ Ext.define('NX.view.dev.styles.Colors', {
 
     me.callParent();
   }
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Fonts.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Fonts.js
@@ -19,6 +19,8 @@
  */
 Ext.define('NX.view.dev.styles.Fonts', {
   extend: 'NX.view.dev.styles.StyleSection',
+
+  //<if debug>
   requires: [
     'Ext.XTemplate'
   ],
@@ -141,4 +143,5 @@ Ext.define('NX.view.dev.styles.Fonts', {
 
     me.callParent();
   }
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Forms.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Forms.js
@@ -20,6 +20,7 @@
 Ext.define('NX.view.dev.styles.Forms', {
   extend: 'NX.view.dev.styles.StyleSection',
 
+  //<if debug>
   title: 'Forms',
   layout: {
     type: 'hbox',
@@ -211,4 +212,5 @@ Ext.define('NX.view.dev.styles.Forms', {
 
     me.callParent();
   }
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Grids.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Grids.js
@@ -19,6 +19,8 @@
  */
 Ext.define('NX.view.dev.styles.Grids', {
   extend: 'NX.view.dev.styles.StyleSection',
+
+  //<if debug>
   requires: [
     'Ext.data.ArrayStore'
   ],
@@ -59,4 +61,5 @@ Ext.define('NX.view.dev.styles.Grids', {
 
     me.callParent();
   }
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Header.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Header.js
@@ -19,6 +19,8 @@
  */
 Ext.define('NX.view.dev.styles.Header', {
   extend: 'NX.view.dev.styles.StyleSection',
+
+  //<if debug>
   requires: [
     'Ext.XTemplate',
     'NX.State',
@@ -190,4 +192,5 @@ Ext.define('NX.view.dev.styles.Header', {
 
     me.callParent();
   }
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Menus.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Menus.js
@@ -20,6 +20,7 @@
 Ext.define('NX.view.dev.styles.Menus', {
   extend: 'NX.view.dev.styles.StyleSection',
 
+  //<if debug>
   title: 'Menus',
   layout: {
     type: 'hbox',
@@ -61,4 +62,5 @@ Ext.define('NX.view.dev.styles.Menus', {
 
     me.callParent();
   }
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Messages.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Messages.js
@@ -19,6 +19,8 @@
  */
 Ext.define('NX.view.dev.styles.Messages', {
   extend: 'NX.view.dev.styles.StyleSection',
+
+  //<if debug>
   requires: [
     'NX.Icons'
   ],
@@ -64,4 +66,5 @@ Ext.define('NX.view.dev.styles.Messages', {
 
     me.callParent();
   }
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Modals.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Modals.js
@@ -19,6 +19,8 @@
  */
 Ext.define('NX.view.dev.styles.Modals', {
   extend: 'NX.view.dev.styles.StyleSection',
+
+  //<if debug>
   requires: [
     'NX.I18n'
   ],
@@ -122,4 +124,5 @@ Ext.define('NX.view.dev.styles.Modals', {
 
     me.callParent();
   }
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Other.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Other.js
@@ -20,6 +20,7 @@
 Ext.define('NX.view.dev.styles.Other', {
   extend: 'NX.view.dev.styles.StyleSection',
 
+  //<if debug>
   title: 'Other',
   layout: {
     type: 'vbox',
@@ -57,4 +58,5 @@ Ext.define('NX.view.dev.styles.Other', {
 
     me.callParent();
   }
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Panels.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Panels.js
@@ -20,6 +20,7 @@
 Ext.define('NX.view.dev.styles.Panels', {
   extend: 'NX.view.dev.styles.StyleSection',
 
+  //<if debug>
   title: 'Panels',
 
   layout: {
@@ -82,4 +83,5 @@ Ext.define('NX.view.dev.styles.Panels', {
 
     me.callParent();
   }
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Pickers.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Pickers.js
@@ -19,6 +19,8 @@
  */
 Ext.define('NX.view.dev.styles.Pickers', {
   extend: 'NX.view.dev.styles.StyleSection',
+
+  //<if debug>
   requires: [
     'Ext.data.ArrayStore'
   ],
@@ -60,4 +62,5 @@ Ext.define('NX.view.dev.styles.Pickers', {
 
     me.callParent();
   }
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/StyleSection.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/StyleSection.js
@@ -20,6 +20,7 @@
 Ext.define('NX.view.dev.styles.StyleSection', {
   extend: 'Ext.panel.Panel',
 
+  //<if debug>
   ui: 'nx-light',
   bodyPadding: '5px 5px 5px 5px',
 
@@ -54,4 +55,5 @@ Ext.define('NX.view.dev.styles.StyleSection', {
     }
     return obj;
   }
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Tabs.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Tabs.js
@@ -20,6 +20,7 @@
 Ext.define('NX.view.dev.styles.Tabs', {
   extend: 'NX.view.dev.styles.StyleSection',
 
+  //<if debug>
   title: 'Tabs',
   layout: {
     type: 'vbox',
@@ -70,4 +71,5 @@ Ext.define('NX.view.dev.styles.Tabs', {
 
     me.callParent();
   }
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Toolbars.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Toolbars.js
@@ -20,6 +20,7 @@
 Ext.define('NX.view.dev.styles.Toolbars', {
   extend: 'NX.view.dev.styles.StyleSection',
 
+  //<if debug>
   title: 'Toolbars',
 
   /**
@@ -104,4 +105,5 @@ Ext.define('NX.view.dev.styles.Toolbars', {
 
     me.callParent();
   }
+  //</if>
 });

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Tooltips.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/dev/styles/Tooltips.js
@@ -20,6 +20,7 @@
 Ext.define('NX.view.dev.styles.Tooltips', {
   extend: 'NX.view.dev.styles.StyleSection',
 
+  //<if debug>
   title: 'Tooltips',
 
   /**
@@ -34,4 +35,5 @@ Ext.define('NX.view.dev.styles.Tooltips', {
 
     me.callParent();
   }
+  //</if>
 });


### PR DESCRIPTION
Reduces size of nexus-rapture-plugin-prod.js by ~30k

Could probably reduce further by omitting the classes completely, but I'm not sure how the extjs-maven-plugin will behave if the entire class is `//<if debug>`'d out, but worth testing.  For now though I only stripped out the meat between core class (and extends) defs.

Resulting js does leave a lot of dangling ',' but thats probably okay, though if stripping out entire classes work that will (mostly) go away.