### PR TITLE
NEXUS-8913 add elapsed time to request log

### DIFF
--- a/assemblies/nexus-bundle-template/src/main/resources/content/conf/logback-access.xml
+++ b/assemblies/nexus-bundle-template/src/main/resources/content/conf/logback-access.xml
@@ -19,7 +19,7 @@
     <File>${nexus-work}/logs/request.log</File>
     <Append>true</Append>
     <encoder class="org.sonatype.nexus.bootstrap.log.AccessPatternLayoutEncoder">
-      <pattern>common</pattern>
+      <pattern>%clientHost %l %user [%date] "%requestURL" %statusCode %bytesSent %elapsedTime</pattern>
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <fileNamePattern>${nexus-work}/logs/request.log.%d{yyyy-MM-dd}.gz</fileNamePattern>


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-8913

common format + elapsedTime

made the pattern tokens verbose to avoid the inevitable browsing of logback-access docs or explaining to end user what the single letter tokens mean

WIP because not officially in a sprint yet