### PR TITLE
Add rapture app ready event and other siesta-js refinements

### DIFF
--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/app/Application.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/app/Application.js
@@ -149,6 +149,15 @@ Ext.define('NX.app.Application', {
   },
 
   /**
+   * Flag to indicate that app is ready.
+   *
+   * @public
+   * @property {Boolean}
+   * @readonly
+   */
+  ready: false,
+
+  /**
    * @override
    * @param {NX.app.Application} app this class
    */
@@ -294,7 +303,7 @@ Ext.define('NX.app.Application', {
    * @public
    */
   start: function () {
-    var me = this, hideMask;
+    var me = this, becomeReady;
 
     //<if debug>
     me.logInfo('Starting');
@@ -311,15 +320,19 @@ Ext.define('NX.app.Application', {
       }
     });
 
-    // hide the loading mask after we have loaded
-    hideMask = function () {
+    becomeReady = function () {
+      // hide the loading mask after we have loaded
       Ext.get('loading').remove();
       Ext.fly('loading-mask').animate({ opacity: 0, remove: true });
+
+      // mark app as ready
+      me.logInfo('Ready');
+      me.ready = true;
     };
 
     // FIXME: Need a better way to know when the UI is actually rendered so we can hide the mask
     // HACK: for now increasing delay slightly to cope with longer loading times
-    Ext.defer(hideMask, 500);
+    Ext.defer(becomeReady, 500);
   },
 
   /**

--- a/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/app/Loader.js
+++ b/plugins/rapture/nexus-rapture-plugin/src/main/resources/static/rapture/NX/app/Loader.js
@@ -89,7 +89,7 @@ Ext.define('NX.app.Loader', {
     App = Ext.ClassManager.get('NX.app.Application');
     Ext.onReady(function () {
       //<if debug>
-      me.logDebug('Received ready event');
+      me.logDebug('Received Ext.ready event');
       //</if>
 
       Ext.app.Application.instance = new App({

--- a/testsuite/functional-testsuite/src/test/ft-resources/testsuite-oss/harness.js
+++ b/testsuite/functional-testsuite/src/test/ft-resources/testsuite-oss/harness.js
@@ -21,6 +21,7 @@ NX.TestHarness.start(
         {
           group: 'UT',
           hostPageUrl: undefined,
+          waitForNxAppReady: false,
           preload: [
             NX.TestHarness.resource('static/rapture/baseapp-{mode}.js'),
             NX.TestHarness.resource('static/rapture/extdirect-{mode}.js'),
@@ -67,7 +68,6 @@ NX.TestHarness.start(
         }
       ]
     },
-
 
     {
       group: 'Security',

--- a/testsupport/nexus-siestajs-testsupport/src/main/resources/ft-overlay/testsuite-lib/NX/TestClass.js
+++ b/testsupport/nexus-siestajs-testsupport/src/main/resources/ft-overlay/testsuite-lib/NX/TestClass.js
@@ -56,7 +56,9 @@ Class('NX.TestClass', {
           };
         }
 
+        // FIXME: remove this, or change level once this is proven to function
         console.error('NX application ready:', this.global.NX.application.ready);
+
         if (!this.global.NX.application.ready) {
           return {
             ready: false,

--- a/testsupport/nexus-siestajs-testsupport/src/main/resources/ft-overlay/testsuite-lib/NX/TestClass.js
+++ b/testsupport/nexus-siestajs-testsupport/src/main/resources/ft-overlay/testsuite-lib/NX/TestClass.js
@@ -56,8 +56,7 @@ Class('NX.TestClass', {
           };
         }
 
-        // FIXME: remove this, or change level once this is proven to function
-        console.error('NX application ready:', this.global.NX.application.ready);
+        console.info('NX application ready:', this.global.NX.application.ready);
 
         if (!this.global.NX.application.ready) {
           return {

--- a/testsupport/nexus-siestajs-testsupport/src/main/resources/ft-overlay/testsuite-lib/NX/TestClass.js
+++ b/testsupport/nexus-siestajs-testsupport/src/main/resources/ft-overlay/testsuite-lib/NX/TestClass.js
@@ -249,5 +249,32 @@ Class('NX.TestClass', {
         }
       }
     }
+  },
+
+  override: {
+    /**
+     * Custom isReady() to cope with rapture application bootstrap.
+     *
+     * @override
+     */
+    isReady: function () {
+      var result = this.SUPERARG(arguments);
+      if (!result.ready) {
+        return result;
+      }
+
+      console.error('NX application ready:', this.global.NX.application.ready);
+      if (!this.global.NX.application.ready) {
+        return {
+          ready: false,
+          reason: 'NX application is not ready'
+        }
+      }
+      else {
+        return {
+          ready: true
+        }
+      }
+    }
   }
 });

--- a/testsupport/nexus-siestajs-testsupport/src/main/resources/ft-overlay/testsuite-lib/NX/TestHarness.js
+++ b/testsupport/nexus-siestajs-testsupport/src/main/resources/ft-overlay/testsuite-lib/NX/TestHarness.js
@@ -22,25 +22,53 @@ Class('NX.TestHarness', {
 
   my: {
     has: {
-      appMode: 'prod'
+      /**
+       * @private
+       * @property {String}
+       */
+      appMode: 'prod',
+
+      /**
+       * Wait for {@link NX.app.Application#ready} to become true.
+       *
+       * @cfg {Boolean}
+       */
+      waitForNxAppReady: true,
+
+      /**
+       * default describe() timeout after 5 minutes.
+       *
+       * @cfg {Number}
+       */
+      describeTimeout: 300000,
+
+      /**
+       * default it() timeout after 30 seconds.
+       *
+       * @cfg {Number}
+       */
+      itTimeout: 30000
     },
 
     methods: {
+      /**
+       * @override
+       */
       configure: function (config) {
         var debug = window.location.href.search("[?&]debug") > -1;
-        console.log('Debug: ' + debug);
+        console.log('Debug:', debug);
 
         if (debug) {
           this.appMode = 'debug';
         }
-        console.log('App Mode: ' + this.appMode);
+        console.log('App Mode:', this.appMode);
 
         // detect the application url to use, enable debug
         var url = '/';
         if (debug) {
           url = url + '?debug';
         }
-        console.log('URL: ' + url);
+        console.log('URL:', url);
 
         // apply defaults to the configuration
         Ext.applyIf(config, {
@@ -63,18 +91,37 @@ Class('NX.TestHarness', {
           // disable recording offsets
           recorderConfig: {
             recordOffsets: false
-          },
-
-          // default describe() timeout after 5 minutes
-          describeTimeout: 300000,
-
-          // default it() timeout after 30 seconds
-          itTimeout: 30000
+          }
         });
 
         this.SUPER(config);
       },
 
+      /**
+       * Propagate harness configuration customization to tests.
+       *
+       * @override
+       */
+      getNewTestConfiguration: function (desc, scopeProvider, contentManager, launchOptions) {
+        var me = this,
+            config = this.SUPERARG(arguments);
+
+        Joose.A.each([
+          'waitForNxAppReady',
+          'describeTimeout',
+          'itTimeout'
+        ], function (name) {
+          config[name] = me.getDescriptorConfig(desc, name);
+        });
+
+        return config
+      },
+
+      /**
+       * @public
+       * @param ref
+       * @returns {XML|void|string}
+       */
       resource: function(ref) {
         return ref.replace('{mode}', this.appMode);
       }


### PR DESCRIPTION
This should help improve reliability of tests, and also fixes issue to allow timeouts to be configured properly on group/test or harness.