### PR TITLE
NEXUS-8913 add elapsed time to request log

### DIFF
--- a/assemblies/nexus-base-template/src/main/resources/overlay/etc/logback-access.xml
+++ b/assemblies/nexus-base-template/src/main/resources/overlay/etc/logback-access.xml
@@ -4,7 +4,7 @@
     <File>${nexus-work}/log/request.log</File>
     <Append>true</Append>
     <encoder class="org.sonatype.nexus.pax.logging.AccessPatternLayoutEncoder">
-      <pattern>common</pattern>
+      <pattern>%clientHost %l %user [%date] "%requestURL" %statusCode %bytesSent %elapsedTime</pattern>
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <fileNamePattern>${nexus-work}/log/request.log.%d{yyyy-MM-dd}.gz</fileNamePattern>


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-8913
common format + elapsedTime

made the pattern tokens verbose to avoid the inevitable browsing of logback-access docs or explaining to end user what the single letter tokens mean

WIP because not officially in a sprint yet

https://github.com/sonatype/nexus-oss/pull/1492
