### PR TITLE
Missing Ext.clone causing memory leaks with drilldown

### DIFF
--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/controller/Content.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/controller/Content.js
@@ -80,7 +80,7 @@ Ext.define('NX.controller.Content', {
     });
 
     // remove the current contents
-    content.removeAll();
+    content.removeAll(true);
 
     // Hide the breadcrumb
     content.showRoot();

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/drilldown/Details.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/view/drilldown/Details.js
@@ -61,7 +61,7 @@ Ext.define('NX.view.drilldown.Details', {
         activeTab: 0,
         layoutOnTabChange: true,
         flex: 1,
-        items: me.tabs
+        items: Ext.clone(me.tabs)
       }
     ];
 


### PR DESCRIPTION
Multiple components with references to the same object prevented that object from being destroyed and removed from the DOM.

Fixes: http://screencast.com/t/km3hvxPpB5C