### PR TITLE
[nexus-2.11.x] JRuby updates

### DIFF
--- a/plugins/rubygem/nexus-ruby-plugin/src/main/java/org/sonatype/nexus/plugins/ruby/ScriptingContainerProvider.java
+++ b/plugins/rubygem/nexus-ruby-plugin/src/main/java/org/sonatype/nexus/plugins/ruby/ScriptingContainerProvider.java
@@ -18,7 +18,7 @@ import javax.inject.Singleton;
 
 import org.sonatype.sisu.goodies.common.ComponentSupport;
 
-import org.jruby.embed.IsolatedScriptingContainer;
+import org.jruby.embed.osgi.OSGiIsolatedScriptingContainer;
 import org.jruby.embed.ScriptingContainer;
 import org.osgi.framework.FrameworkUtil;
 
@@ -36,13 +36,13 @@ public class ScriptingContainerProvider
     extends ComponentSupport
     implements Provider<ScriptingContainer>
 {
-  private IsolatedScriptingContainer scriptingContainer;
+  private OSGiIsolatedScriptingContainer scriptingContainer;
 
   @Override
   public synchronized ScriptingContainer get() {
     if (scriptingContainer == null) {
       log.debug("Creating JRuby ScriptingContainer");
-      scriptingContainer = new IsolatedScriptingContainer();
+      scriptingContainer = new OSGiIsolatedScriptingContainer();
       scriptingContainer.addBundleToGemPath( FrameworkUtil.getBundle( ScriptingContainerProvider.class ) );
     }
     return scriptingContainer;

--- a/plugins/rubygem/nexus-ruby-tools/src/main/java/org/sonatype/nexus/ruby/cuba/RootCuba.java
+++ b/plugins/rubygem/nexus-ruby-tools/src/main/java/org/sonatype/nexus/ruby/cuba/RootCuba.java
@@ -12,6 +12,7 @@
  */
 package org.sonatype.nexus.ruby.cuba;
 
+import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -37,7 +38,17 @@ public class RootCuba
 
   public static final String MAVEN = "maven";
 
-  private static final Pattern SPECS = Pattern.compile("^((prerelease_|latest_)?specs)" + _4_8 + "(" + GZ + ")?$");
+  public static final Pattern SPECS = Pattern.compile("^((prerelease_|latest_)?specs)" + _4_8 + "(" + GZ + ")?$");
+
+  public static final String[] SPEC_FILES = {"specs.4.8", "latest_specs.4.8", "prerelease_specs.4.8",
+      "specs.4.8.gz", "latest_specs.4.8.gz", "prerelease_specs.4.8.gz"};
+
+  public static final String[] FILES;
+  static {
+      String[] files = new String[] { API, QUICK, GEMS, MAVEN };
+      FILES = Arrays.copyOf(files, files.length + SPEC_FILES.length);
+      System.arraycopy(SPEC_FILES, 0, FILES, files.length, SPEC_FILES.length);
+  }
 
   private final Cuba api;
 
@@ -71,11 +82,7 @@ public class RootCuba
       case MAVEN:
         return state.nested(maven);
       case "":
-        return state.context.factory.directory(state.context.original,
-                "api/", "quick/", "gems/", "maven/",
-                "specs.4.8", "latest_specs.4.8", "prerelease_specs.4.8",
-                "specs.4.8.gz", "latest_specs.4.8.gz", "prerelease_specs.4.8.gz"
-            );
+        return state.context.factory.directory(state.context.original, FILES );
       default:
     }
     Matcher m = SPECS.matcher(state.name);

--- a/plugins/rubygem/nexus-ruby-tools/src/main/java/org/sonatype/nexus/ruby/cuba/api/ApiCuba.java
+++ b/plugins/rubygem/nexus-ruby-tools/src/main/java/org/sonatype/nexus/ruby/cuba/api/ApiCuba.java
@@ -12,6 +12,9 @@
  */
 package org.sonatype.nexus.ruby.cuba.api;
 
+import java.util.Arrays;
+import java.util.regex.Matcher;
+
 import org.sonatype.nexus.ruby.RubygemsFile;
 import org.sonatype.nexus.ruby.cuba.Cuba;
 import org.sonatype.nexus.ruby.cuba.RootCuba;
@@ -26,6 +29,13 @@ public class ApiCuba
     implements Cuba
 {
   public static final String V1 = "v1";
+
+  public static final String[] FILES;
+  static {
+      String[] files = new String[] { V1, RootCuba.QUICK, RootCuba.GEMS };
+      FILES = Arrays.copyOf(files, files.length + RootCuba.SPEC_FILES.length);
+      System.arraycopy(RootCuba.SPEC_FILES, 0, FILES, files.length, RootCuba.SPEC_FILES.length);
+  }
 
   private final Cuba v1;
 
@@ -52,9 +62,15 @@ public class ApiCuba
       case RootCuba.GEMS:
         return state.nested(gems);
       case "":
-        String[] items = {V1, RootCuba.QUICK, RootCuba.GEMS};
-        return state.context.factory.directory(state.context.original, items);
+        return state.context.factory.directory(state.context.original, FILES);
       default:
+        Matcher m = RootCuba.SPECS.matcher(state.name);
+        if (m.matches()) {
+          if (m.group(3) == null) {
+            return state.context.factory.specsIndexFile(m.group(1));
+          }
+          return state.context.factory.specsIndexZippedFile(m.group(1));
+        }
         return state.context.factory.notFound(state.context.original);
     }
   }

