### PR TITLE
Add NX.Assert and support for //<if assert> omission

### DIFF
--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -36,6 +36,7 @@
     -->
     <extjs.omit>true</extjs.omit>
     <extjs.omit.debug>true</extjs.omit.debug>
+    <extjs.omit.assert>true</extjs.omit.assert>
     <maven.yuicompressor.nomunge>false</maven.yuicompressor.nomunge>
     <maven.yuicompressor.nominify>false</maven.yuicompressor.nominify>
     <maven.yuicompressor.disableOptimizations>false</maven.yuicompressor.disableOptimizations>
@@ -264,6 +265,7 @@
                 <outputFile>${project.build.outputDirectory}/static/rapture/${project.artifactId}-debug.js</outputFile>
                 <omitFlags>
                   <debug>${extjs.omit.debug}</debug>
+                  <assert>${extjs.omit.assert}</assert>
                 </omitFlags>
               </configuration>
             </execution>

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/Assert.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/Assert.js
@@ -10,7 +10,7 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
-/*global Ext*/
+/*global Ext, NX*/
 
 /**
  * Assertion helper.

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/Assert.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/Assert.js
@@ -1,0 +1,52 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2008-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+/*global Ext*/
+
+/**
+ * Assertion helper.
+ *
+ * @since 3.0
+ */
+Ext.define('NX.Assert', {
+  singleton: true,
+  requires: [
+    'NX.Log'
+  ],
+
+  /**
+   * Set to true to disable all assertions.
+   *
+   * @public
+   * @property {Boolean}
+   */
+  disable: false,
+
+  /**
+   * @public
+   * @param {Boolean} expression
+   * @param {String...} message
+   */
+  assert: function() {
+    //<if assert>
+    if (this.disable) {
+      return;
+    }
+    var args = Array.prototype.slice.call(arguments),
+        expression = args.shift();
+    if (!expression) {
+      args.unshift('Assertion failure:');
+      NX.Log.error.apply(NX.Log, args);
+    }
+    //</if>
+  }
+});

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/Permissions.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/Permissions.js
@@ -20,6 +20,7 @@
 Ext.define('NX.Permissions', {
   singleton: true,
   requires: [
+    'NX.Assert',
     'NX.util.Array'
   ],
   mixins: {
@@ -91,10 +92,9 @@ Ext.define('NX.Permissions', {
     var me = this,
         hasPermission = false;
 
-    // HACK: for now complain if we see 'undefined' in permission string
-    if (expectedPermission.search('undefined') !== -1) {
-      me.logError('Invalid permission check:', expectedPermission);
-    }
+    //<if assert>
+    NX.Assert.assert(expectedPermission.search('undefined') === -1, 'Invalid permission check:', expectedPermission);
+    //</if>
 
     // short-circuit if permissions are not installed
     if (!me.available()) {


### PR DESCRIPTION
related: https://github.com/sonatype/nexus-pro/pull/567

will log an error if boolean expression doesn't eval to true, not throwing exceptions as that messes up the entire app.

adds a omission flag to compile this out of the app.