### PR TITLE
Make Message windowOptions available for internal customization

### DIFF
--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/controller/Message.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/controller/Message.js
@@ -150,6 +150,17 @@ Ext.define('NX.controller.Message', {
   },
 
   /**
+   * Internal customization of message window options.
+   * At the moment, mainly intended for use by functional tests that need to
+   * override default settings.
+   *
+   * @private
+   * @property {Object}
+   */
+  windowOptions: {
+  },
+
+  /**
    * @public
    */
   addMessage: function (message) {
@@ -166,11 +177,12 @@ Ext.define('NX.controller.Message', {
     store.insert(0, message);
 
     // show transient message notification
-    me.getView('message.Notification').create({
+    var cfg = Ext.clone(me.windowOptions);
+    me.getView('message.Notification').create(Ext.apply(cfg, {
       ui: 'nx-message-' + message.type,
       iconCls: NX.Icons.cls('message-' + message.type, 'x16'),
       title: Ext.String.capitalize(message.type),
       html: message.text
-    });
+    }));
   }
 });


### PR DESCRIPTION
Mostly so functional tests can do something like the following to control the timings associated with message windows.
```
  Ext.merge(t.controller('Message').windowOptions, {
    slideInDuration: 200,
    slideBackDuration: 200,
    autoCloseDelay: 300,
  });
```