--- a/plugins/rubygem/nexus-ruby-tools/src/test/java/org/sonatype/nexus/ruby/layout/DefaultLayoutTest.java
+++ b/plugins/rubygem/nexus-ruby-tools/src/test/java/org/sonatype/nexus/ruby/layout/DefaultLayoutTest.java
@@ -424,6 +424,48 @@ public class DefaultLayoutTest
   }
 
   @Test
+  public void testApiSpecsIndexFile() throws Exception {
+    RubygemsFile file = fileSystem.get("/api/specs.4.8.gz");
+    assertThat(file, notNullValue());
+    assertThat(file.type(), equalTo(FileType.SPECS_INDEX_ZIPPED));
+    RubygemsFile file2 = fileSystem.get("/api/specs.4.8");
+    assertThat(file2.type(), equalTo(FileType.SPECS_INDEX));
+
+    assertThat((SpecsIndexZippedFile) file,
+        equalTo(((SpecsIndexFile) file2).zippedSpecsIndexFile()));
+    assertThat((SpecsIndexFile) file2,
+        equalTo(((SpecsIndexZippedFile) file).unzippedSpecsIndexFile()));
+  }
+
+  @Test
+  public void testApiLatestSpecsIndexFile() throws Exception {
+    RubygemsFile file = fileSystem.get("/api/latest_specs.4.8.gz");
+    assertThat(file, notNullValue());
+    assertThat(file.type(), equalTo(FileType.SPECS_INDEX_ZIPPED));
+    RubygemsFile file2 = fileSystem.get("/api/latest_specs.4.8");
+    assertThat(file2.type(), equalTo(FileType.SPECS_INDEX));
+
+    assertThat((SpecsIndexZippedFile) file,
+        equalTo(((SpecsIndexFile) file2).zippedSpecsIndexFile()));
+    assertThat((SpecsIndexFile) file2,
+        equalTo(((SpecsIndexZippedFile) file).unzippedSpecsIndexFile()));
+  }
+
+  @Test
+  public void testApiPrereleasedSpecsIndexFile() throws Exception {
+    RubygemsFile file = fileSystem.get("/api/prerelease_specs.4.8.gz");
+    assertThat(file, notNullValue());
+    assertThat(file.type(), equalTo(FileType.SPECS_INDEX_ZIPPED));
+    RubygemsFile file2 = fileSystem.get("/api/prerelease_specs.4.8");
+    assertThat(file2.type(), equalTo(FileType.SPECS_INDEX));
+
+    assertThat((SpecsIndexZippedFile) file,
+        equalTo(((SpecsIndexFile) file2).zippedSpecsIndexFile()));
+    assertThat((SpecsIndexFile) file2,
+        equalTo(((SpecsIndexZippedFile) file).unzippedSpecsIndexFile()));
+  }
+
+  @Test
   public void testNotFile() throws Exception {
     RubygemsFile file = fileSystem.get("/prereleased_specs.4.8.gz");
     assertThat(file, notNullValue());

--- a/plugins/rubygem/nexus-ruby-tools/src/test/java/org/sonatype/nexus/ruby/layout/HostedGETLayoutTest.java
+++ b/plugins/rubygem/nexus-ruby-tools/src/test/java/org/sonatype/nexus/ruby/layout/HostedGETLayoutTest.java
@@ -305,9 +305,10 @@ public class HostedGETLayoutTest
     };
     assertFiletypeWithNullPayload(pathes, FileType.DIRECTORY);
 
