### PR TITLE
NEXUS-8944 nexus archive log names

### DIFF
--- a/assemblies/nexus-base-template/src/main/resources/overlay/etc/logback.xml
+++ b/assemblies/nexus-base-template/src/main/resources/overlay/etc/logback.xml
@@ -15,7 +15,7 @@
       <pattern>%d{"yyyy-MM-dd HH:mm:ss,SSSZ"} %-5p [%thread] %X{userId} %c - %m%n</pattern>
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>${karaf.data}/log/karaf.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+      <fileNamePattern>${karaf.data}/log/karaf-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
       <maxHistory>90</maxHistory>
     </rollingPolicy>
   </appender>

--- a/components/nexus-core/src/main/resources/org/sonatype/nexus/internal/log/logback-nexus.xml
+++ b/components/nexus-core/src/main/resources/org/sonatype/nexus/internal/log/logback-nexus.xml
@@ -31,7 +31,7 @@
       <pattern>%d{"yyyy-MM-dd HH:mm:ss,SSSZ"} %-5p [%thread] %X{userId} %c - %m%n</pattern>
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>${nexus-work}/log/nexus.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+      <fileNamePattern>${nexus-work}/log/nexus-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
       <maxHistory>90</maxHistory>
     </rollingPolicy>
   </appender>


### PR DESCRIPTION
make the same as recent request log changes.

Do not plan to make this change in 2.11.x unless team insists - worried about the fact this has been this way too long in nexus 2.x

trivial in theory and didn't want to forget about it due to recent request log changes.