### PR TITLE
[NEXUS-8981] apply NonProxyHost validation to XO

### DIFF
--- a/components/nexus-httpclient/src/main/java/org/sonatype/nexus/httpclient/config/NonProxyHosts.java
+++ b/components/nexus-httpclient/src/main/java/org/sonatype/nexus/httpclient/config/NonProxyHosts.java
@@ -19,8 +19,6 @@ import java.lang.annotation.Target;
 import javax.validation.Constraint;
 import javax.validation.Payload;
 
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
-import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
@@ -33,7 +31,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Target({METHOD, FIELD, PARAMETER})
 @Retention(RUNTIME)
-@Constraint(validatedBy = NonProxyHostsValidator.class)
+@Constraint(validatedBy = {NonProxyHostsValidator.class, NonProxyHostsValidator.ForArray.class})
 @Documented
 public @interface NonProxyHosts
 {

--- a/components/nexus-httpclient/src/test/java/org/sonatype/nexus/httpclient/config/NonProxyHostsValidatorTest.groovy
+++ b/components/nexus-httpclient/src/test/java/org/sonatype/nexus/httpclient/config/NonProxyHostsValidatorTest.groovy
@@ -34,7 +34,7 @@ class NonProxyHostsValidatorTest
   NonProxyHostsValidator validator = new NonProxyHostsValidator()
 
   private validateAndExpect(String expression, boolean expected) {
-    assertThat(validator.isValid([expression].toArray(new String[0]), context), equalTo(expected))
+    assertThat(validator.isValid([expression] as Set, context), equalTo(expected))
   }
 
   @Test

--- a/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/HttpSettingsXO.groovy
+++ b/plugins/rapture/nexus-coreui-plugin/src/main/java/org/sonatype/nexus/coreui/HttpSettingsXO.groovy
@@ -15,6 +15,8 @@ package org.sonatype.nexus.coreui
 import javax.validation.constraints.Max
 import javax.validation.constraints.Min
 
+import org.sonatype.nexus.httpclient.config.NonProxyHosts
+
 import groovy.transform.ToString
 
 /**
@@ -84,5 +86,6 @@ class HttpSettingsXO
 
   // HTTP[S] non-proxy hosts
 
+  @NonProxyHosts
   Set<String> nonProxyHosts
 }


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-8981
http://bamboo.s/browse/NX3-OSSF597-2 :white_check_mark: 

Note this leaves the existing annotation in place at https://github.com/sonatype/nexus-oss/blob/master/components/nexus-httpclient/src/main/java/org/sonatype/nexus/httpclient/config/ProxyConfiguration.java#L38 for when we enable validation in HttpClientManagerImpl