### PR TITLE
Removes redundant summary title from capabilities

### DIFF
--- a/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/app/PluginStrings.js
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/app/PluginStrings.js
@@ -698,7 +698,6 @@ Ext.define('NX.coreui.app.PluginStrings', {
     Capability_CapabilitySummary_Title: 'Summary',
     Capability_CapabilitySettings_Title: 'Settings',
     Capability_CapabilitySettingsForm_Enabled_FieldLabel: 'Enable this capability',
-    Capability_CapabilitySummary_Summary_Title: 'Summary',
     Capability_CapabilitySummary_Status_Title: 'Status',
     Capability_CapabilitySummary_About_Title: 'About',
     Capability_CapabilitySummary_Notes_Title: 'Notes',

--- a/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/view/capability/CapabilitySummary.js
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/view/capability/CapabilitySummary.js
@@ -48,7 +48,6 @@ Ext.define('NX.coreui.view.capability.CapabilitySummary', {
           ui: 'nx-subsection',
           itemId: 'nx-coreui-capability-summary-subsection',
           frame: true,
-          title: NX.I18n.get('Capability_CapabilitySummary_Summary_Title'),
           layout: 'column',
           weight: 10,
           items: [


### PR DESCRIPTION
Before:
![capabilities - sonatype nexus 2015-06-29 16-00-54](https://cloud.githubusercontent.com/assets/186715/8417132/83fb18fe-1e78-11e5-89f4-7229c01d55a0.png)

After:
![capabilities - sonatype nexus 2015-06-29 16-03-15](https://cloud.githubusercontent.com/assets/186715/8417134/883845b8-1e78-11e5-9b6d-d1dd613ee3b2.png)