-    assertDirectory("/", "api/", "quick/", "gems/", "maven/", "specs.4.8", "latest_specs.4.8", "prerelease_specs.4.8",
+    assertDirectory("/", "api", "quick", "gems", "maven", "specs.4.8", "latest_specs.4.8", "prerelease_specs.4.8",
         "specs.4.8.gz", "latest_specs.4.8.gz", "prerelease_specs.4.8.gz");
-    assertDirectory("/api", "v1", "quick", "gems");
+    assertDirectory("/api", "v1", "quick", "gems", "specs.4.8", "latest_specs.4.8", "prerelease_specs.4.8",
+         "specs.4.8.gz", "latest_specs.4.8.gz", "prerelease_specs.4.8.gz");
     assertDirectory("/api/v1", "api_key", "dependencies");
     assertDirectory("/api/v1/dependencies");//"hufflepuf.ruby", "pre.ruby", "zip.ruby" );
     assertDirectory("/api/quick", "Marshal.4.8");

--- a/plugins/rubygem/nexus-ruby-tools/src/test/java/org/sonatype/nexus/ruby/layout/ProxiesGETLayoutTest.java
+++ b/plugins/rubygem/nexus-ruby-tools/src/test/java/org/sonatype/nexus/ruby/layout/ProxiesGETLayoutTest.java
@@ -309,9 +309,10 @@ public class ProxiesGETLayoutTest
     };
     assertFiletypeWithNullPayload(pathes, FileType.DIRECTORY);
 
-    assertDirectory("/", "api/", "quick/", "gems/", "maven/", "specs.4.8", "latest_specs.4.8", "prerelease_specs.4.8",
+    assertDirectory("/", "api", "quick", "gems", "maven", "specs.4.8", "latest_specs.4.8", "prerelease_specs.4.8",
         "specs.4.8.gz", "latest_specs.4.8.gz", "prerelease_specs.4.8.gz");
-    assertDirectory("/api", "v1", "quick", "gems");
+    assertDirectory("/api", "v1", "quick", "gems", "specs.4.8", "latest_specs.4.8", "prerelease_specs.4.8",
+        "specs.4.8.gz", "latest_specs.4.8.gz", "prerelease_specs.4.8.gz");
     assertDirectory("/api/v1", "api_key", "dependencies");
     assertDirectory("/api/v1/dependencies");//"hufflepuf.ruby", "pre.ruby", "zip.ruby" );
     assertDirectory("/api/quick", "Marshal.4.8");

--- a/plugins/rubygem/nexus-ruby-tools/src/test/minispecs/repair_helper_spec.rb
+++ b/plugins/rubygem/nexus-ruby-tools/src/test/minispecs/repair_helper_spec.rb
@@ -64,7 +64,7 @@ describe Nexus::RepairHelperImpl do
     # also includes all the gems coming from maven-tools dependency !!
     # i.e. a new jruby.version can change that number !!
     # puts Dir[ File.join( broken_to, 'quick', '**', '*' ) ].join("\n")
-    Dir[ File.join( broken_to, 'quick', '**', '*' ) ].size.must_equal 32
+    Dir[ File.join( broken_to, 'quick', '**', '*' ) ].size.must_equal 31
   end
 
 end

--- a/plugins/rubygem/pom.xml
+++ b/plugins/rubygem/pom.xml
@@ -28,7 +28,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <jruby.version>1.7.19</jruby.version>
+    <jruby.version>9.0.0.0</jruby.version>
     <jruby-plugins.version>1.0.7</jruby-plugins.version>
   </properties>
 


### PR DESCRIPTION
first is use jruby-9k and duplicate more api under /api as more clients will use the new rubygems API.
